### PR TITLE
docs: fix installation path for individual skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ npx skills add dodopayments/skills
 Or install individual skills:
 
 ```bash
-npx skills add dodopayments/skills/dodo-best-practices
-npx skills add dodopayments/skills/webhook-integration
-npx skills add dodopayments/skills/subscription-integration
+npx skills add dodopayments/skills/dodo-payments/best-practices
+npx skills add dodopayments/skills/dodo-payments/webhook-integration
+npx skills add dodopayments/skills/dodo-payments/subscription-integration
 ```
 
 ### Claude Code


### PR DESCRIPTION
Problem:
The current README documentation provides installation commands for individual skills that point to relevant skill directory, for example: dodopayments/skills/dodo-best-practices. However, individual skills are actually nested inside the `dodo-payments/` directory.

Running the documented command results in a No valid skills found error because the CLI cannot locate the SKILL.md file at the root level.

Solution:
- Updated the command to reflect the correct directory structure: dodopayments/skills/dodo-payments/best-practices.
- Also, corrected `dodo-best-practices` to `best-practices` as per the real directory name

Test Configuration:

Verified the fix by running individual skill command such as: npx skills add dodopayments/skills/dodo-payments/best-practices

Confirmed the skill was successfully identified and added.