### PR TITLE
fix: add marketplace.json for Claude Code plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "Dodo Payments Skills",
+  "description": "Agent Skills for Dodo Payments",
+  "skills": [
+    "dodo-payments/best-practices",
+    "dodo-payments/billing-sdk",
+    "dodo-payments/checkout-integration",
+    "dodo-payments/credit-based-billing",
+    "dodo-payments/license-keys",
+    "dodo-payments/subscription-integration",
+    "dodo-payments/usage-based-billing",
+    "dodo-payments/webhook-integration"
+  ]
+}


### PR DESCRIPTION
## Description

This PR fixes an installation failure when users try to add this repository as a marketplace plugin in Claude Code via `/plugin → Add Marketplace → dodopayments/skills`.

### The Problem
When running the installation command, the process crashes with the following error:
```text
Marketplace file not found at /Users/.../.claude/plugins/marketplaces/dodopayments-skills/.claude-plugin/marketplace.json
```
Closes #3 and #2 
