### PR TITLE
Modernize all skills against the current API, add nine new ones

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "dodo-best-practices",
-      "description": "Guide for integrating Dodo Payments - the all-in-one payment and billing platform for SaaS and AI products.",
+      "description": "Guide for initial Dodo Payments setup, including SDK installation, test and live environments, API keys, and the canonical checkout-to-webhook architecture.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -20,7 +20,7 @@
     },
     {
       "name": "better-auth-integration",
-      "description": "Guide for integrating Dodo Payments with Better Auth for automatic customer sync, checkout, portal, and verified webhooks",
+      "description": "Guide only for applications using @dodopayments/better-auth, covering authenticated customer sync, checkout, portal access, usage ingestion, and verified webhook callbacks.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -38,7 +38,7 @@
     },
     {
       "name": "checkout-integration",
-      "description": "Guide for creating checkout sessions and payment flows with Dodo Payments - one-time, subscriptions, and overlay checkout.",
+      "description": "Guide for starting hosted Checkout Sessions, payment links, and overlay or inline checkout for one-time and recurring products; use subscription-integration for post-checkout lifecycle management.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -47,7 +47,7 @@
     },
     {
       "name": "credit-based-billing",
-      "description": "Complete guide for implementing credit-based billing with Dodo Payments using credit entitlements, balances, ledger entries, rollover, overage, and meter-based deduction.",
+      "description": "Complete guide for giving customers included, free, prepaid, promotional, or top-up credits using grants, balances, ledger deductions, rollover, expiry, alerts, and overage.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -56,7 +56,7 @@
     },
     {
       "name": "customer-management",
-      "description": "Guide for managing customers, self-service portals, payment methods, and customer wallets with Dodo Payments",
+      "description": "Guide for managing customer records, saved payment methods, monetary wallets, and hosted customer-portal sessions; subscription lifecycle and custom billing UI are covered separately.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -74,7 +74,7 @@
     },
     {
       "name": "framework-adapters",
-      "description": "Guide for implementing Dodo Payments checkout, customer portal, and webhooks using official framework adapter packages for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex.",
+      "description": "Guide for mounting official @dodopayments/* checkout, portal, and verified-webhook route handlers in supported web frameworks; use domain skills for payment and lifecycle logic.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -128,7 +128,7 @@
     },
     {
       "name": "subscription-integration",
-      "description": "Guide for implementing subscription billing with Dodo Payments - trials, upgrades, downgrades, and on-demand charging.",
+      "description": "Guide for managing recurring subscriptions after checkout, including trials, lifecycle states, plan changes, cancellation, failed-payment recovery, proration, mandates, and on-demand charges.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -137,7 +137,7 @@
     },
     {
       "name": "testing-and-go-live",
-      "description": "Guide for testing payment flows, webhook verification, and launching to production with Dodo Payments",
+      "description": "Guide for test-mode payment scenarios, renewal simulation, local webhook delivery tests, test and live catalog migration, and production launch checks.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -146,7 +146,7 @@
     },
     {
       "name": "usage-based-billing",
-      "description": "Guide for implementing usage-based billing with Dodo Payments - meters, events, pricing per unit, and metered subscriptions.",
+      "description": "Guide for charging directly per measured API call, token, storage unit, or other consumption using meters, stable usage events, aggregation, free thresholds, and metered subscriptions.",
       "source": "./",
       "strict": false,
       "skills": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "url": "https://dodopayments.com"
   },
   "metadata": {
-    "description": "Official Agent Skills for Dodo Payments — payments, subscriptions, billing, webhooks, and more.",
-    "version": "1.0.0"
+    "description": "Official Agent Skills for Dodo Payments — payments, checkout, subscriptions, usage and credit billing, webhooks, and more.",
+    "version": "2.0.0"
   },
   "plugins": [
     {
       "name": "dodo-best-practices",
-      "description": "Comprehensive guide for integrating Dodo Payments — the all-in-one payment and billing platform for SaaS and AI products.",
+      "description": "Guide for integrating Dodo Payments - the all-in-one payment and billing platform for SaaS and AI products.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -19,8 +19,17 @@
       ]
     },
     {
+      "name": "better-auth-integration",
+      "description": "Guide for integrating Dodo Payments with Better Auth for automatic customer sync, checkout, portal, and verified webhooks",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/better-auth-integration"
+      ]
+    },
+    {
       "name": "billing-sdk",
-      "description": "Guide for using BillingSDK — open-source React components for pricing tables, subscription management, and billing UI with Dodo Payments.",
+      "description": "Guide for building billing UI with BillingSDK - the open-source React component library for pricing tables, subscription management, usage meters, invoice history, and customer portal flows wired to Dodo Payments.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -29,7 +38,7 @@
     },
     {
       "name": "checkout-integration",
-      "description": "Guide for creating checkout sessions and payment flows with Dodo Payments — one-time, subscriptions, and overlay checkout.",
+      "description": "Guide for creating checkout sessions and payment flows with Dodo Payments - one-time, subscriptions, and overlay checkout.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -38,7 +47,7 @@
     },
     {
       "name": "credit-based-billing",
-      "description": "Guide for implementing credit-based billing with Dodo Payments — credit entitlements, balances, ledger management, rollover, overage, and meter-based deduction.",
+      "description": "Complete guide for implementing credit-based billing with Dodo Payments using credit entitlements, balances, ledger entries, rollover, overage, and meter-based deduction.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -46,8 +55,35 @@
       ]
     },
     {
+      "name": "customer-management",
+      "description": "Guide for managing customers, self-service portals, payment methods, and customer wallets with Dodo Payments",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/customer-management"
+      ]
+    },
+    {
+      "name": "discounts-and-promotions",
+      "description": "Guide for implementing discount codes and promotional pricing with Dodo Payments, including CRUD operations, eligibility rules, stacking, subscription-cycle limits, and plan-change preservation.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/discounts-and-promotions"
+      ]
+    },
+    {
+      "name": "framework-adapters",
+      "description": "Guide for implementing Dodo Payments checkout, customer portal, and webhooks using official framework adapter packages for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/framework-adapters"
+      ]
+    },
+    {
       "name": "license-keys",
-      "description": "Guide for implementing license key management with Dodo Payments — activation, validation, and access control for software products.",
+      "description": "Guide for implementing license key management with Dodo Payments - activation, validation, and access control for software products.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -55,8 +91,44 @@
       ]
     },
     {
+      "name": "localized-pricing",
+      "description": "Guide for implementing localized pricing, adaptive currency, and purchasing power parity with Dodo Payments",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/localized-pricing"
+      ]
+    },
+    {
+      "name": "mobile-checkout",
+      "description": "Guide for implementing mobile in-app checkout with Dodo Payments across React Native, Flutter, iOS, and Android platforms.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/mobile-checkout"
+      ]
+    },
+    {
+      "name": "product-catalog-management",
+      "description": "Guide for creating and managing products, pricing, add-ons, product collections, images, and digital product delivery",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/product-catalog-management"
+      ]
+    },
+    {
+      "name": "refunds-and-disputes",
+      "description": "Guide for issuing refunds, handling disputes and chargebacks, and reconciling customer access with Dodo Payments",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/refunds-and-disputes"
+      ]
+    },
+    {
       "name": "subscription-integration",
-      "description": "Guide for implementing subscription billing with Dodo Payments — trials, upgrades, downgrades, and on-demand billing.",
+      "description": "Guide for implementing subscription billing with Dodo Payments - trials, upgrades, downgrades, and on-demand charging.",
       "source": "./",
       "strict": false,
       "skills": [
@@ -64,8 +136,17 @@
       ]
     },
     {
+      "name": "testing-and-go-live",
+      "description": "Guide for testing payment flows, webhook verification, and launching to production with Dodo Payments",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./dodo-payments/testing-and-go-live"
+      ]
+    },
+    {
       "name": "usage-based-billing",
-      "description": "Guide for implementing usage-based billing with Dodo Payments — meters, events, pricing per unit, and metered subscriptions.",
+      "description": "Guide for implementing usage-based billing with Dodo Payments - meters, events, pricing per unit, and metered subscriptions.",
       "source": "./",
       "strict": false,
       "skills": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: Validate and type-check skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # Structural rules: real hostnames, correct key prefixes, no hand-rolled
+      # webhook HMAC, no deprecated calls, manifest/README/frontmatter integrity.
+      - name: Validate skills
+        run: npm run validate
+
+      # Compiles every TypeScript example in every SKILL.md against the real
+      # `dodopayments` types. This is the check that catches wrong field and
+      # parameter names - the failure mode prose review does not reliably catch,
+      # and the one that fails silently in production rather than loudly.
+      - name: Type-check examples
+        run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
           node-version: 20
           cache: npm
 
+      # Needed by the Go/Python example checks below - not incidental config.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install
         run: npm ci
 
@@ -31,3 +40,12 @@ jobs:
       # and the one that fails silently in production rather than loudly.
       - name: Type-check examples
         run: npm run typecheck
+
+      # ~20 of the published examples are not TypeScript. An unchecked block is
+      # where the surviving bugs were found in the last two review rounds, so
+      # these run with the real toolchains rather than being taken on trust.
+      - name: Type-check Go examples
+        run: npm run typecheck:go
+
+      - name: Type-check Python examples
+        run: npm run typecheck:python

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,4 @@
-# Dependencies
 node_modules/
-
-# IDE
-.idea/
-.vscode/
-*.swp
-*.swo
-*~
-
-# OS
-.DS_Store
-Thumbs.db
-
-# Logs
+.typecheck-tmp/
 *.log
-
-# Environment
-.env
-.env.local
-.env.*.local
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
 .typecheck-tmp/
+.gocheck-tmp/
+.pycheck-tmp/
+.python-check-venv/
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ Skills are reusable capabilities for AI agents. They provide procedural knowledg
 ## Contributing
 
 Skills are pasted verbatim into an agent's context and reproduced as-is, so a wrong field name propagates
-exactly as reliably as correct code — and usually fails *silently* rather than loudly. Two checks run in CI
+exactly as reliably as correct code — and usually fails *silently* rather than loudly. Four checks run in CI
 and should be run locally before opening a PR:
 
 ```bash
 npm install
-npm run check      # validate + typecheck
+npm run check      # validate + typecheck (TypeScript, Go, Python)
 ```
 
 **`npm run validate`** enforces structural rules: real API hostnames, correct `dodo_test_`/`dodo_live_` key
@@ -109,8 +109,17 @@ formats, no hand-rolled webhook HMAC, no deprecated SDK calls, no type suppressi
 each skill's directory name, its frontmatter, `marketplace.json`, and the README table.
 
 **`npm run typecheck`** extracts every TypeScript block from every `SKILL.md` and compiles it against the
-real `dodopayments` types. This is what catches wrong field and parameter names. Blocks introduced as
-deliberate counter-examples (`Wrong:`, `Incorrect:`) are skipped, since they are supposed to be wrong.
+real `dodopayments` types — plus the `@dodopayments/*` framework adapters, so adapter examples are checked
+rather than degrading to `any`. This is what catches wrong field and parameter names.
+
+**`npm run typecheck:go`** and **`npm run typecheck:python`** do the same for Go and Python examples, using
+`go build` against `dodopayments-go` and pyright against the real Python SDK. The Python check creates a
+virtualenv on first run and reuses it afterwards.
+
+Blocks that are deliberate counter-examples are skipped, but only when *explicitly* labelled — a bolded
+`**Wrong:**`-style marker, or an `<!-- typecheck: skip -->` comment. Inferring "this is meant to be broken"
+from surrounding prose silently removed coverage from correct blocks, so opting out is now deliberate and
+greppable.
 
 When you add or change an example, prefer fixing the field name over casting to `any` — the point of the
 check is that the published example actually compiles.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ Skills are automatically available when configured in your OpenCode settings.
 
 Skills are reusable capabilities for AI agents. They provide procedural knowledge that helps agents accomplish specific tasks more effectively. Think of them as plugins that enhance what your AI agent can do when working with Dodo Payments.
 
+## Contributing
+
+Skills are pasted verbatim into an agent's context and reproduced as-is, so a wrong field name propagates
+exactly as reliably as correct code — and usually fails *silently* rather than loudly. Two checks run in CI
+and should be run locally before opening a PR:
+
+```bash
+npm install
+npm run check      # validate + typecheck
+```
+
+**`npm run validate`** enforces structural rules: real API hostnames, correct `dodo_test_`/`dodo_live_` key
+formats, no hand-rolled webhook HMAC, no deprecated SDK calls, no type suppression, and agreement between
+each skill's directory name, its frontmatter, `marketplace.json`, and the README table.
+
+**`npm run typecheck`** extracts every TypeScript block from every `SKILL.md` and compiles it against the
+real `dodopayments` types. This is what catches wrong field and parameter names. Blocks introduced as
+deliberate counter-examples (`Wrong:`, `Incorrect:`) are skipped, since they are supposed to be wrong.
+
+When you add or change an example, prefer fixing the field name over casting to `any` — the point of the
+check is that the published example actually compiles.
+
 ## Resources
 
 - [Dodo Payments Documentation](https://docs.dodopayments.com)

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ npx skills add dodopayments/skills/subscription-integration
 
 Add the marketplace:
 
-```
+```text
 /plugin marketplace add dodopayments/skills
 ```
 
 Install a plugin:
 
-```
+```text
 /plugin install dodo-best-practices
 /plugin install webhook-integration
 /plugin install subscription-integration

--- a/README.md
+++ b/README.md
@@ -42,16 +42,52 @@ Skills are automatically available when configured in your OpenCode settings.
 
 ## Available Skills
 
+### Getting started
+
 | Skill | Description |
 |-------|-------------|
-| [dodo-best-practices](./dodo-payments/best-practices/) | Comprehensive guide to integrating Dodo Payments with best practices |
-| [webhook-integration](./dodo-payments/webhook-integration/) | Setting up and handling webhooks for payment events |
-| [subscription-integration](./dodo-payments/subscription-integration/) | Implementing subscription billing flows |
-| [checkout-integration](./dodo-payments/checkout-integration/) | Creating checkout sessions and payment flows |
-| [usage-based-billing](./dodo-payments/usage-based-billing/) | Implementing metered billing with events and meters |
-| [billing-sdk](./dodo-payments/billing-sdk/) | Using BillingSDK React components |
-| [license-keys](./dodo-payments/license-keys/) | Managing license keys for digital products |
-| [credit-based-billing](./dodo-payments/credit-based-billing/) | Implementing credit entitlements, balances, and metered credit deduction |
+| [dodo-best-practices](./dodo-payments/best-practices/) | Orientation guide: SDKs, environments, auth, core concepts, and the canonical integration path |
+| [framework-adapters](./dodo-payments/framework-adapters/) | Official adapter packages for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex |
+| [testing-and-go-live](./dodo-payments/testing-and-go-live/) | Test mode, test payment methods, webhook testing, and the production launch checklist |
+
+### Accepting payments
+
+| Skill | Description |
+|-------|-------------|
+| [checkout-integration](./dodo-payments/checkout-integration/) | Creating checkout sessions, payment links, and overlay checkout |
+| [subscription-integration](./dodo-payments/subscription-integration/) | Subscription lifecycle, trials, plan changes, proration, and on-demand charging |
+| [mobile-checkout](./dodo-payments/mobile-checkout/) | In-app checkout for React Native, Flutter, iOS, and Android |
+| [webhook-integration](./dodo-payments/webhook-integration/) | Receiving and verifying webhooks with the Standard Webhooks specification |
+
+### Billing models
+
+| Skill | Description |
+|-------|-------------|
+| [credit-based-billing](./dodo-payments/credit-based-billing/) | Credit entitlements, balances, ledger, rollover, overage, and meter-based deduction |
+| [usage-based-billing](./dodo-payments/usage-based-billing/) | Metered billing with meters, event ingestion, and per-unit pricing |
+| [license-keys](./dodo-payments/license-keys/) | License key activation, validation, and instance management |
+
+### Catalog and pricing
+
+| Skill | Description |
+|-------|-------------|
+| [product-catalog-management](./dodo-payments/product-catalog-management/) | Products, pricing, add-ons, collections, images, and digital product delivery |
+| [discounts-and-promotions](./dodo-payments/discounts-and-promotions/) | Discount codes, eligibility rules, stacking, and subscription-cycle limits |
+| [localized-pricing](./dodo-payments/localized-pricing/) | Localized pricing, adaptive currency, and purchasing power parity |
+
+### Customers and operations
+
+| Skill | Description |
+|-------|-------------|
+| [customer-management](./dodo-payments/customer-management/) | Customers, the self-service portal, payment methods, and wallets |
+| [refunds-and-disputes](./dodo-payments/refunds-and-disputes/) | Issuing refunds, handling disputes and chargebacks, reconciling access |
+
+### UI and integrations
+
+| Skill | Description |
+|-------|-------------|
+| [billing-sdk](./dodo-payments/billing-sdk/) | BillingSDK React components for pricing tables and billing UI |
+| [better-auth-integration](./dodo-payments/better-auth-integration/) | The `@dodopayments/better-auth` plugin for customer sync, checkout, and portal |
 
 ## What are Skills?
 

--- a/dodo-payments/best-practices/SKILL.md
+++ b/dodo-payments/best-practices/SKILL.md
@@ -104,6 +104,8 @@ go get -u github.com/dodopayments/dodopayments-go@v1.110.0
 
 ```go
 import (
+    "os"
+
     "github.com/dodopayments/dodopayments-go"
     "github.com/dodopayments/dodopayments-go/option"
 )

--- a/dodo-payments/best-practices/SKILL.md
+++ b/dodo-payments/best-practices/SKILL.md
@@ -1,43 +1,65 @@
 ---
 name: dodo-best-practices
-description: Comprehensive guide for integrating Dodo Payments - the all-in-one payment and billing platform for SaaS and AI products.
+description: Guide for integrating Dodo Payments - the all-in-one payment and billing platform for SaaS and AI products.
 ---
 
 # Dodo Payments Integration Guide
 
-**Always consult [docs.dodopayments.com](https://docs.dodopayments.com) for the latest API reference and code examples.**
+This skill covers the foundational concepts and setup for Dodo Payments. Use it when starting a new integration, setting up the SDK, or understanding the core payment flow.
 
-Dodo Payments is the all-in-one engine to launch, scale, and monetize worldwide. Designed for SaaS and AI products, it handles payments, billing, subscriptions, and distribution without extra engineering.
+## When to use this skill
+
+- You're building a new payment integration and need to understand Dodo's architecture
+- You need to install and initialize the SDK in your language
+- You want to understand the canonical payment flow and webhook verification
+- You're choosing between framework adapters or payment methods
+- You need to know what Dodo handles versus what you must build
 
 ---
 
-## Quick Reference
+## What is Dodo Payments
+
+Dodo Payments is a Merchant of Record (MoR). That means Dodo is the legal seller on every transaction, handles sales tax registration and calculation across all jurisdictions, remits taxes to authorities, and manages card-network disputes and chargebacks. As a developer, you don't build a sales-tax engine or dispute-handling system. You create checkout sessions, listen to webhooks, and grant access when payment succeeds.
+
+---
+
+## Environment Setup
+
+### Base URLs
+
+Only two real base URLs exist:
+
+- **Live**: `https://live.dodopayments.com`
+- **Test**: `https://test.dodopayments.com`
+
+Never use `api.dodopayments.com` — it has no DNS record and cannot be reached.
+
+### API Keys
+
+Keys have two formats:
+
+- **Test**: `dodo_test_...`
+- **Live**: `dodo_live_...`
 
 ### Environment Variables
-- `DODO_PAYMENTS_API_KEY` - Your API key from the dashboard
-- `DODO_PAYMENTS_WEBHOOK_SECRET` - Webhook signing secret for verification
 
-### API Environments
-- **Live Mode**: `https://api.dodopayments.com` (default)
-- **Test Mode**: `https://api.dodopayments.com` with `environment: 'test_mode'`
+```bash
+DODO_PAYMENTS_API_KEY       # Bearer token for API requests
+DODO_PAYMENTS_WEBHOOK_KEY   # Secret for webhook signature verification
+```
 
-### Dashboard URLs
-- **Main Dashboard**: [app.dodopayments.com](https://app.dodopayments.com)
-- **API Keys**: Dashboard → Developer → API
-- **Webhooks**: Dashboard → Developer → Webhooks
-- **Products**: Dashboard → Products
+### Default Environment
+
+The `environment` parameter defaults to `live_mode` if omitted. Always pass `test_mode` explicitly during development.
 
 ---
 
-## SDK Installation
+## SDK Installation & Initialization
 
-### TypeScript/JavaScript
+### TypeScript/Node.js
+
 ```bash
 npm install dodopayments
-# or
-yarn add dodopayments
-# or
-pnpm add dodopayments
 ```
 
 ```typescript
@@ -45,271 +67,355 @@ import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: 'live_mode', // or 'test_mode'
+  environment: 'test_mode', // defaults to 'live_mode'
 });
 ```
 
+Constructor options:
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `bearerToken` | string | env `DODO_PAYMENTS_API_KEY` | Required for API calls |
+| `environment` | `'test_mode' \| 'live_mode'` | `'live_mode'` | Explicit in dev |
+| `webhookKey` | string | env `DODO_PAYMENTS_WEBHOOK_KEY` | For `webhooks.unwrap()` |
+| `baseURL` | string | — | Override; mutually exclusive with `environment` |
+
 ### Python
+
 ```bash
 pip install dodopayments
 ```
 
 ```python
+import os
 from dodopayments import DodoPayments
 
-client = DodoPayments(bearer_token=os.environ["DODO_PAYMENTS_API_KEY"])
+client = DodoPayments(
+    bearer_token=os.environ.get("DODO_PAYMENTS_API_KEY"),
+    environment="test_mode",  # defaults to "live_mode"
+)
 ```
 
 ### Go
+
 ```bash
-go get github.com/dodopayments/dodopayments-go
+go get -u github.com/dodopayments/dodopayments-go@v1.110.0
 ```
 
 ```go
-import "github.com/dodopayments/dodopayments-go"
+import (
+    "github.com/dodopayments/dodopayments-go"
+    "github.com/dodopayments/dodopayments-go/option"
+)
 
 client := dodopayments.NewClient(
     option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
+    option.WithEnvironmentTestMode(), // defaults to live
 )
 ```
 
 ### PHP
+
 ```bash
-composer require dodopayments/client
+composer require "dodopayments/client:6.19.0"
 ```
 
 ```php
 use Dodopayments\Client;
 
-$client = new Client(bearerToken: getenv('DODO_PAYMENTS_API_KEY'));
+$client = new Client(
+    bearerToken: getenv('DODO_PAYMENTS_API_KEY') ?: 'My Bearer Token',
+    environment: 'test_mode',
+);
 ```
+
+### Ruby
+
+```bash
+gem "dodopayments", "~> 2.22.0"
+```
+
+```ruby
+dodo_payments = Dodopayments::Client.new(
+    bearer_token: ENV["DODO_PAYMENTS_API_KEY"],
+    environment: "test_mode"
+)
+```
+
+### Java
+
+```xml
+<dependency>
+    <groupId>com.dodopayments.api</groupId>
+    <artifactId>dodo-payments-java</artifactId>
+    <version>1.110.0</version>
+</dependency>
+```
+
+```java
+DodoPaymentsClient client = DodoPaymentsOkHttpClient.fromEnv();
+// Reads DODO_PAYMENTS_API_KEY, DODO_PAYMENTS_WEBHOOK_KEY, DODO_PAYMENTS_BASE_URL
+```
+
+### Kotlin
+
+```xml
+<dependency>
+    <groupId>com.dodopayments.api</groupId>
+    <artifactId>dodo-payments-kotlin</artifactId>
+    <version>1.110.0</version>
+</dependency>
+```
+
+```kotlin
+val client: DodoPaymentsClient = DodoPaymentsOkHttpClient.fromEnv()
+```
+
+---
+
+## Framework Adapters
+
+Dodo publishes framework-specific packages under `@dodopayments/*`. Use the one matching your stack:
+
+| Framework | Package | Use if |
+|---|---|---|
+| Next.js | `@dodopayments/nextjs` | Building with Next.js App Router |
+| Nuxt | `@dodopayments/nuxt` | Building with Nuxt 3+ |
+| Express | `@dodopayments/express` | Using Express.js |
+| Fastify | `@dodopayments/fastify` | Using Fastify |
+| Hono | `@dodopayments/hono` | Using Hono (Edge/Node) |
+| Astro | `@dodopayments/astro` | Using Astro endpoints |
+| SvelteKit | `@dodopayments/sveltekit` | Using SvelteKit server routes |
+| Remix | `@dodopayments/remix` | Using Remix loaders/actions |
+| TanStack Start | `@dodopayments/tanstack` | Using TanStack Start |
+| Better Auth | `@dodopayments/better-auth` | Integrating with Better Auth |
+| Convex | `@dodopayments/convex` | Using Convex backend |
+| Bun | `@dodopayments/bun` | Using Bun.serve() |
+
+Each adapter provides checkout, customer portal, and webhook handlers tailored to the framework's conventions.
 
 ---
 
 ## Core Concepts
 
 ### Products
-Products are the items you sell. Create them in the dashboard or via API:
-- **One-time**: Single purchase products
-- **Subscription**: Recurring billing products
-- **Usage-based**: Metered billing per consumption
 
-### Credit Entitlements
-Credits are virtual balances (API calls, tokens, compute hours) attached to products. Create them in Dashboard → Products → Credits:
-- **Custom Unit**: Your own metric with configurable precision
-- **Fiat Credits**: Real currency value (USD, EUR, etc.)
-- Attach up to 3 credits per product
-- Configure rollover, overage, and expiration per entitlement
+Items you sell. Create in the dashboard or via API. Types:
+
+- **One-time**: Single purchase
+- **Subscription**: Recurring billing
+- **Usage-based**: Metered consumption
+
+### Customers
+
+Represent buyers. Can have multiple payment methods, subscriptions, and credit balances. Create explicitly or implicitly during checkout.
+
 ### Checkout Sessions
-The primary way to collect payments. Create a checkout session and redirect customers:
 
-```typescript
-const session = await client.checkoutSessions.create({
-  product_cart: [
-    { product_id: 'prod_xxxxx', quantity: 1 }
-  ],
-  customer: {
-    email: 'customer@example.com',
-    name: 'John Doe',
-  },
-  return_url: 'https://yoursite.com/success',
-});
+The primary payment collection method. Create a session server-side, redirect the customer to the hosted checkout URL, and listen for webhooks to confirm payment.
 
-// Redirect customer to: session.checkout_url
-```
+See the `checkout-and-subscriptions` skill for detailed checkout configuration.
+
+### Subscriptions
+
+Recurring charges on a schedule. Managed through checkout sessions or the subscriptions API. See the `subscription-integration` skill for lifecycle, trials, plan changes, and on-demand charging.
 
 ### Webhooks
-Listen to events for real-time updates:
-- `payment.succeeded` - Payment completed
-- `payment.failed` - Payment failed
-- `subscription.active` - Subscription activated
-- `subscription.cancelled` - Subscription cancelled
-- `refund.succeeded` - Refund processed
-- `dispute.opened` - Dispute received
-- `license_key.created` - License key generated
-- `credit.added` - Credits granted to customer
-- `credit.deducted` - Credits consumed
-- `credit.balance_low` - Credit balance below threshold
+
+Real-time event notifications. Dodo sends events like `payment.succeeded`, `subscription.active`, `refund.succeeded`, and `credit.deducted`. Webhook signature verification is covered in the `webhook-integration` skill.
+
+### Credit Entitlements
+
+Virtual balances (API calls, tokens, compute hours) attached to products. Configured per product with rollover, overage, and expiration rules. See the `credit-based-billing` skill.
+
 ---
 
-## Common Integration Patterns
+## The Canonical Payment Flow
 
-### One-Time Payment Flow
+1. **Create checkout session** on your server with product ID and customer email.
+2. **Redirect customer** to the `checkout_url` returned.
+3. **Customer pays** on the hosted checkout.
+4. **Dodo sends webhook** (e.g., `payment.succeeded`) to your endpoint.
+5. **Verify the webhook signature** using `client.webhooks.unwrap()`.
+6. **Grant access** only after webhook verification succeeds.
 
-1. Create product in dashboard
-2. Create checkout session with product ID
-3. Redirect customer to checkout URL
-4. Handle `payment.succeeded` webhook
-5. Fulfill order / grant access
+Never grant access based on the browser `return_url` redirect alone. The webhook is the authoritative confirmation.
 
 ```typescript
-// Create checkout for one-time payment
+// 1. Create session
 const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'prod_one_time_product', quantity: 1 }],
+  product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
   customer: { email: 'customer@example.com' },
   return_url: 'https://yoursite.com/success',
 });
-```
 
-### Subscription Flow
+// 2. Redirect to session.checkout_url
 
-1. Create subscription product in dashboard
-2. Create checkout session
-3. Handle `subscription.active` webhook to grant access
-4. Handle `subscription.cancelled` to revoke access
+// 3. Listen for webhook
+app.post('/webhook', async (req, res) => {
+  try {
+    // 4. Verify signature
+    const event = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
 
-```typescript
-// Create checkout for subscription
-const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'prod_monthly_subscription', quantity: 1 }],
-  subscription_data: { trial_period_days: 14 }, // Optional trial
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yoursite.com/success',
+    // 5. Grant access
+    if (event.type === 'payment.succeeded') {
+      const payment = event.data;
+      await grantAccess(payment.customer.customer_id);
+    }
+
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
+  }
 });
 ```
 
-### Webhook Verification
+---
 
-Always verify webhook signatures:
+## API Foundations
 
-```typescript
-import crypto from 'crypto';
+### Authentication
 
-function verifyWebhook(payload: string, signature: string, secret: string): boolean {
-  const expectedSignature = crypto
-    .createHmac('sha256', secret)
-    .update(payload)
-    .digest('hex');
-  
-  return crypto.timingSafeEqual(
-    Buffer.from(signature),
-    Buffer.from(expectedSignature)
-  );
-}
+All requests use Bearer token authentication:
+
+```http
+Authorization: Bearer dodo_live_...
 ```
 
----
+### Pagination
 
-## API Key Management
-
-### Generation
-1. Navigate to Dashboard → Developer → API
-2. Click "Create API Key"
-3. Copy and securely store the key
-
-### Security Best Practices
-- Never expose API keys in client-side code
-- Use environment variables
-- Rotate keys periodically
-- Use test mode keys for development
-
----
-
-## Customer Portal
-
-Allow customers to manage their subscriptions:
+List endpoints support `limit` and `offset`:
 
 ```typescript
-const portal = await client.customers.createPortalSession({
-  customer_id: 'cust_xxxxx',
-  return_url: 'https://yoursite.com/account',
+const payments = await client.payments.list({
+  limit: 50,
+  offset: 0,
 });
-
-// Redirect to: portal.url
 ```
 
----
+### Rate Limits
 
-## Error Handling
+Dodo enforces rate limits. Responses include `X-RateLimit-*` headers. Implement exponential backoff on `429` responses.
 
-Handle API errors gracefully:
+### SDK Error Classes
+
+The SDK throws typed errors. Catch and inspect:
 
 ```typescript
 try {
-  const session = await client.checkoutSessions.create({...});
+  await client.checkoutSessions.create({...});
 } catch (error) {
-  if (error.status === 400) {
-    // Invalid request - check parameters
-  } else if (error.status === 401) {
-    // Invalid API key
-  } else if (error.status === 429) {
-    // Rate limited - implement backoff
+  if (error instanceof DodoPayments.APIError) {
+    console.error(error.status, error.message);
   }
 }
 ```
 
----
+### Retries
 
-## Testing
-
-### Test Mode
-- Use test API keys (start with `sk_test_`)
-- Test webhooks with dashboard tools
-- Use test card numbers:
-  - `4242 4242 4242 4242` - Success
-  - `4000 0000 0000 0002` - Decline
-
-### Local Development
-Use ngrok or similar for webhook testing:
-```bash
-ngrok http 3000
-```
-Then configure the ngrok URL as your webhook endpoint in the dashboard.
+The SDK does not retry automatically. Implement retry logic for transient failures (5xx, timeouts).
 
 ---
 
-## Framework Integration
+## Webhook Verification
 
-### Next.js
-Use API routes for server-side operations:
+Webhook signature verification is mandatory. Never trust the payload without verification.
+
+Dodo implements the Standard Webhooks spec. The signed message is `webhook-id.webhook-timestamp.raw_body` (period-joined), HMAC-SHA256, base64-encoded.
+
+**Use the SDK helper:**
 
 ```typescript
-// app/api/checkout/route.ts
-import { NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
-
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+const event = client.webhooks.unwrap(req.body.toString(), {
+  headers: {
+    'webhook-id': req.headers['webhook-id'] as string,
+    'webhook-signature': req.headers['webhook-signature'] as string,
+    'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+  },
 });
-
-export async function POST(req: Request) {
-  const { productId, email } = await req.json();
-  
-  const session = await client.checkoutSessions.create({
-    product_cart: [{ product_id: productId, quantity: 1 }],
-    customer: { email },
-    return_url: `${process.env.NEXT_PUBLIC_URL}/success`,
-  });
-
-  return NextResponse.json({ url: session.checkout_url });
-}
 ```
 
-### Express.js
+The `unwrap()` method verifies the signature and parses the payload. If verification fails, it throws an error.
+
+For detailed webhook setup, event types, and testing, see the `webhook-integration` skill.
+
+---
+
+## Common Mistakes
+
+### 1. Granting access on `return_url` redirect
+
+The browser redirect is not proof of payment. Always wait for the webhook.
+
 ```typescript
-import express from 'express';
-import DodoPayments from 'dodopayments';
+// WRONG
+app.get('/success', (req, res) => {
+  grantAccess(req.query.customer_id); // No verification!
+});
 
-const app = express();
-const client = new DodoPayments({ bearerToken: process.env.DODO_PAYMENTS_API_KEY! });
-
-app.post('/create-checkout', async (req, res) => {
-  const session = await client.checkoutSessions.create({
-    product_cart: [{ product_id: req.body.productId, quantity: 1 }],
-    customer: { email: req.body.email },
-    return_url: 'https://yoursite.com/success',
-  });
-  res.json({ url: session.checkout_url });
+// CORRECT
+app.post('/webhook', async (req, res) => {
+  const event = client.webhooks.unwrap(...);
+  if (event.type === 'payment.succeeded') {
+    grantAccess(event.data.customer.customer_id);
+  }
 });
 ```
+
+### 2. Hand-rolling webhook verification
+
+Don't implement HMAC verification yourself. Use `client.webhooks.unwrap()`.
+
+The old approach of signing just the payload is wrong because Standard Webhooks signs `webhook-id.webhook-timestamp.raw_body`. Hand-rolled HMAC will never match.
+
+### 3. Re-serializing the request body
+
+Webhook verification requires the exact raw body. If you parse JSON and re-stringify it, the signature breaks.
+
+```typescript
+// WRONG
+const body = JSON.parse(req.body);
+const event = client.webhooks.unwrap(JSON.stringify(body), {...});
+
+// CORRECT
+const event = client.webhooks.unwrap(req.body.toString(), {...});
+```
+
+### 4. Using deprecated APIs
+
+Don't use `client.payments.create()` or `client.subscriptions.create()` for new integrations. Both are deprecated. Use `client.checkoutSessions.create()`.
+
+### 5. Forgetting to set `environment: 'test_mode'`
+
+The default is `live_mode`. Always pass `test_mode` explicitly during development to avoid charging real cards.
+
+### 6. Storing API keys in code
+
+Never hardcode keys. Always use environment variables.
+
+### 7. Ignoring the `webhook-timestamp` header
+
+The timestamp prevents replay attacks. `client.webhooks.unwrap()` validates it automatically, but if you hand-roll verification, check that the timestamp is recent (within a few minutes).
+
+### 8. Using `unsafeUnwrap()` in production
+
+`unsafeUnwrap()` skips signature verification. Use it only for unsigned test payloads from `dodo wh trigger`. Never use it for production webhooks.
 
 ---
 
 ## Resources
 
-- [Documentation](https://docs.dodopayments.com)
+- [Dodo Payments Docs](https://docs.dodopayments.com)
 - [API Reference](https://docs.dodopayments.com/api-reference/introduction)
 - [SDK Repositories](https://github.com/dodopayments)
-- [Discord Community](https://discord.gg/bYqAp4ayYh)
-- [Support](mailto:support@dodopayments.com)
+- [Checkout Sessions Guide](https://docs.dodopayments.com/developer-resources/checkout-session)
+- [Webhook Guide](https://docs.dodopayments.com/developer-resources/webhooks)
+- [Customer Portal](https://docs.dodopayments.com/features/customer-portal)
+- [Subscription Integration](https://docs.dodopayments.com/developer-resources/subscription-integration-guide)
 - [Credit-Based Billing](https://docs.dodopayments.com/features/credit-based-billing)

--- a/dodo-payments/best-practices/SKILL.md
+++ b/dodo-payments/best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dodo-best-practices
-description: Guide for integrating Dodo Payments - the all-in-one payment and billing platform for SaaS and AI products.
+description: Guide for initial Dodo Payments setup, including SDK installation, test and live environments, API keys, and the canonical checkout-to-webhook architecture.
 ---
 
 # Dodo Payments Integration Guide
@@ -214,7 +214,7 @@ Represent buyers. Can have multiple payment methods, subscriptions, and credit b
 
 The primary payment collection method. Create a session server-side, redirect the customer to the hosted checkout URL, and listen for webhooks to confirm payment.
 
-See the `checkout-and-subscriptions` skill for detailed checkout configuration.
+See the `checkout-integration` skill for detailed checkout configuration and the `subscription-integration` skill for recurring lifecycle management.
 
 ### Subscriptions
 
@@ -242,6 +242,10 @@ Virtual balances (API calls, tokens, compute hours) attached to products. Config
 Never grant access based on the browser `return_url` redirect alone. The webhook is the authoritative confirmation.
 
 ```typescript
+import express from 'express';
+
+const app = express();
+
 // 1. Create session
 const session = await client.checkoutSessions.create({
   product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
@@ -251,25 +255,34 @@ const session = await client.checkoutSessions.create({
 
 // 2. Redirect to session.checkout_url
 
-// 3. Listen for webhook
-app.post('/webhook', async (req, res) => {
+// 3. Listen for webhook with the exact raw request bytes
+app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
     // 4. Verify signature
+    const webhookId = req.headers['webhook-id'] as string;
     const event = client.webhooks.unwrap(req.body.toString(), {
       headers: {
-        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-id': webhookId,
         'webhook-signature': req.headers['webhook-signature'] as string,
         'webhook-timestamp': req.headers['webhook-timestamp'] as string,
       },
     });
 
-    // 5. Grant access
-    if (event.type === 'payment.succeeded') {
-      const payment = event.data;
-      await grantAccess(payment.customer.customer_id);
-    }
+    // 5. Suppress duplicates with an atomic unique insert and run side effects
+    // in the same database transaction.
+    const handled = await processWebhookOnce(webhookId, async () => {
+      if (event.type === 'payment.succeeded') {
+        // ONE-TIME purchases only. Subscription access starts on subscription.active.
+        const payment = event.data;
+        await grantOneTimeAccess(payment.customer.customer_id);
+      }
 
-    res.json({ received: true });
+      if (event.type === 'subscription.active') {
+        await grantSubscriptionAccess(event.data);
+      }
+    });
+
+    res.json({ received: true, duplicate: !handled });
   } catch (error) {
     res.status(401).json({ error: 'Invalid signature' });
   }
@@ -290,18 +303,31 @@ Authorization: Bearer dodo_live_...
 
 ### Pagination
 
-List endpoints support `limit` and `offset`:
+List endpoints are page-numbered. They accept `page_size` and `page_number`, and the response
+exposes the rows on `items`:
 
 ```typescript
 const payments = await client.payments.list({
-  limit: 50,
-  offset: 0,
+  page_size: 50,
+  page_number: 0,
 });
+
+for (const payment of payments.items) {
+  console.log(payment.payment_id);
+}
+```
+
+The SDK can also walk every page for you:
+
+```typescript
+for await (const payment of client.payments.list()) {
+  console.log(payment.payment_id);
+}
 ```
 
 ### Rate Limits
 
-Dodo enforces rate limits. Responses include `X-RateLimit-*` headers. Implement exponential backoff on `429` responses.
+Dodo enforces rate limits. The SDK automatically retries `429` responses as described below.
 
 ### SDK Error Classes
 
@@ -319,7 +345,29 @@ try {
 
 ### Retries
 
-The SDK does not retry automatically. Implement retry logic for transient failures (5xx, timeouts).
+The SDK retries twice by default with a short exponential backoff on connection errors and `408`, `409`, `429`, and `5xx` responses. Do not add an unconditional custom retry loop.
+
+Override the default for all requests when constructing the client:
+
+```typescript
+const clientWithoutRetries = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+  maxRetries: 0,
+});
+```
+
+Or override it for one request:
+
+```typescript
+await client.checkoutSessions.create(
+  {
+    product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
+    customer: { email: 'customer@example.com' },
+  },
+  { maxRetries: 0 },
+);
+```
 
 ---
 

--- a/dodo-payments/better-auth-integration/SKILL.md
+++ b/dodo-payments/better-auth-integration/SKILL.md
@@ -45,9 +45,12 @@ export const auth = betterAuth({
     dodopayments({
       client: dodoPayments,
       createCustomerOnSignUp: true,
+      // `user` here is Better Auth's base user: id, name, email, emailVerified,
+      // image, createdAt, updatedAt. Anything else (phone number, company, plan)
+      // must first be declared via `user.additionalFields` in your Better Auth
+      // config, otherwise it does not exist on the type and will be undefined.
       getCustomerParams: (user) => ({
         metadata: { better_auth_user_id: user.id },
-        phone_number: user.phoneNumber ?? null,
       }),
       use: [
         checkout({

--- a/dodo-payments/better-auth-integration/SKILL.md
+++ b/dodo-payments/better-auth-integration/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: better-auth-integration
+description: Guide for integrating Dodo Payments with Better Auth for automatic customer sync, checkout, portal, and verified webhooks
+---
+
+# Better Auth Integration
+
+This skill covers the `@dodopayments/better-auth` plugin, which synchronizes customers between Better Auth and Dodo Payments, handles checkout sessions, customer portal access, subscription listing, metered usage, and signature-verified webhooks.
+
+## When to use this skill
+
+- You're building a SaaS with Better Auth and need to sync users to Dodo Payments automatically on sign-up.
+- You want to create checkout sessions tied to authenticated users without manual customer creation.
+- You need to let signed-in users access the Dodo customer portal for subscriptions and payment methods.
+- You're ingesting metered usage events from authenticated sessions.
+- You need to handle Dodo webhooks with signature verification and event-specific callbacks.
+
+## Core concepts
+
+**Customer synchronization:** When a user signs up via Better Auth, the plugin creates a Dodo customer automatically if `createCustomerOnSignUp` is enabled. Metadata (like the Better Auth user ID) is attached to the customer record.
+
+**Product slug mapping:** Instead of passing product IDs to checkout, you configure product slugs in the plugin. The plugin maps `slug: "premium-plan"` to the actual Dodo product ID.
+
+**Authenticated portal:** The customer portal session is created server-side for the signed-in user, then redirected to the hosted portal URL.
+
+**Webhook verification:** The plugin exposes a signature-verified webhook endpoint. Dodo signs each webhook with HMAC-SHA256 following the Standard Webhooks spec.
+
+## Install
+
+```bash
+npm install @dodopayments/better-auth dodopayments better-auth zod
+```
+
+Verify the exact export names against your installed package version, as the official docs show an inconsistency between lowercase `betterAuth` and uppercase `BetterAuth`.
+
+## Server setup
+
+Register the Dodo plugin with your Better Auth instance. The plugin accepts a Dodo client, customer creation settings, and optional portal support.
+
+```typescript
+import { betterAuth } from "better-auth";
+import DodoPayments from "dodopayments";
+import { dodopayments, portal } from "@dodopayments/better-auth";
+
+const dodoPayments = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT || "test_mode",
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+});
+
+export const auth = betterAuth({
+  database: {
+    // your database config
+  },
+  plugins: [
+    dodopayments({
+      client: dodoPayments,
+      createCustomerOnSignUp: true,
+      use: [portal()],
+      getCustomerParams: (user) => ({
+        metadata: { userId: user.id },
+        phone_number: user.phoneNumber ?? null,
+      }),
+    }),
+  ],
+});
+```
+
+**Key options:**
+
+- `client`: The initialized Dodo Payments client.
+- `createCustomerOnSignUp`: If `true`, a Dodo customer is created when a user signs up. Defaults to `false`.
+- `use`: Array of plugin features. Include `portal()` to enable the customer portal.
+- `getCustomerParams`: A function that receives the Better Auth user object and returns Dodo customer metadata. Use this to attach the Better Auth user ID or other fields to the Dodo customer record.
+
+## Client setup and checkout
+
+On the client side, use the `authClient.dodopayments.checkoutSession()` method to create a checkout session for the signed-in user.
+
+```typescript
+import { authClient } from "@/lib/auth-client";
+
+async function startCheckout() {
+  const { data: session, error } = await authClient.dodopayments.checkoutSession({
+    slug: "premium-plan",
+    referenceId: "order_123",
+  });
+
+  if (error) {
+    console.error("Checkout error:", error);
+    return;
+  }
+
+  if (session) {
+    window.location.href = session.url;
+  }
+}
+```
+
+**Parameters:**
+
+- `slug`: The product slug configured in your Better Auth plugin setup. Maps to a Dodo product ID.
+- `referenceId`: Your internal order or reference ID. Useful for reconciliation.
+
+The method returns a checkout session with a `url` property. Redirect the user to that URL to begin payment.
+
+## Customer portal
+
+Enable the customer portal by including `portal()` in the plugin's `use` array during server setup. Then create a portal session server-side and redirect the user.
+
+```typescript
+import { auth } from "@/lib/auth";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  if (!session) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const portalSession = await auth.api.dodopayments.customerPortal({
+    headers: request.headers,
+  });
+
+  if (portalSession?.url) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: portalSession.url },
+    });
+  }
+
+  return new Response("Portal session failed", { status: 500 });
+}
+```
+
+The portal allows users to manage subscriptions, update payment methods, view invoices, and cancel plans.
+
+## List subscriptions and payments
+
+Retrieve the signed-in customer's subscriptions and payments.
+
+```typescript
+const { data: subscriptions } = await authClient.dodopayments.listSubscriptions({
+  headers: request.headers,
+});
+
+const { data: payments } = await authClient.dodopayments.listPayments({
+  headers: request.headers,
+});
+
+subscriptions?.forEach((sub) => {
+  console.log(`Subscription ${sub.id}: ${sub.status}`);
+});
+
+payments?.forEach((payment) => {
+  console.log(`Payment ${payment.id}: ${payment.amount} ${payment.currency}`);
+});
+```
+
+## Metered usage ingestion
+
+If you're using metered billing, ingest usage events through the plugin.
+
+```typescript
+const { error } = await authClient.dodopayments.ingestUsage({
+  meter_id: "meter_abc123",
+  quantity: 100,
+  idempotency_key: `usage_${Date.now()}`,
+});
+
+if (error) {
+  console.error("Usage ingestion failed:", error);
+}
+```
+
+The `idempotency_key` ensures the same event is not counted twice if the request is retried.
+
+## Webhook endpoint
+
+Set up a server-side webhook endpoint that verifies signatures and dispatches events.
+
+```typescript
+import { auth } from "@/lib/auth";
+
+export async function POST(request: Request) {
+  const body = await request.text();
+
+  try {
+    const event = await auth.api.dodopayments.verifyWebhook({
+      body,
+      headers: {
+        "webhook-id": request.headers.get("webhook-id") || "",
+        "webhook-signature": request.headers.get("webhook-signature") || "",
+        "webhook-timestamp": request.headers.get("webhook-timestamp") || "",
+      },
+    });
+
+    // Handle event
+    switch (event.type) {
+      case "payment.succeeded":
+        console.log("Payment succeeded:", event.data.payment_id);
+        break;
+      case "subscription.created":
+        console.log("Subscription created:", event.data.subscription_id);
+        break;
+      case "subscription.cancelled":
+        console.log("Subscription cancelled:", event.data.subscription_id);
+        break;
+      default:
+        console.log("Unhandled event:", event.type);
+    }
+
+    return new Response(JSON.stringify({ received: true }), { status: 200 });
+  } catch (error) {
+    console.error("Webhook verification failed:", error);
+    return new Response("Invalid signature", { status: 401 });
+  }
+}
+```
+
+The plugin verifies the webhook signature using the Standard Webhooks spec. The signed message is `webhook-id.webhook-timestamp.raw_body`, HMAC-SHA256, base64-encoded.
+
+## Common mistakes
+
+**Creating Dodo customers manually in addition to the plugin.** If `createCustomerOnSignUp` is enabled, the plugin creates the customer automatically. Don't call `client.customers.create()` yourself for the same user, or you'll end up with duplicate customer records.
+
+**Trusting client-side session state for entitlement.** Always verify the user's subscription status server-side before granting access to premium features. A user's session cookie can be forged or expired; the Dodo subscription is the source of truth.
+
+**Skipping the webhook endpoint.** If you don't set up the webhook handler, you won't know when subscriptions renew, fail, or are cancelled. Implement the webhook endpoint and register it in the Dodo dashboard.
+
+**Forgetting to pass the raw request body to webhook verification.** If you parse the body as JSON first, then re-serialize it, the signature will not match. Always pass the raw body string to the verification function.
+
+**Not mapping user metadata.** Use `getCustomerParams` to attach the Better Auth user ID to the Dodo customer. This makes it easy to look up the Dodo customer later when you receive a webhook event.
+
+## Resources
+
+- [Better Auth Adapter](https://docs.dodopayments.com/developer-resources/better-auth-adaptor)
+- [Dodo Payments SDK](https://github.com/dodopayments/dodopayments-typescript)
+- [Standard Webhooks Spec](https://standardwebhooks.com)

--- a/dodo-payments/better-auth-integration/SKILL.md
+++ b/dodo-payments/better-auth-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: better-auth-integration
-description: Guide for integrating Dodo Payments with Better Auth for automatic customer sync, checkout, portal, and verified webhooks
+description: Guide only for applications using @dodopayments/better-auth, covering authenticated customer sync, checkout, portal access, usage ingestion, and verified webhook callbacks.
 ---
 
 # Better Auth Integration
@@ -200,8 +200,8 @@ export async function POST(request: Request) {
       case "payment.succeeded":
         console.log("Payment succeeded:", event.data.payment_id);
         break;
-      case "subscription.created":
-        console.log("Subscription created:", event.data.subscription_id);
+      case "subscription.active":
+        console.log("Subscription active:", event.data.subscription_id);
         break;
       case "subscription.cancelled":
         console.log("Subscription cancelled:", event.data.subscription_id);

--- a/dodo-payments/better-auth-integration/SKILL.md
+++ b/dodo-payments/better-auth-integration/SKILL.md
@@ -5,47 +5,36 @@ description: Guide only for applications using @dodopayments/better-auth, coveri
 
 # Better Auth Integration
 
-This skill covers the `@dodopayments/better-auth` plugin, which synchronizes customers between Better Auth and Dodo Payments, handles checkout sessions, customer portal access, subscription listing, metered usage, and signature-verified webhooks.
+Use `@dodopayments/better-auth` to synchronize Better Auth users with Dodo Payments and expose authenticated checkout, customer portal, subscription, payment, usage, and webhook endpoints.
 
 ## When to use this skill
 
-- You're building a SaaS with Better Auth and need to sync users to Dodo Payments automatically on sign-up.
-- You want to create checkout sessions tied to authenticated users without manual customer creation.
-- You need to let signed-in users access the Dodo customer portal for subscriptions and payment methods.
-- You're ingesting metered usage events from authenticated sessions.
-- You need to handle Dodo webhooks with signature verification and event-specific callbacks.
-
-## Core concepts
-
-**Customer synchronization:** When a user signs up via Better Auth, the plugin creates a Dodo customer automatically if `createCustomerOnSignUp` is enabled. Metadata (like the Better Auth user ID) is attached to the customer record.
-
-**Product slug mapping:** Instead of passing product IDs to checkout, you configure product slugs in the plugin. The plugin maps `slug: "premium-plan"` to the actual Dodo product ID.
-
-**Authenticated portal:** The customer portal session is created server-side for the signed-in user, then redirected to the hosted portal URL.
-
-**Webhook verification:** The plugin exposes a signature-verified webhook endpoint. Dodo signs each webhook with HMAC-SHA256 following the Standard Webhooks spec.
+- Create a Dodo customer automatically when a Better Auth user signs up.
+- Start checkout for a signed-in user without exposing a Dodo API key.
+- Let users open their customer portal or list their subscriptions and payments.
+- Submit metered usage for the signed-in customer.
+- Receive signature-verified Dodo webhooks through Better Auth.
 
 ## Install
 
 ```bash
-npm install @dodopayments/better-auth dodopayments better-auth zod
+npm install @dodopayments/better-auth dodopayments better-auth
 ```
 
-Verify the exact export names against your installed package version, as the official docs show an inconsistency between lowercase `betterAuth` and uppercase `BetterAuth`.
+The package exports the lowercase server functions `dodopayments`, `checkout`, `portal`, `usage`, and `webhooks`. Its client entry point exports `dodopaymentsClient`.
 
 ## Server setup
 
-Register the Dodo plugin with your Better Auth instance. The plugin accepts a Dodo client, customer creation settings, and optional portal support.
+Every endpoint is registered by a feature in `use`. Include every feature that the application calls; omitting one makes its route return 404.
 
 ```typescript
 import { betterAuth } from "better-auth";
 import DodoPayments from "dodopayments";
-import { dodopayments, portal } from "@dodopayments/better-auth";
+import { checkout, dodopayments, portal, usage, webhooks } from "@dodopayments/better-auth";
 
 const dodoPayments = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT || "test_mode",
-  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  environment: "test_mode",
 });
 
 export const auth = betterAuth({
@@ -56,26 +45,48 @@ export const auth = betterAuth({
     dodopayments({
       client: dodoPayments,
       createCustomerOnSignUp: true,
-      use: [portal()],
       getCustomerParams: (user) => ({
-        metadata: { userId: user.id },
+        metadata: { better_auth_user_id: user.id },
         phone_number: user.phoneNumber ?? null,
       }),
+      use: [
+        checkout({
+          products: [
+            { productId: "pdt_premium", slug: "premium-plan" },
+          ],
+          successUrl: "https://app.example.com/billing/success",
+          authenticatedUsersOnly: true,
+        }),
+        portal(),
+        usage(),
+        webhooks({
+          webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+          onPayload: async (payload) => {
+            console.log("Verified Dodo webhook:", payload.type);
+          },
+        }),
+      ],
     }),
   ],
 });
 ```
 
-**Key options:**
+`products` maps an application slug to a Dodo product ID. `authenticatedUsersOnly: true` requires a Better Auth session for checkout. `getCustomerParams` adds application metadata when customer synchronization runs.
 
-- `client`: The initialized Dodo Payments client.
-- `createCustomerOnSignUp`: If `true`, a Dodo customer is created when a user signs up. Defaults to `false`.
-- `use`: Array of plugin features. Include `portal()` to enable the customer portal.
-- `getCustomerParams`: A function that receives the Better Auth user object and returns Dodo customer metadata. Use this to attach the Better Auth user ID or other fields to the Dodo customer record.
+## Browser client setup
 
-## Client setup and checkout
+```typescript
+import { createAuthClient } from "better-auth/react";
+import { dodopaymentsClient } from "@dodopayments/better-auth/client";
 
-On the client side, use the `authClient.dodopayments.checkoutSession()` method to create a checkout session for the signed-in user.
+export const authClient = createAuthClient({
+  plugins: [dodopaymentsClient()],
+});
+```
+
+These are browser methods. They send the Better Auth session cookie automatically; do not pass `request.headers` to them.
+
+## Create a checkout session
 
 ```typescript
 import { authClient } from "@/lib/auth-client";
@@ -97,143 +108,104 @@ async function startCheckout() {
 }
 ```
 
-**Parameters:**
+`slug` must match a product configured in `checkout({ products: [...] })`. `referenceId` is optional reconciliation metadata.
 
-- `slug`: The product slug configured in your Better Auth plugin setup. Maps to a Dodo product ID.
-- `referenceId`: Your internal order or reference ID. Useful for reconciliation.
-
-The method returns a checkout session with a `url` property. Redirect the user to that URL to begin payment.
-
-## Customer portal
-
-Enable the customer portal by including `portal()` in the plugin's `use` array during server setup. Then create a portal session server-side and redirect the user.
+## Open the customer portal
 
 ```typescript
-import { auth } from "@/lib/auth";
+const { data: portalSession, error } =
+  await authClient.dodopayments.customer.portal();
 
-export async function GET(request: Request) {
-  const session = await auth.api.getSession({ headers: request.headers });
-
-  if (!session) {
-    return new Response("Unauthorized", { status: 401 });
-  }
-
-  const portalSession = await auth.api.dodopayments.customerPortal({
-    headers: request.headers,
-  });
-
-  if (portalSession?.url) {
-    return new Response(null, {
-      status: 302,
-      headers: { Location: portalSession.url },
-    });
-  }
-
-  return new Response("Portal session failed", { status: 500 });
+if (error) {
+  console.error("Portal error:", error);
+} else if (portalSession?.redirect) {
+  window.location.href = portalSession.url;
 }
 ```
 
-The portal allows users to manage subscriptions, update payment methods, view invoices, and cancel plans.
+The portal endpoint requires a signed-in, verified user and resolves that user's synchronized Dodo customer.
 
 ## List subscriptions and payments
 
-Retrieve the signed-in customer's subscriptions and payments.
-
 ```typescript
-const { data: subscriptions } = await authClient.dodopayments.listSubscriptions({
-  headers: request.headers,
-});
+const { data: subscriptions, error: subscriptionsError } =
+  await authClient.dodopayments.customer.subscriptions.list({
+    query: { page: 1, limit: 10, status: "active" },
+  });
 
-const { data: payments } = await authClient.dodopayments.listPayments({
-  headers: request.headers,
-});
+const { data: payments, error: paymentsError } =
+  await authClient.dodopayments.customer.payments.list({
+    query: { page: 1, limit: 10, status: "succeeded" },
+  });
 
-subscriptions?.forEach((sub) => {
-  console.log(`Subscription ${sub.id}: ${sub.status}`);
-});
-
-payments?.forEach((payment) => {
-  console.log(`Payment ${payment.id}: ${payment.amount} ${payment.currency}`);
-});
+if (subscriptionsError || paymentsError) {
+  console.error("Could not load billing history");
+} else {
+  console.log("Subscriptions:", subscriptions?.items);
+  console.log("Payments:", payments?.items);
+}
 ```
 
-## Metered usage ingestion
+Both list responses use an `items` envelope. Subscription filters accept `page`, `limit`, and `status`; payment filters use the same pagination fields and payment statuses.
 
-If you're using metered billing, ingest usage events through the plugin.
+## Ingest metered usage
+
+Enable `usage()` on the server, then submit an event for the signed-in customer:
 
 ```typescript
-const { error } = await authClient.dodopayments.ingestUsage({
-  meter_id: "meter_abc123",
-  quantity: 100,
-  idempotency_key: `usage_${Date.now()}`,
+const { data, error } = await authClient.dodopayments.usage.ingest({
+  event_id: "evt_usage_123",
+  event_name: "api_calls",
+  metadata: { requests: 100 },
+  timestamp: new Date(),
 });
 
 if (error) {
   console.error("Usage ingestion failed:", error);
+} else {
+  console.log("Ingested events:", data?.ingested_count);
 }
 ```
 
-The `idempotency_key` ensures the same event is not counted twice if the request is retried.
+The plugin derives `customer_id` from the authenticated session. `event_id` is the event's idempotency key; reuse it when retrying the same event.
 
 ## Webhook endpoint
 
-Set up a server-side webhook endpoint that verifies signatures and dispatches events.
+`webhooks({ webhookKey, onPayload })` verifies and handles the request itself. With Better Auth's default `/api/auth` base path, configure this URL in the Dodo dashboard:
 
-```typescript
-import { auth } from "@/lib/auth";
-
-export async function POST(request: Request) {
-  const body = await request.text();
-
-  try {
-    const event = await auth.api.dodopayments.verifyWebhook({
-      body,
-      headers: {
-        "webhook-id": request.headers.get("webhook-id") || "",
-        "webhook-signature": request.headers.get("webhook-signature") || "",
-        "webhook-timestamp": request.headers.get("webhook-timestamp") || "",
-      },
-    });
-
-    // Handle event
-    switch (event.type) {
-      case "payment.succeeded":
-        console.log("Payment succeeded:", event.data.payment_id);
-        break;
-      case "subscription.active":
-        console.log("Subscription active:", event.data.subscription_id);
-        break;
-      case "subscription.cancelled":
-        console.log("Subscription cancelled:", event.data.subscription_id);
-        break;
-      default:
-        console.log("Unhandled event:", event.type);
-    }
-
-    return new Response(JSON.stringify({ received: true }), { status: 200 });
-  } catch (error) {
-    console.error("Webhook verification failed:", error);
-    return new Response("Invalid signature", { status: 401 });
-  }
-}
+```text
+https://app.example.com/api/auth/dodopayments/webhooks
 ```
 
-The plugin verifies the webhook signature using the Standard Webhooks spec. The signed message is `webhook-id.webhook-timestamp.raw_body`, HMAC-SHA256, base64-encoded.
+Do not create a second route and do not call `auth.api.dodopayments.verifyWebhook()`; that method does not exist. The plugin reads the raw request, verifies the Standard Webhooks signature with `webhookKey`, and invokes `onPayload` plus any configured event-specific callback.
+
+## Registered endpoints
+
+- `POST /dodopayments/checkout`
+- `POST /dodopayments/checkout-session`
+- `GET /dodopayments/customer/portal`
+- `GET /dodopayments/customer/subscriptions/list`
+- `GET /dodopayments/customer/payments/list`
+- `POST /dodopayments/usage/ingest`
+- `GET /dodopayments/usage/meters/list`
+- `POST /dodopayments/webhooks`
+
+Better Auth prefixes these plugin paths with its configured API base path.
 
 ## Common mistakes
 
-**Creating Dodo customers manually in addition to the plugin.** If `createCustomerOnSignUp` is enabled, the plugin creates the customer automatically. Don't call `client.customers.create()` yourself for the same user, or you'll end up with duplicate customer records.
+**Enabling only `portal()`.** Checkout, usage, and webhook routes do not exist unless `checkout()`, `usage()`, and `webhooks()` are also present in `use`.
 
-**Trusting client-side session state for entitlement.** Always verify the user's subscription status server-side before granting access to premium features. A user's session cookie can be forged or expired; the Dodo subscription is the source of truth.
+**Mixing browser and server APIs.** Call `authClient.dodopayments...` in browser code without a `headers` option. Use Better Auth's server API separately when handling server requests.
 
-**Skipping the webhook endpoint.** If you don't set up the webhook handler, you won't know when subscriptions renew, fail, or are cancelled. Implement the webhook endpoint and register it in the Dodo dashboard.
+**Creating duplicate customers.** When `createCustomerOnSignUp` is enabled, do not also call `client.customers.create()` for the same user.
 
-**Forgetting to pass the raw request body to webhook verification.** If you parse the body as JSON first, then re-serialize it, the signature will not match. Always pass the raw body string to the verification function.
+**Granting access from browser state.** Treat verified webhook events or a server-side Dodo lookup as the source of truth for entitlements.
 
-**Not mapping user metadata.** Use `getCustomerParams` to attach the Better Auth user ID to the Dodo customer. This makes it easy to look up the Dodo customer later when you receive a webhook event.
+**Adding a custom webhook verifier.** The plugin owns `/dodopayments/webhooks`, signature verification, and callback dispatch.
 
 ## Resources
 
 - [Better Auth Adapter](https://docs.dodopayments.com/developer-resources/better-auth-adaptor)
+- [Dodo Payments Better Auth package](https://www.npmjs.com/package/@dodopayments/better-auth)
 - [Dodo Payments SDK](https://github.com/dodopayments/dodopayments-typescript)
-- [Standard Webhooks Spec](https://standardwebhooks.com)

--- a/dodo-payments/billing-sdk/SKILL.md
+++ b/dodo-payments/billing-sdk/SKILL.md
@@ -1,501 +1,488 @@
 ---
 name: billing-sdk
-description: Guide for using BillingSDK - open-source React components for pricing tables, subscription management, and billing UI with Dodo Payments.
+description: Guide for building billing UI with BillingSDK - the open-source React component library for pricing tables, subscription management, usage meters, invoice history, and customer portal flows wired to Dodo Payments.
 ---
 
-# BillingSDK Integration
+# BillingSDK
 
-**Reference: [docs.dodopayments.com/developer-resources/billingsdk](https://docs.dodopayments.com/developer-resources/billingsdk) | [billingsdk.com](https://billingsdk.com)**
+BillingSDK is an open-source React component library for billing interfaces, maintained by Dodo Payments
+at `github.com/dodopayments/billingsdk`. Components are copied into your repository as source files
+(shadcn/ui model) rather than imported from a runtime npm package.
 
-BillingSDK provides open-source, customizable React components for billing interfaces - pricing tables, subscription management, usage meters, and more.
+Use this skill when building the front end. All Dodo Payments API calls belong in server-side route
+handlers; the components are presentation only.
 
----
+## When to use this skill
 
-## Overview
+- Building a pricing page that starts a Dodo checkout.
+- Building an account/billing page with subscription details and a "Manage billing" button.
+- Rendering usage meters, credit balances, invoice history, or upcoming charges.
+- Adding cancel / upgrade / downgrade UI to an existing React or Next.js app.
+- Deciding whether to scaffold with `@billingsdk/cli init` or add individual components.
 
-BillingSDK offers:
-- **React Components**: Pre-built, customizable billing components
-- **CLI Tooling**: Project initialization and component management
-- **Framework Support**: Next.js, Express.js, Hono, Fastify, React
-- **Payment Provider**: Full integration with Dodo Payments
+## Core concepts
 
----
+**Source-installed, not a dependency.** The repository root package `billingsdk` is private. There is no
+verified general-purpose runtime npm component package. You install components through the CLI or the
+shadcn registry, and the `.tsx` files land in your project under `components/billingsdk/`.
 
-## Quick Start Options
+**The installed file is the prop contract.** Because components are vendored into your repo, the exported
+props type in `components/billingsdk/<component>.tsx` is authoritative for your version. Read it before
+wiring callbacks. Do not assume prop names from another project.
 
-### Option 1: New Project (Recommended)
-Complete project setup with framework configuration and API routes:
+**The registry is the installability source of truth.** Use
+[`registry.json`](https://github.com/dodopayments/billingsdk/blob/main/registry.json). The docs navigation
+has drifted from it — for example `payment-success-dialog` appears in navigation but not in the current
+registry. If `add` fails, the block is not in the registry.
+
+**Components never call Dodo.** They receive data and fire callbacks. Every Dodo Payments call runs on your
+server with `DODO_PAYMENTS_API_KEY`. That key is `dodo_test_...` or `dodo_live_...` and must never reach
+the browser.
+
+## Installation
+
+Scaffold a new integration (framework config, API routes, `useBilling` hooks, `lib/dodopayments.ts`,
+dependencies, and env vars `DODO_PAYMENTS_API_KEY`, `DODO_PAYMENTS_ENVIRONMENT`,
+`DODO_PAYMENTS_WEBHOOK_KEY`):
 
 ```bash
 npx @billingsdk/cli init
 ```
 
-The CLI will:
-- Configure your framework (Next.js App Router)
-- Set up Dodo Payments integration
-- Generate API routes for checkout, customers, webhooks
-- Install dependencies
-- Create configuration files
-
-### Option 2: Add to Existing Project
-Add individual components using the CLI:
+Add a single component to an existing project:
 
 ```bash
 npx @billingsdk/cli add pricing-table-one
-npx @billingsdk/cli add subscription-management
-npx @billingsdk/cli add usage-meter-circle
 ```
 
-### Option 3: Manual via shadcn/ui
-Install directly using shadcn registry:
+Or install through the shadcn registry using the `@billingsdk/` namespace:
 
 ```bash
 npx shadcn@latest add @billingsdk/pricing-table-one
 ```
 
----
+The published CLI package is `@billingsdk/cli`, most recently seen at version 0.9.0.
 
-## CLI Reference
+## Component inventory
 
-### Initialize Project
+From the current official registry, grouped by purpose:
 
-```bash
-npx @billingsdk/cli init
+| Group | Blocks |
+|---|---|
+| Pricing | `pricing-table-one` through `pricing-table-eight` |
+| Subscription | `subscription-management`, `usage-based-pricing`, `invoice-history`, `update-plan-card`, `update-plan-dialog`, `proration-preview`, `cancel-subscription-card`, `cancel-subscription-dialog` |
+| Usage and billing | `usage-meter-linear`, `usage-meter-circle`, `usage-table`, `detailed-usage-table`, `billing-screen`, `billing-settings`, `billing-settings-2`, `upcoming-charges` |
+| Payments | `payment-details`, `payment-details-two`, `payment-method-selector`, `payment-card`, `payment-failure` |
+| Promotion and trials | `banner`, `limited-offer-dialog`, `trial-expiry-card` |
+
+`pricing-table-one` is the only block with an officially published prop example, reproduced below. For
+every other block, run `add` and read the generated file's props type.
+
+## Server client
+
+One module, imported only by route handlers and server components.
+
+```typescript
+// lib/dodopayments.ts
+import DodoPayments from 'dodopayments';
+
+if (!process.env.DODO_PAYMENTS_API_KEY) {
+  throw new Error('DODO_PAYMENTS_API_KEY is not set');
+}
+
+export const dodo = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live_mode' : 'test_mode',
+});
 ```
 
-Interactive setup prompts:
-1. Select framework (Next.js, Express.js, Hono, Fastify, React)
-2. Select payment provider (Dodo Payments)
-3. Configure project settings
+`environment` defaults to `'live_mode'` when omitted, so set it explicitly during development. Base URLs
+are `https://test.dodopayments.com` and `https://live.dodopayments.com`.
 
-### Add Components
+## Pricing page
 
-```bash
-npx @billingsdk/cli add <component-name>
-```
+### 1. Plan catalogue
 
-**Available components:**
-- `pricing-table-one` - Simple pricing table
-- `pricing-table-two` - Feature-rich pricing table
-- `subscription-management` - Manage active subscriptions
-- `usage-meter-circle` - Circular usage visualization
-- More components available...
+Keep the product ids and the display copy in one module. The `price` here is a display number rendered by
+the component — the amount actually charged comes from the Dodo product catalogue, and Dodo API amounts
+are always in the smallest currency unit (cents). Treat this file as a mirror of the dashboard and
+reconcile it when you change a price.
 
-### What happens when adding:
-1. Downloads component from registry
-2. Installs files to `components/billingsdk/`
-3. Updates project configuration
-4. Installs additional dependencies
+```typescript
+// lib/plans.ts
+export type PlanId = 'starter' | 'pro';
 
----
+export interface Plan {
+  id: PlanId;
+  title: string;
+  price: number;
+  period: string;
+  features: string[];
+  popular: boolean;
+}
 
-## Components
-
-### Pricing Table One
-
-Simple, clean pricing table for displaying plans.
-
-**Installation:**
-```bash
-npx @billingsdk/cli add pricing-table-one
-# or
-npx shadcn@latest add @billingsdk/pricing-table-one
-```
-
-**Usage:**
-```tsx
-import { PricingTableOne } from "@/components/billingsdk/pricing-table-one";
-
-const plans = [
+export const PLANS: readonly Plan[] = [
   {
-    id: 'prod_free',
-    name: 'Free',
-    price: 0,
-    interval: 'month',
-    features: ['5 projects', 'Basic support'],
+    id: 'starter',
+    title: 'Starter',
+    price: 9,
+    period: 'month',
+    features: ['100 requests', 'Basic support', '1 project'],
+    popular: false,
   },
   {
-    id: 'prod_pro',
-    name: 'Pro',
+    id: 'pro',
+    title: 'Pro',
     price: 29,
-    interval: 'month',
-    features: ['Unlimited projects', 'Priority support', 'API access'],
+    period: 'month',
+    features: ['Unlimited requests', 'Priority support', '10 projects'],
     popular: true,
   },
-  {
-    id: 'prod_enterprise',
-    name: 'Enterprise',
-    price: 99,
-    interval: 'month',
-    features: ['Everything in Pro', 'Custom integrations', 'Dedicated support'],
-  },
 ];
-
-export function PricingPage() {
-  const handleSelectPlan = async (planId: string) => {
-    // Create checkout session
-    const response = await fetch('/api/checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ productId: planId }),
-    });
-    
-    const { checkoutUrl } = await response.json();
-    window.location.href = checkoutUrl;
-  };
-
-  return (
-    <PricingTableOne 
-      plans={plans}
-      onSelectPlan={handleSelectPlan}
-    />
-  );
-}
 ```
 
-### Pricing Table Two
+### 2. Product id map — server only
 
-Feature-comparison pricing table with toggle for monthly/yearly.
+Never let the browser choose an arbitrary `product_id`. Map the public plan slug to a `pdt_` id on the
+server and reject anything else.
 
-**Installation:**
-```bash
-npx @billingsdk/cli add pricing-table-two
-```
-
-**Usage:**
-```tsx
-import { PricingTableTwo } from "@/components/billingsdk/pricing-table-two";
-
-const plans = [
-  {
-    id: 'prod_starter_monthly',
-    yearlyId: 'prod_starter_yearly',
-    name: 'Starter',
-    monthlyPrice: 19,
-    yearlyPrice: 190,
-    features: [
-      { name: 'Projects', value: '10' },
-      { name: 'Storage', value: '5 GB' },
-      { name: 'Support', value: 'Email' },
-    ],
-  },
-  {
-    id: 'prod_pro_monthly',
-    yearlyId: 'prod_pro_yearly',
-    name: 'Pro',
-    monthlyPrice: 49,
-    yearlyPrice: 490,
-    popular: true,
-    features: [
-      { name: 'Projects', value: 'Unlimited' },
-      { name: 'Storage', value: '50 GB' },
-      { name: 'Support', value: 'Priority' },
-    ],
-  },
-];
-
-export function PricingPage() {
-  return (
-    <PricingTableTwo 
-      plans={plans}
-      onSelectPlan={(planId, billingInterval) => {
-        console.log(`Selected: ${planId}, Interval: ${billingInterval}`);
-      }}
-    />
-  );
-}
-```
-
-### Subscription Management
-
-Allow users to view and manage their subscription.
-
-**Installation:**
-```bash
-npx @billingsdk/cli add subscription-management
-```
-
-**Usage:**
-```tsx
-import { SubscriptionManagement } from "@/components/billingsdk/subscription-management";
-
-export function AccountPage() {
-  const subscription = {
-    plan: 'Pro',
-    status: 'active',
-    currentPeriodEnd: '2025-02-21',
-    amount: 49,
-    interval: 'month',
-  };
-
-  return (
-    <SubscriptionManagement 
-      subscription={subscription}
-      onManageBilling={async () => {
-        // Open customer portal
-        const response = await fetch('/api/portal', { method: 'POST' });
-        const { url } = await response.json();
-        window.location.href = url;
-      }}
-      onCancelSubscription={async () => {
-        if (confirm('Are you sure you want to cancel?')) {
-          await fetch('/api/subscription/cancel', { method: 'POST' });
-        }
-      }}
-    />
-  );
-}
-```
-
-### Usage Meter
-
-Display usage-based billing metrics.
-
-**Installation:**
-```bash
-npx @billingsdk/cli add usage-meter-circle
-```
-
-**Usage:**
-```tsx
-import { UsageMeterCircle } from "@/components/billingsdk/usage-meter-circle";
-
-export function UsageDashboard() {
-  return (
-    <div className="grid grid-cols-3 gap-4">
-      <UsageMeterCircle 
-        label="API Calls"
-        current={8500}
-        limit={10000}
-        unit="calls"
-      />
-      <UsageMeterCircle 
-        label="Storage"
-        current={3.2}
-        limit={5}
-        unit="GB"
-      />
-      <UsageMeterCircle 
-        label="Bandwidth"
-        current={45}
-        limit={100}
-        unit="GB"
-      />
-    </div>
-  );
-}
-```
-
----
-
-## Next.js Integration
-
-### Project Structure (after `init`)
-
-```
-your-project/
-├── app/
-│   ├── api/
-│   │   ├── checkout/
-│   │   │   └── route.ts
-│   │   ├── portal/
-│   │   │   └── route.ts
-│   │   └── webhooks/
-│   │       └── dodo/
-│   │           └── route.ts
-│   └── pricing/
-│       └── page.tsx
-├── components/
-│   └── billingsdk/
-│       ├── pricing-table-one.tsx
-│       └── subscription-management.tsx
-├── lib/
-│   ├── dodo.ts
-│   └── billingsdk-config.ts
-└── .env.local
-```
-
-### Generated API Routes
-
-**Checkout Route (`app/api/checkout/route.ts`):**
 ```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { dodo } from '@/lib/dodo';
+// lib/plan-products.server.ts
+import 'server-only';
+import type { PlanId } from './plans';
 
-export async function POST(req: NextRequest) {
-  const { productId, email } = await req.json();
-
-  const session = await dodo.checkoutSessions.create({
-    product_cart: [{ product_id: productId, quantity: 1 }],
-    customer: { email },
-    return_url: `${process.env.NEXT_PUBLIC_APP_URL}/success`,
-  });
-
-  return NextResponse.json({ checkoutUrl: session.checkout_url });
-}
-```
-
-**Portal Route (`app/api/portal/route.ts`):**
-```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { dodo } from '@/lib/dodo';
-import { getSession } from '@/lib/auth';
-
-export async function POST(req: NextRequest) {
-  const session = await getSession();
-  
-  const portal = await dodo.customers.createPortalSession({
-    customer_id: session.user.customerId,
-    return_url: `${process.env.NEXT_PUBLIC_APP_URL}/account`,
-  });
-
-  return NextResponse.json({ url: portal.url });
-}
-```
-
-### Configuration File
-
-**`lib/billingsdk-config.ts`:**
-```typescript
-export const plans = [
-  {
-    id: process.env.NEXT_PUBLIC_PLAN_FREE_ID!,
-    name: 'Free',
-    description: 'Perfect for trying out',
-    price: 0,
-    interval: 'month' as const,
-    features: [
-      '5 projects',
-      '1 GB storage',
-      'Community support',
-    ],
-  },
-  {
-    id: process.env.NEXT_PUBLIC_PLAN_PRO_ID!,
-    name: 'Pro',
-    description: 'For professionals',
-    price: 29,
-    interval: 'month' as const,
-    popular: true,
-    features: [
-      'Unlimited projects',
-      '50 GB storage',
-      'Priority support',
-      'API access',
-    ],
-  },
-];
-
-export const config = {
-  returnUrl: process.env.NEXT_PUBLIC_APP_URL + '/success',
-  portalReturnUrl: process.env.NEXT_PUBLIC_APP_URL + '/account',
+const PRODUCT_IDS: Record<PlanId, string> = {
+  starter: 'pdt_starter_monthly',
+  pro: 'pdt_pro_monthly',
 };
+
+export function productIdForPlan(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return PRODUCT_IDS[value as PlanId] ?? null;
+}
 ```
 
----
+### 3. Checkout route
 
-## Customization
+```typescript
+// app/api/checkout/route.ts
+import { NextResponse } from 'next/server';
+import { dodo } from '@/lib/dodopayments';
+import { productIdForPlan } from '@/lib/plan-products.server';
+import { getCurrentUser } from '@/lib/auth';
 
-### Styling with Tailwind
+export async function POST(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
 
-Components use Tailwind CSS and shadcn/ui patterns. Customize via:
+  const body: unknown = await request.json();
+  const planId = (body as { planId?: unknown }).planId;
+  const productId = productIdForPlan(planId);
 
-1. **Theme variables** in `globals.css`
-2. **Direct class overrides** on components
-3. **Component source modification** (files are local)
+  if (!productId) {
+    return NextResponse.json({ error: 'Unknown plan' }, { status: 400 });
+  }
 
-**Example - Custom colors:**
-```css
-/* globals.css */
-@layer base {
-  :root {
-    --primary: 220 90% 56%;
-    --primary-foreground: 0 0% 100%;
+  try {
+    const session = await dodo.checkoutSessions.create({
+      product_cart: [{ product_id: productId, quantity: 1 }],
+      customer: { email: user.email, name: user.name },
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/billing/return`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/pricing`,
+      metadata: { app_user_id: user.id },
+    });
+
+    if (!session.checkout_url) {
+      return NextResponse.json({ error: 'No checkout URL returned' }, { status: 502 });
+    }
+
+    return NextResponse.json({ checkoutUrl: session.checkout_url });
+  } catch (error) {
+    console.error('Checkout session creation failed', error);
+    return NextResponse.json({ error: 'Could not start checkout' }, { status: 500 });
   }
 }
 ```
 
-### Component Props
+`checkout_url` is nullable — it is absent when the session is created with `payment_method_id` — so guard
+it rather than redirecting to `undefined`. Checkout URLs are single-use and normally expire after 24 hours.
 
-Most components accept standard styling props:
+Use `checkoutSessions.create`. `payments.create` and `subscriptions.create` are deprecated for new
+integrations. Checkout parameters are covered in depth in the `checkout-integration` skill.
+
+### 4. Client component
 
 ```tsx
-<PricingTableOne 
-  plans={plans}
-  onSelectPlan={handleSelect}
-  className="max-w-4xl mx-auto"
-  containerClassName="gap-8"
-  cardClassName="border-2"
-/>
+// components/pricing-plans.tsx
+'use client';
+
+import { useState } from 'react';
+import { PricingTableOne } from '@/components/billingsdk/pricing-table-one';
+import { PLANS } from '@/lib/plans';
+
+export function PricingPlans() {
+  const [error, setError] = useState<string | null>(null);
+
+  async function handlePlanSelect(planId: string) {
+    setError(null);
+    try {
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ planId }),
+      });
+
+      if (!response.ok) {
+        setError('Could not start checkout. Please try again.');
+        return;
+      }
+
+      const { checkoutUrl } = (await response.json()) as { checkoutUrl: string };
+      window.location.href = checkoutUrl;
+    } catch {
+      setError('Network error. Please try again.');
+    }
+  }
+
+  return (
+    <>
+      <PricingTableOne
+        plans={PLANS}
+        title="Choose your plan"
+        description="Select the plan that works best for you"
+        onPlanSelect={handlePlanSelect}
+        theme="classic"
+        size="medium"
+      />
+      {error ? <p role="alert">{error}</p> : null}
+    </>
+  );
+}
 ```
 
----
+Render `<PricingPlans />` from `app/pricing/page.tsx`. Nothing secret crosses into the client component:
+it sends a plan slug and receives a URL.
 
-## Environment Variables
+## Subscription management and customer portal
+
+Install the block, then read its props from the generated file:
 
 ```bash
-# .env.local
+npx @billingsdk/cli add subscription-management
+```
 
-# Dodo Payments
-DODO_PAYMENTS_API_KEY=sk_live_xxxxx
-DODO_PAYMENTS_WEBHOOK_SECRET=whsec_xxxxx
+The portal route. The method is `customers.customerPortal.create(customerID, { ...params })` and the
+session's URL field is `link`.
 
-# Product IDs (from dashboard)
-NEXT_PUBLIC_PLAN_FREE_ID=prod_xxxxx
-NEXT_PUBLIC_PLAN_PRO_ID=prod_xxxxx
-NEXT_PUBLIC_PLAN_ENTERPRISE_ID=prod_xxxxx
+```typescript
+// app/api/portal/route.ts
+import { NextResponse } from 'next/server';
+import { dodo } from '@/lib/dodopayments';
+import { getCurrentUser } from '@/lib/auth';
 
-# App
+export async function POST() {
+  const user = await getCurrentUser();
+  if (!user?.dodoCustomerId) {
+    return NextResponse.json({ error: 'No billing account' }, { status: 400 });
+  }
+
+  try {
+    const session = await dodo.customers.customerPortal.create(user.dodoCustomerId, {
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/account`,
+    });
+
+    return NextResponse.json({ url: session.link });
+  } catch (error) {
+    console.error('Customer portal session failed', error);
+    return NextResponse.json({ error: 'Could not open billing portal' }, { status: 500 });
+  }
+}
+```
+
+Portal links expire after 24 hours, so mint one per click instead of caching it. In the portal a customer
+can view and cancel subscriptions, change plans within enabled product collections, update payment
+methods, download invoices, and retrieve license keys.
+
+Client side:
+
+```tsx
+// components/manage-billing-button.tsx
+'use client';
+
+import { useState } from 'react';
+
+export function ManageBillingButton() {
+  const [pending, setPending] = useState(false);
+
+  async function openPortal() {
+    setPending(true);
+    try {
+      const response = await fetch('/api/portal', { method: 'POST' });
+      if (!response.ok) {
+        setPending(false);
+        return;
+      }
+      const { url } = (await response.json()) as { url: string };
+      window.location.href = url;
+    } catch {
+      setPending(false);
+    }
+  }
+
+  return (
+    <button type="button" onClick={openPortal} disabled={pending}>
+      {pending ? 'Opening…' : 'Manage billing'}
+    </button>
+  );
+}
+```
+
+Wire `openPortal` to whichever callback prop your installed `subscription-management.tsx` exposes, or
+render the standalone button next to it. Load the subscription itself in the server component that hosts
+the page — `await dodo.subscriptions.retrieve(user.dodoSubscriptionId)` — and pass plain data down.
+
+## Usage and credit display
+
+Install a meter block:
+
+```bash
+npx @billingsdk/cli add usage-meter-linear
+```
+
+Fetch the numbers server-side. Credit balances come from `creditEntitlements.balances.retrieve`:
+
+```typescript
+// app/api/usage/credits/route.ts
+import { NextResponse } from 'next/server';
+import { dodo } from '@/lib/dodopayments';
+import { getCurrentUser } from '@/lib/auth';
+
+const CREDIT_ENTITLEMENT_ID = process.env.DODO_CREDIT_ENTITLEMENT_ID;
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user?.dodoCustomerId || !CREDIT_ENTITLEMENT_ID) {
+    return NextResponse.json({ error: 'No billing account' }, { status: 400 });
+  }
+
+  try {
+    const balance = await dodo.creditEntitlements.balances.retrieve(user.dodoCustomerId, {
+      credit_entitlement_id: CREDIT_ENTITLEMENT_ID,
+    });
+
+    return NextResponse.json({ balance: balance.balance, overage: balance.overage });
+  } catch (error) {
+    console.error('Credit balance lookup failed', error);
+    return NextResponse.json({ error: 'Could not read balance' }, { status: 500 });
+  }
+}
+```
+
+Pass the result into the meter block using the prop names in your installed
+`components/billingsdk/usage-meter-linear.tsx`. Related blocks for the same surface: `usage-meter-circle`,
+`usage-table`, `detailed-usage-table`, `upcoming-charges`, `invoice-history`.
+
+Credit balances are eventually consistent — meter-to-credit deduction runs on a background worker roughly
+once a minute — so the displayed balance is informational. Do not gate a request on it. Metering, credit
+entitlements, and ledger entries are covered in the `usage-based-billing` and `credit-based-billing` skills.
+
+## Theming and customization
+
+Components are Tailwind CSS plus shadcn/ui conventions, so there are three layers:
+
+1. **Theme tokens.** Override the shadcn CSS variables in `globals.css`; every block inherits them.
+
+   ```css
+   @layer base {
+     :root {
+       --primary: 220 90% 56%;
+       --primary-foreground: 0 0% 100%;
+     }
+   }
+   ```
+
+2. **Component props.** `pricing-table-one` accepts `theme` (`"classic"` in the official example) and
+   `size` (`"medium"`). Check the installed file for the full union types.
+
+3. **Source edits.** The files are yours. Editing them is the supported path for structural changes, at
+   the cost of manual reconciliation when you re-run `add`.
+
+The hosted Dodo checkout page is themed separately, through `customization.theme_config` on the checkout
+session — not by these components.
+
+## Framework support
+
+The components are **not** framework-agnostic. They require React or Next.js plus Tailwind CSS and
+shadcn/ui conventions.
+
+The CLI additionally ships server integration templates for Next.js, Express, Hono, Fastify, and React.
+That covers the route-handler side only. Caution: Dodo's integration page and BillingSDK's own
+introduction have disagreed about which server templates are shipping versus "coming soon" — confirm the
+adapter you want with the current CLI before committing to it.
+
+For non-React front ends, call Dodo through a framework adapter (`@dodopayments/nextjs`,
+`@dodopayments/express`, `@dodopayments/sveltekit`, and others) and build your own UI.
+
+## Environment variables
+
+```bash
+# .env.local — server-side only, never prefixed with NEXT_PUBLIC_
+DODO_PAYMENTS_API_KEY=dodo_test_xxxxxxxxxxxxxxxx
+DODO_PAYMENTS_ENVIRONMENT=test_mode
+DODO_PAYMENTS_WEBHOOK_KEY=xxxxxxxxxxxxxxxx
+DODO_CREDIT_ENTITLEMENT_ID=cde_xxxxxxxxxxxxxxxx
+
+# Safe to expose
 NEXT_PUBLIC_APP_URL=https://yoursite.com
 ```
 
----
+Switch to `dodo_live_...` and `DODO_PAYMENTS_ENVIRONMENT=live_mode` together. A live key against
+`test_mode` fails, and a test key against `live_mode` fails.
 
-## Best Practices
+## Common mistakes
 
-### 1. Use Product IDs from Environment
-Keep product IDs in environment variables for easy staging/production switching.
+**Exposing the API key to the browser.** `NEXT_PUBLIC_DODO_PAYMENTS_API_KEY` inlines the secret into the
+JS bundle for anyone to read. There is no publishable key in Dodo Payments — every key is secret. Import
+`lib/dodopayments.ts` only from route handlers and server components.
 
-### 2. Handle Loading States
-Components should show loading states during checkout:
+**Calling `customers.createPortalSession`.** That method does not exist. Use
+`client.customers.customerPortal.create(customerID, { ...params })` and read `.link`, not `.url`.
 
-```tsx
-const [loading, setLoading] = useState(false);
+**Trusting client-rendered plan state.** The selected plan in React state, or the fact that the user
+returned to `return_url`, does not mean the subscription is active. Grant entitlements only from
+webhook-confirmed subscription events persisted in your database, then render UI from that. Webhook
+signature verification is covered in the `webhook-integration` skill.
 
-const handleSelect = async (planId: string) => {
-  setLoading(true);
-  try {
-    const response = await fetch('/api/checkout', {...});
-    const { checkoutUrl } = await response.json();
-    window.location.href = checkoutUrl;
-  } finally {
-    setLoading(false);
-  }
-};
-```
+**Accepting a raw `product_id` from the request body.** A caller can then check out against any product in
+your catalogue, including internal or discounted ones. Map an opaque plan slug to a `pdt_` id server-side.
 
-### 3. Server-Side Data Fetching
-Fetch subscription data server-side when possible:
+**Hardcoding prices in the client.** `PLANS[].price` is display text. When you change a price in the Dodo
+dashboard, the checkout charges the new amount while the pricing page keeps advertising the old one.
+Reconcile `lib/plans.ts` with the dashboard as part of any pricing change.
 
-```tsx
-// app/account/page.tsx
-import { getSubscription } from '@/lib/subscription';
+**`npm install billingsdk`.** The root repository package is private. Install through
+`@billingsdk/cli` or the shadcn registry instead.
 
-export default async function AccountPage() {
-  const subscription = await getSubscription();
-  
-  return <SubscriptionManagement subscription={subscription} />;
-}
-```
+**Guessing prop names.** `pricing-table-one` is the only block with a published prop example. Open the
+generated file under `components/billingsdk/` and read the exported props type before wiring anything else.
 
-### 4. Implement Webhooks
-Always use webhooks as source of truth for subscription status, not client-side data.
+**Using `DODO_PAYMENTS_WEBHOOK_SECRET`.** The SDK reads `DODO_PAYMENTS_WEBHOOK_KEY` for the `webhookKey`
+option.
 
----
+**Gating requests on the displayed credit balance.** Deduction is asynchronous, so the reported balance
+lags. Dodo explicitly warns against using it as strict per-request authorization.
+
+**Using `payments.create` or `subscriptions.create` for a purchase.** Both are deprecated. Use
+`checkoutSessions.create`.
 
 ## Resources
 
-- [BillingSDK Documentation](https://billingsdk.com/docs)
-- [Dodo Payments Integration](https://docs.dodopayments.com/developer-resources/billingsdk)
-- [Component Gallery](https://billingsdk.com/docs/components)
-- [GitHub Repository](https://github.com/dodopayments/billingsdk)
+- [BillingSDK on Dodo docs](https://docs.dodopayments.com/developer-resources/billingsdk)
+- [BillingSDK quick start](https://billingsdk.com/docs/quick-start)
+- [Component catalogue](https://billingsdk.com/docs/components)
+- [`registry.json` — installability source of truth](https://github.com/dodopayments/billingsdk/blob/main/registry.json)
+- [Checkout Sessions guide](https://docs.dodopayments.com/developer-resources/checkout-session)
+- [Customer Portal](https://docs.dodopayments.com/features/customer-portal)
+- [Credit-based billing](https://docs.dodopayments.com/features/credit-based-billing)

--- a/dodo-payments/checkout-integration/SKILL.md
+++ b/dodo-payments/checkout-integration/SKILL.md
@@ -72,9 +72,13 @@ console.log('Redirect to:', session.checkout_url);
 
 Response fields:
 - `session_id`: Unique checkout session ID
-- `checkout_url`: Hosted checkout URL (redirect customer here)
+- `checkout_url`: Hosted checkout URL (redirect customer here). Nullable when `confirm=true`
 - `client_secret`: Present only if `confirm=true`
+- `publishable_key`: Present only if `confirm=true`. Pair it with `client_secret` for the inline SDK flow
 - `payment_id`: Present only if `confirm=true`
+
+`publishable_key` is a per-session value returned for confirm-mode inline checkout. It is not a Stripe-style
+publishable *API key* — Dodo issues no such credential, and every API key is secret and server-side only.
 
 ### With Multiple Products
 
@@ -710,8 +714,8 @@ Supported parameters:
 ```typescript
 const status = await client.checkoutSessions.retrieve('cks_session_id');
 
-console.log(status.session_id);
-console.log(status.checkout_url);
+console.log(status.id);
+console.log(status.payment_status);
 ```
 
 ### Preview Session (without creating)

--- a/dodo-payments/checkout-integration/SKILL.md
+++ b/dodo-payments/checkout-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: checkout-integration
-description: Guide for creating checkout sessions and payment flows with Dodo Payments - one-time, subscriptions, and overlay checkout.
+description: Guide for starting hosted Checkout Sessions, payment links, and overlay or inline checkout for one-time and recurring products; use subscription-integration for post-checkout lifecycle management.
 ---
 
 # Dodo Payments Checkout Integration
@@ -26,7 +26,7 @@ Dodo Payments offers three ways to collect payment:
 |--------|----------|-------|
 | **Checkout Sessions** (recommended) | Most integrations; full control | Server-side SDK call |
 | **Static Payment Links** | No-code sharing; reusable URLs | Dashboard or direct URL |
-| **Overlay/Inline Checkout** | Seamless UX; stays on your site | Client-side SDK |
+| **Overlay/Inline Checkout** | Checkout stays on your site | Client-side SDK |
 
 **Legacy:** Dynamic Payment Links created via `POST /payments` or `POST /subscriptions` are deprecated. Use Checkout Sessions instead.
 
@@ -96,7 +96,7 @@ const session = await client.checkoutSessions.create({
   product_cart: [
     { product_id: 'pdt_example', quantity: 1 }
   ],
-  customer_id: 'cus_existing_id',
+  customer: { customer_id: 'cus_existing_id' },
   return_url: 'https://yoursite.com/success'
 });
 ```
@@ -209,29 +209,64 @@ const session = await client.checkoutSessions.create({
 
 ```typescript
 // app/api/checkout/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import DodoPayments from 'dodopayments';
+import { getCurrentUser } from '@/lib/auth';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
   environment: process.env.NODE_ENV === 'production' ? 'live_mode' : 'test_mode'
 });
 
-export async function POST(req: NextRequest) {
+type PlanId = 'starter' | 'pro';
+
+const PRODUCT_IDS: Record<PlanId, string> = {
+  starter: 'pdt_starter_monthly',
+  pro: 'pdt_pro_monthly'
+};
+
+function productIdForPlan(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return PRODUCT_IDS[value as PlanId] ?? null;
+}
+
+export async function POST(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  let body: unknown;
   try {
-    const { productId, quantity = 1, email, name, metadata } = await req.json();
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
 
-    if (!productId || !email) {
-      return NextResponse.json(
-        { error: 'Missing productId or email' },
-        { status: 400 }
-      );
-    }
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
 
+  const input = body as { planId?: unknown; quantity?: unknown };
+  const productId = productIdForPlan(input.planId);
+  const quantity = input.quantity ?? 1;
+
+  if (!productId) {
+    return NextResponse.json({ error: 'Unknown plan' }, { status: 400 });
+  }
+
+  if (!Number.isInteger(quantity) || (quantity as number) < 1) {
+    return NextResponse.json(
+      { error: 'Quantity must be a positive integer' },
+      { status: 400 }
+    );
+  }
+
+  try {
     const session = await client.checkoutSessions.create({
-      product_cart: [{ product_id: productId, quantity }],
-      customer: { email, name },
-      metadata,
+      product_cart: [{ product_id: productId, quantity: quantity as number }],
+      customer: { email: user.email, name: user.name },
+      metadata: { app_user_id: user.id },
       return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success`
     });
 
@@ -239,10 +274,10 @@ export async function POST(req: NextRequest) {
       checkoutUrl: session.checkout_url,
       sessionId: session.session_id
     });
-  } catch (error: any) {
+  } catch (error) {
     console.error('Checkout error:', error);
     return NextResponse.json(
-      { error: error.message || 'Failed to create checkout' },
+      { error: 'Failed to create checkout' },
       { status: 500 }
     );
   }
@@ -258,13 +293,12 @@ export async function POST(req: NextRequest) {
 import { useState } from 'react';
 
 interface CheckoutButtonProps {
-  productId: string;
-  email: string;
-  name?: string;
+  planId: 'starter' | 'pro';
+  quantity?: number;
   children: React.ReactNode;
 }
 
-export function CheckoutButton({ productId, email, name, children }: CheckoutButtonProps) {
+export function CheckoutButton({ planId, quantity = 1, children }: CheckoutButtonProps) {
   const [loading, setLoading] = useState(false);
 
   const handleCheckout = async () => {
@@ -273,15 +307,16 @@ export function CheckoutButton({ productId, email, name, children }: CheckoutBut
       const response = await fetch('/api/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId, email, name })
+        body: JSON.stringify({ planId, quantity })
       });
 
-      const data = await response.json();
-      if (data.checkoutUrl) {
-        window.location.href = data.checkoutUrl;
-      } else {
-        throw new Error(data.error || 'Failed to create checkout');
+      if (!response.ok) {
+        throw new Error('Failed to create checkout');
       }
+
+      const data = (await response.json()) as { checkoutUrl?: string };
+      if (!data.checkoutUrl) throw new Error('Checkout URL was not returned');
+      window.location.href = data.checkoutUrl;
     } catch (error) {
       console.error('Checkout error:', error);
       alert('Failed to start checkout. Please try again.');
@@ -334,28 +369,91 @@ export default function SuccessPage() {
 ```typescript
 import express from 'express';
 import DodoPayments from 'dodopayments';
+import { getCurrentUser } from './auth';
+import { fulfillOneTimePurchase, grantSubscriptionAccess } from './entitlements';
 
 const app = express();
-app.use(express.json());
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
   environment: process.env.NODE_ENV === 'production' ? 'live_mode' : 'test_mode'
 });
 
-app.post('/api/checkout', async (req, res) => {
+// Mount the webhook before express.json() so verification receives signed bytes.
+app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const { productId, email, name, quantity = 1 } = req.body;
+    const event = client.webhooks.unwrap(req.body.toString('utf8'), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string
+      }
+    });
 
+    if (event.type === 'payment.succeeded') {
+      // This branch fulfills one-time purchases only.
+      await fulfillOneTimePurchase(event.data.customer.customer_id);
+    } else if (event.type === 'subscription.active') {
+      // Subscription access starts only after this verified event.
+      await grantSubscriptionAccess(event.data);
+    }
+
+    res.json({ received: true });
+  } catch (error) {
+    console.error('Webhook verification failed:', error);
+    res.status(401).json({ error: 'Invalid signature' });
+  }
+});
+
+app.use(express.json());
+
+type PlanId = 'starter' | 'pro';
+
+const PRODUCT_IDS: Record<PlanId, string> = {
+  starter: 'pdt_starter_monthly',
+  pro: 'pdt_pro_monthly'
+};
+
+function productIdForPlan(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return PRODUCT_IDS[value as PlanId] ?? null;
+}
+
+app.post('/api/checkout', async (req, res) => {
+  const user = await getCurrentUser(req);
+  if (!user) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  const { planId, quantity = 1 } = req.body as {
+    planId?: unknown;
+    quantity?: unknown;
+  };
+  const productId = productIdForPlan(planId);
+
+  if (!productId) {
+    res.status(400).json({ error: 'Unknown plan' });
+    return;
+  }
+
+  if (!Number.isInteger(quantity) || (quantity as number) < 1) {
+    res.status(400).json({ error: 'Quantity must be a positive integer' });
+    return;
+  }
+
+  try {
     const session = await client.checkoutSessions.create({
-      product_cart: [{ product_id: productId, quantity }],
-      customer: { email, name },
+      product_cart: [{ product_id: productId, quantity: quantity as number }],
+      customer: { email: user.email, name: user.name },
+      metadata: { app_user_id: user.id },
       return_url: `${process.env.APP_URL}/success`
     });
 
     res.json({ checkoutUrl: session.checkout_url });
-  } catch (error: any) {
-    res.status(500).json({ error: error.message });
+  } catch (error) {
+    console.error('Checkout error:', error);
+    res.status(500).json({ error: 'Failed to create checkout' });
   }
 });
 
@@ -369,40 +467,54 @@ app.get('/success', (req, res) => {
 ## Python (FastAPI)
 
 ```python
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from dodopayments import DodoPayments
+import logging
 import os
+from typing import Annotated, Literal
+
+from dodopayments import DodoPayments
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from app.auth import User, get_current_user
 
 app = FastAPI()
+logger = logging.getLogger(__name__)
 client = DodoPayments(
     bearer_token=os.environ["DODO_PAYMENTS_API_KEY"],
     environment="test_mode"
 )
 
+PRODUCT_IDS = {
+    "starter": "pdt_starter_monthly",
+    "pro": "pdt_pro_monthly",
+}
+
 class CheckoutRequest(BaseModel):
-    product_id: str
-    email: str
-    name: str = None
-    quantity: int = 1
+    plan_id: Literal["starter", "pro"]
+    quantity: int = Field(default=1, gt=0)
 
 @app.post("/api/checkout")
-async def create_checkout(request: CheckoutRequest):
+async def create_checkout(
+    request: CheckoutRequest,
+    user: Annotated[User, Depends(get_current_user)],
+):
     try:
         session = client.checkout_sessions.create(
             product_cart=[{
-                "product_id": request.product_id,
+                "product_id": PRODUCT_IDS[request.plan_id],
                 "quantity": request.quantity
             }],
             customer={
-                "email": request.email,
-                "name": request.name
+                "email": user.email,
+                "name": user.name
             },
+            metadata={"app_user_id": user.id},
             return_url=f"{os.environ['APP_URL']}/success"
         )
         return {"checkout_url": session.checkout_url}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as error:
+        logger.exception("Checkout session creation failed")
+        raise HTTPException(status_code=500, detail="Failed to create checkout") from error
 ```
 
 ---
@@ -417,49 +529,140 @@ Use the `dodopayments-checkout` package for overlay or inline checkout that stay
 npm install dodopayments-checkout
 ```
 
-### Overlay Mode
+### Server Route
+
+Create the Checkout Session on the server. The browser sends a public plan slug, while the server derives
+the customer from the authenticated user and maps the slug to an allowlisted product id.
 
 ```typescript
-import { DodoPayments } from 'dodopayments-checkout';
+// app/api/overlay-checkout/route.ts
+import { NextResponse } from 'next/server';
+import DodoPayments from 'dodopayments';
+import { getCurrentUser } from '@/lib/auth';
 
-// First, create a checkout session on your server
-const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yoursite.com/success'
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+  environment: process.env.NODE_ENV === 'production' ? 'live_mode' : 'test_mode'
 });
 
-// Then initialize and open the overlay
-DodoPayments.Initialize({
-  mode: 'test', // or 'live'
-  displayType: 'overlay',
-  onEvent: (event) => {
-    console.log('Checkout event:', event);
+type PlanId = 'starter' | 'pro';
+
+const PRODUCT_IDS: Record<PlanId, string> = {
+  starter: 'pdt_starter_monthly',
+  pro: 'pdt_pro_monthly'
+};
+
+export async function POST(request: Request) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
-});
 
-DodoPayments.Checkout.open({
-  checkoutUrl: session.checkout_url
-});
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { planId, quantity = 1 } = body as {
+    planId?: unknown;
+    quantity?: unknown;
+  };
+  const productId = typeof planId === 'string'
+    ? PRODUCT_IDS[planId as PlanId]
+    : undefined;
+
+  if (!productId) {
+    return NextResponse.json({ error: 'Unknown plan' }, { status: 400 });
+  }
+
+  if (!Number.isInteger(quantity) || (quantity as number) < 1) {
+    return NextResponse.json(
+      { error: 'Quantity must be a positive integer' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const session = await client.checkoutSessions.create({
+      product_cart: [{ product_id: productId, quantity: quantity as number }],
+      customer: { email: user.email, name: user.name },
+      metadata: { app_user_id: user.id },
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success`
+    });
+
+    if (!session.checkout_url) {
+      return NextResponse.json({ error: 'Checkout URL was not returned' }, { status: 502 });
+    }
+
+    return NextResponse.json({ checkoutUrl: session.checkout_url });
+  } catch (error) {
+    console.error('Overlay checkout error:', error);
+    return NextResponse.json({ error: 'Failed to create checkout' }, { status: 500 });
+  }
+}
 ```
 
-### Inline/Embedded Mode
+### Browser Overlay and Inline Modes
+
+Browser code calls the server route and receives only the checkout URL. The Dodo Payments API bearer token
+stays in the server route and is never sent to the browser.
 
 ```typescript
+// lib/open-checkout.ts
 import { DodoPayments } from 'dodopayments-checkout';
 
-DodoPayments.Initialize({
-  mode: 'test',
-  displayType: 'inline',
-  onEvent: (event) => {
-    console.log('Checkout event:', event);
-  }
-});
+type PlanId = 'starter' | 'pro';
 
-DodoPayments.Checkout.open({
-  checkoutUrl: session.checkout_url,
-  elementId: 'dodo-inline-checkout'
-});
+async function createCheckoutUrl(planId: PlanId, quantity = 1): Promise<string> {
+  const response = await fetch('/api/overlay-checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ planId, quantity })
+  });
+
+  if (!response.ok) throw new Error('Failed to create checkout');
+
+  const data = (await response.json()) as { checkoutUrl?: string };
+  if (!data.checkoutUrl) throw new Error('Checkout URL was not returned');
+  return data.checkoutUrl;
+}
+
+export async function openOverlayCheckout(planId: PlanId): Promise<void> {
+  const checkoutUrl = await createCheckoutUrl(planId);
+
+  DodoPayments.Initialize({
+    mode: 'test', // or 'live'
+    displayType: 'overlay',
+    onEvent: (event) => {
+      console.log('Checkout event:', event);
+    }
+  });
+
+  DodoPayments.Checkout.open({ checkoutUrl });
+}
+
+export async function openInlineCheckout(planId: PlanId): Promise<void> {
+  const checkoutUrl = await createCheckoutUrl(planId);
+
+  DodoPayments.Initialize({
+    mode: 'test', // or 'live'
+    displayType: 'inline',
+    onEvent: (event) => {
+      console.log('Checkout event:', event);
+    }
+  });
+
+  DodoPayments.Checkout.open({
+    checkoutUrl,
+    elementId: 'dodo-inline-checkout'
+  });
+}
 ```
 
 ```html
@@ -522,7 +725,7 @@ const preview = await client.checkoutSessions.preview({
   billing_currency: 'EUR'
 });
 
-console.log('Preview total:', preview.total_amount);
+console.log('Preview total:', preview.current_breakup.total_amount);
 ```
 
 ---
@@ -591,30 +794,9 @@ Query parameters:
 
 ### Verify Payment Server-Side
 
-Do not trust the browser redirect. Always verify via webhook:
-
-```typescript
-app.post('/webhook', async (req, res) => {
-  try {
-    const event = client.webhooks.unwrap(req.body.toString(), {
-      headers: {
-        'webhook-id': req.headers['webhook-id'] as string,
-        'webhook-signature': req.headers['webhook-signature'] as string,
-        'webhook-timestamp': req.headers['webhook-timestamp'] as string
-      }
-    });
-
-    if (event.type === 'payment.succeeded') {
-      // Payment verified. Grant access here.
-      await grantAccess(event.data.customer_id);
-    }
-
-    res.json({ received: true });
-  } catch (error) {
-    res.status(401).json({ error: 'Invalid signature' });
-  }
-});
-```
+Do not trust the browser redirect. Use the Express webhook route above: it receives the raw signed body
+before `express.json()`, fulfills one-time purchases on verified `payment.succeeded` using
+`event.data.customer.customer_id`, and grants subscription access only on verified `subscription.active`.
 
 Webhook signature verification is covered in the `webhook-integration` skill.
 
@@ -622,8 +804,9 @@ Webhook signature verification is covered in the `webhook-integration` skill.
 
 ## Common Mistakes
 
-**1. Trusting the browser redirect**
-The return URL redirect is not proof of payment. Always verify via webhook before granting access or fulfilling the order.
+**1. Granting access from the return URL**
+The return URL redirect is not proof of payment. Never grant access or fulfill an order from its query
+parameters; wait for a verified webhook event.
 
 **2. Using deprecated APIs**
 Do not use `client.payments.create()` or `client.subscriptions.create()` for new integrations. Both are deprecated. Use `client.checkoutSessions.create()`.
@@ -631,8 +814,8 @@ Do not use `client.payments.create()` or `client.subscriptions.create()` for new
 **3. Forgetting the `environment` flag**
 The default is `live_mode`. Always set `environment: 'test_mode'` during development to avoid charging real cards.
 
-**4. Mixing `discount_code` and `discount_codes`**
-The singular `discount_code` is deprecated. Use the array `discount_codes` (max 20). They cannot be combined.
+**4. Assuming only one discount-code form is valid**
+Both `discount_code` (a string) and `discount_codes` (an array) are valid Checkout Session parameters.
 
 **5. Amounts in wrong unit**
 All amounts are in the smallest currency unit (cents for USD). $10 is `1000`, not `10`.
@@ -644,7 +827,12 @@ Checkout URLs are single-use. Create a new session for each checkout attempt.
 When `confirm=true`, the session is finalized immediately and the checkout URL expires in 15 minutes instead of 24 hours. Use only when you have all required customer data.
 
 **8. Forgetting raw body for webhooks**
-Webhook signature verification requires the raw request body, not a re-serialized JSON object. Use `express.raw()` middleware.
+Webhook signature verification requires the raw request body, not a re-serialized JSON object. Mount the
+webhook route with `express.raw({ type: 'application/json' })` before `express.json()`.
+
+**9. Trusting a client-supplied product id**
+Do not accept an arbitrary `pdt_` id from the browser. Authenticate the user, accept a public plan slug,
+map it to an allowlisted product id on the server, and reject quantities that are not positive integers.
 
 ---
 

--- a/dodo-payments/checkout-integration/SKILL.md
+++ b/dodo-payments/checkout-integration/SKILL.md
@@ -5,73 +5,182 @@ description: Guide for creating checkout sessions and payment flows with Dodo Pa
 
 # Dodo Payments Checkout Integration
 
-**Reference: [docs.dodopayments.com/developer-resources/integration-guide](https://docs.dodopayments.com/developer-resources/integration-guide)**
+Use `client.checkoutSessions.create(...)` to build hosted checkout pages or overlay checkout modals. This is the recommended path for all new payment integrations.
 
-Create seamless payment experiences with hosted checkout pages or overlay checkout modals.
+## When to use this skill
+
+- Build a one-time payment checkout flow
+- Create a subscription checkout with optional trial
+- Embed checkout in an overlay or inline modal
+- Collect customer billing info and custom fields at checkout
+- Apply discount codes or handle currency selection
+- Redirect customers after payment completes
 
 ---
 
 ## Checkout Methods
 
-| Method | Best For | Integration |
-|--------|----------|-------------|
-| **Hosted Checkout** | Simple integration, full-page redirect | Server-side SDK |
-| **Overlay Checkout** | Seamless UX, stays on your site | JavaScript SDK |
-| **Payment Links** | No-code, shareable links | Dashboard |
+Dodo Payments offers three ways to collect payment:
+
+| Method | Best For | Setup |
+|--------|----------|-------|
+| **Checkout Sessions** (recommended) | Most integrations; full control | Server-side SDK call |
+| **Static Payment Links** | No-code sharing; reusable URLs | Dashboard or direct URL |
+| **Overlay/Inline Checkout** | Seamless UX; stays on your site | Client-side SDK |
+
+**Legacy:** Dynamic Payment Links created via `POST /payments` or `POST /subscriptions` are deprecated. Use Checkout Sessions instead.
 
 ---
 
-## Hosted Checkout
+## Core Concepts
 
-### Basic Implementation
+**Amounts in smallest currency unit:** All prices are in cents (or equivalent). A $10 USD charge is `1000`.
+
+**Checkout Session:** A single-use session that generates a hosted checkout URL. Expires after 24 hours (or 15 minutes if `confirm=true`).
+
+**Return URL:** Where the customer lands after payment. Query parameters include `status=success` and `session_id`.
+
+**Entitlement on webhook:** The browser redirect is not the source of truth. Always verify payment via webhook before granting access. See `webhook-integration` skill for verification.
+
+---
+
+## Create a Checkout Session
+
+### Basic One-Time Payment
 
 ```typescript
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode', // or 'live_mode'
 });
 
-// Create checkout session
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_xxxxx', quantity: 1 }
+    { product_id: 'pdt_example', quantity: 1 }
   ],
   customer: {
     email: 'customer@example.com',
-    name: 'John Doe',
+    name: 'Jane Doe'
   },
-  return_url: 'https://yoursite.com/checkout/success',
+  return_url: 'https://yoursite.com/checkout/success'
 });
 
-// Redirect customer to checkout
-// session.checkout_url
+console.log('Redirect to:', session.checkout_url);
 ```
+
+Response fields:
+- `session_id`: Unique checkout session ID
+- `checkout_url`: Hosted checkout URL (redirect customer here)
+- `client_secret`: Present only if `confirm=true`
+- `payment_id`: Present only if `confirm=true`
 
 ### With Multiple Products
 
 ```typescript
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_item_1', quantity: 2 },
-    { product_id: 'prod_item_2', quantity: 1 },
+    { product_id: 'pdt_item_1', quantity: 2 },
+    { product_id: 'pdt_item_2', quantity: 1 }
   ],
-  customer: {
-    email: 'customer@example.com',
-  },
-  return_url: 'https://yoursite.com/success',
+  customer: { email: 'customer@example.com' },
+  return_url: 'https://yoursite.com/success'
 });
 ```
 
-### With Customer ID (Existing Customer)
+### With Existing Customer
 
 ```typescript
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_xxxxx', quantity: 1 }
+    { product_id: 'pdt_example', quantity: 1 }
   ],
-  customer_id: 'cust_existing_customer',
-  return_url: 'https://yoursite.com/success',
+  customer_id: 'cus_existing_id',
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+### With Billing Address and Tax ID
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'pdt_example', quantity: 1 }
+  ],
+  customer: {
+    email: 'customer@example.com',
+    name: 'Jane Doe'
+  },
+  billing_address: {
+    country: 'US',
+    street: '123 Main St',
+    city: 'San Francisco',
+    state: 'CA',
+    zipcode: '94105'
+  },
+  tax_id: 'VAT123456789',
+  customer_business_name: 'Acme Corp',
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+### With Discount Codes
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'pdt_example', quantity: 1 }
+  ],
+  customer: { email: 'customer@example.com' },
+  discount_codes: ['PROMO10', 'WELCOME5'], // max 20, ordered
+  feature_flags: {
+    allow_discount_code: true
+  },
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+### With Subscription and Trial
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'pdt_monthly_subscription', quantity: 1 }
+  ],
+  subscription_data: {
+    trial_period_days: 14
+  },
+  customer: { email: 'subscriber@example.com' },
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+### With Custom Fields
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'pdt_example', quantity: 1 }
+  ],
+  customer: { email: 'customer@example.com' },
+  custom_fields: [
+    {
+      key: 'company_size',
+      label: 'Company Size',
+      field_type: 'dropdown',
+      options: ['1-10', '11-50', '51-200', '200+'],
+      required: true
+    },
+    {
+      key: 'use_case',
+      label: 'Primary Use Case',
+      field_type: 'text',
+      placeholder: 'e.g., analytics, reporting',
+      required: false
+    }
+  ],
+  return_url: 'https://yoursite.com/success'
 });
 ```
 
@@ -80,23 +189,21 @@ const session = await client.checkoutSessions.create({
 ```typescript
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_xxxxx', quantity: 1 }
+    { product_id: 'pdt_example', quantity: 1 }
   ],
-  customer: {
-    email: 'customer@example.com',
-  },
+  customer: { email: 'customer@example.com' },
   metadata: {
     order_id: 'order_12345',
     referral_code: 'FRIEND20',
-    user_id: 'internal_user_id',
+    campaign: 'summer_sale'
   },
-  return_url: 'https://yoursite.com/success',
+  return_url: 'https://yoursite.com/success'
 });
 ```
 
 ---
 
-## Next.js Implementation
+## Next.js App Router
 
 ### API Route
 
@@ -107,6 +214,7 @@ import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+  environment: process.env.NODE_ENV === 'production' ? 'live_mode' : 'test_mode'
 });
 
 export async function POST(req: NextRequest) {
@@ -115,7 +223,7 @@ export async function POST(req: NextRequest) {
 
     if (!productId || !email) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Missing productId or email' },
         { status: 400 }
       );
     }
@@ -124,12 +232,12 @@ export async function POST(req: NextRequest) {
       product_cart: [{ product_id: productId, quantity }],
       customer: { email, name },
       metadata,
-      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success`,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success`
     });
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       checkoutUrl: session.checkout_url,
-      sessionId: session.checkout_session_id,
+      sessionId: session.session_id
     });
   } catch (error: any) {
     console.error('Checkout error:', error);
@@ -161,16 +269,14 @@ export function CheckoutButton({ productId, email, name, children }: CheckoutBut
 
   const handleCheckout = async () => {
     setLoading(true);
-    
     try {
       const response = await fetch('/api/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ productId, email, name }),
+        body: JSON.stringify({ productId, email, name })
       });
 
       const data = await response.json();
-      
       if (data.checkoutUrl) {
         window.location.href = data.checkoutUrl;
       } else {
@@ -201,9 +307,9 @@ import { Suspense } from 'react';
 function SuccessContent() {
   return (
     <div className="text-center py-20">
-      <h1 className="text-3xl font-bold">Payment Successful!</h1>
+      <h1 className="text-3xl font-bold">Payment Successful</h1>
       <p className="mt-4 text-gray-600">
-        Thank you for your purchase. You will receive a confirmation email shortly.
+        Thank you for your purchase. Check your email for a confirmation.
       </p>
       <a href="/" className="mt-8 inline-block text-blue-600 hover:underline">
         Return to Home
@@ -223,119 +329,7 @@ export default function SuccessPage() {
 
 ---
 
-## Overlay Checkout
-
-Embed checkout directly on your page without redirects.
-
-### Installation
-
-```bash
-npm install @dodopayments/checkout
-```
-
-### Basic Usage
-
-```typescript
-import { DodoCheckout } from '@dodopayments/checkout';
-
-// Initialize
-const checkout = new DodoCheckout({
-  apiKey: 'your_publishable_key',
-  environment: 'live', // or 'test'
-});
-
-// Open overlay
-checkout.open({
-  productId: 'prod_xxxxx',
-  customer: {
-    email: 'customer@example.com',
-  },
-  onSuccess: (result) => {
-    console.log('Payment successful:', result);
-    // Handle success
-  },
-  onClose: () => {
-    console.log('Checkout closed');
-  },
-});
-```
-
-### React Component
-
-```typescript
-// components/OverlayCheckout.tsx
-'use client';
-
-import { useEffect, useRef } from 'react';
-import { DodoCheckout } from '@dodopayments/checkout';
-
-interface OverlayCheckoutProps {
-  productId: string;
-  email: string;
-  onSuccess?: (result: any) => void;
-  children: React.ReactNode;
-}
-
-export function OverlayCheckout({ 
-  productId, 
-  email, 
-  onSuccess,
-  children 
-}: OverlayCheckoutProps) {
-  const checkoutRef = useRef<DodoCheckout | null>(null);
-
-  useEffect(() => {
-    checkoutRef.current = new DodoCheckout({
-      apiKey: process.env.NEXT_PUBLIC_DODO_PUBLISHABLE_KEY!,
-      environment: process.env.NODE_ENV === 'production' ? 'live' : 'test',
-    });
-
-    return () => {
-      checkoutRef.current?.close();
-    };
-  }, []);
-
-  const handleClick = () => {
-    checkoutRef.current?.open({
-      productId,
-      customer: { email },
-      onSuccess: (result) => {
-        onSuccess?.(result);
-        // Optionally redirect
-        window.location.href = '/checkout/success';
-      },
-      onClose: () => {
-        console.log('Checkout closed');
-      },
-    });
-  };
-
-  return (
-    <button onClick={handleClick}>
-      {children}
-    </button>
-  );
-}
-```
-
-### Customization
-
-```typescript
-checkout.open({
-  productId: 'prod_xxxxx',
-  customer: { email: 'customer@example.com' },
-  theme: {
-    primaryColor: '#0066FF',
-    backgroundColor: '#FFFFFF',
-    fontFamily: 'Inter, sans-serif',
-  },
-  locale: 'en',
-});
-```
-
----
-
-## Express.js Implementation
+## Express.js
 
 ```typescript
 import express from 'express';
@@ -346,16 +340,17 @@ app.use(express.json());
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+  environment: process.env.NODE_ENV === 'production' ? 'live_mode' : 'test_mode'
 });
 
-app.post('/api/create-checkout', async (req, res) => {
+app.post('/api/checkout', async (req, res) => {
   try {
     const { productId, email, name, quantity = 1 } = req.body;
 
     const session = await client.checkoutSessions.create({
       product_cart: [{ product_id: productId, quantity }],
       customer: { email, name },
-      return_url: `${process.env.APP_URL}/success`,
+      return_url: `${process.env.APP_URL}/success`
     });
 
     res.json({ checkoutUrl: session.checkout_url });
@@ -364,7 +359,6 @@ app.post('/api/create-checkout', async (req, res) => {
   }
 });
 
-// Success page route
 app.get('/success', (req, res) => {
   res.send('Payment successful!');
 });
@@ -372,9 +366,7 @@ app.get('/success', (req, res) => {
 
 ---
 
-## Python Implementation
-
-### FastAPI
+## Python (FastAPI)
 
 ```python
 from fastapi import FastAPI, HTTPException
@@ -383,7 +375,10 @@ from dodopayments import DodoPayments
 import os
 
 app = FastAPI()
-client = DodoPayments(bearer_token=os.environ["DODO_PAYMENTS_API_KEY"])
+client = DodoPayments(
+    bearer_token=os.environ["DODO_PAYMENTS_API_KEY"],
+    environment="test_mode"
+)
 
 class CheckoutRequest(BaseModel):
     product_id: str
@@ -405,195 +400,259 @@ async def create_checkout(request: CheckoutRequest):
             },
             return_url=f"{os.environ['APP_URL']}/success"
         )
-        
         return {"checkout_url": session.checkout_url}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 ```
 
-### Flask
+---
 
-```python
-from flask import Flask, request, jsonify
-from dodopayments import DodoPayments
-import os
+## Overlay Checkout
 
-app = Flask(__name__)
-client = DodoPayments(bearer_token=os.environ["DODO_PAYMENTS_API_KEY"])
+Use the `dodopayments-checkout` package for overlay or inline checkout that stays on your site.
 
-@app.route('/api/checkout', methods=['POST'])
-def create_checkout():
-    data = request.json
-    
-    session = client.checkout_sessions.create(
-        product_cart=[{
-            "product_id": data['product_id'],
-            "quantity": data.get('quantity', 1)
-        }],
-        customer={
-            "email": data['email'],
-            "name": data.get('name')
-        },
-        return_url=f"{os.environ['APP_URL']}/success"
-    )
-    
-    return jsonify({"checkout_url": session.checkout_url})
+### Installation
+
+```bash
+npm install dodopayments-checkout
+```
+
+### Overlay Mode
+
+```typescript
+import { DodoPayments } from 'dodopayments-checkout';
+
+// First, create a checkout session on your server
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
+  customer: { email: 'customer@example.com' },
+  return_url: 'https://yoursite.com/success'
+});
+
+// Then initialize and open the overlay
+DodoPayments.Initialize({
+  mode: 'test', // or 'live'
+  displayType: 'overlay',
+  onEvent: (event) => {
+    console.log('Checkout event:', event);
+  }
+});
+
+DodoPayments.Checkout.open({
+  checkoutUrl: session.checkout_url
+});
+```
+
+### Inline/Embedded Mode
+
+```typescript
+import { DodoPayments } from 'dodopayments-checkout';
+
+DodoPayments.Initialize({
+  mode: 'test',
+  displayType: 'inline',
+  onEvent: (event) => {
+    console.log('Checkout event:', event);
+  }
+});
+
+DodoPayments.Checkout.open({
+  checkoutUrl: session.checkout_url,
+  elementId: 'dodo-inline-checkout'
+});
+```
+
+```html
+<div id="dodo-inline-checkout"></div>
 ```
 
 ---
 
-## Go Implementation
+## Static Payment Links
 
-```go
-package main
+No-code shareable links. No server-side API call needed.
 
-import (
-    "encoding/json"
-    "net/http"
-    "os"
-    
-    "github.com/dodopayments/dodopayments-go"
-)
+### Basic Format
 
-var client = dodopayments.NewClient(
-    option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
-)
+```text
+https://checkout.dodopayments.com/buy/{productid}
+```
 
-type CheckoutRequest struct {
-    ProductID string `json:"product_id"`
-    Email     string `json:"email"`
-    Name      string `json:"name"`
-    Quantity  int    `json:"quantity"`
-}
+Example:
+```text
+https://checkout.dodopayments.com/buy/pdt_example
+```
 
-func createCheckout(w http.ResponseWriter, r *http.Request) {
-    var req CheckoutRequest
-    json.NewDecoder(r.Body).Decode(&req)
-    
-    if req.Quantity == 0 {
-        req.Quantity = 1
-    }
-    
-    session, err := client.CheckoutSessions.Create(r.Context(), &dodopayments.CheckoutSessionCreateParams{
-        ProductCart: []dodopayments.CartItem{
-            {ProductID: req.ProductID, Quantity: req.Quantity},
-        },
-        Customer: &dodopayments.Customer{
-            Email: req.Email,
-            Name:  req.Name,
-        },
-        ReturnURL: os.Getenv("APP_URL") + "/success",
-    })
-    
-    if err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-        return
-    }
-    
-    json.NewEncoder(w).Encode(map[string]string{
-        "checkout_url": session.CheckoutURL,
-    })
-}
+### With Query Parameters
+
+```text
+https://checkout.dodopayments.com/buy/pdt_example?quantity=2&email=customer@example.com&redirect_url=https%3A%2F%2Fyoursite.com%2Fsuccess
+```
+
+Supported parameters:
+- `quantity`: Item quantity
+- `redirect_url`: Success redirect URL
+- `email`: Prefill customer email
+- `fullName`, `firstName`, `lastName`: Prefill name
+- `country`, `city`, `state`, `zipCode`, `addressLine`: Prefill address
+- `paymentCurrency`: Force currency
+- `metadata_*`: Custom metadata (e.g., `metadata_orderId=123`)
+
+---
+
+## Retrieve and Preview Sessions
+
+### Retrieve Session Status
+
+```typescript
+const status = await client.checkoutSessions.retrieve('cks_session_id');
+
+console.log(status.session_id);
+console.log(status.checkout_url);
+```
+
+### Preview Session (without creating)
+
+```typescript
+const preview = await client.checkoutSessions.preview({
+  product_cart: [
+    { product_id: 'pdt_example', quantity: 1 }
+  ],
+  customer: { email: 'customer@example.com' },
+  billing_currency: 'EUR'
+});
+
+console.log('Preview total:', preview.total_amount);
 ```
 
 ---
 
-## Handling Success
+## Customization
 
-### Query Parameters
-The return URL receives these query parameters:
-- `status=success` - Payment completed
-- `session_id` - Checkout session ID
+### Theme and Appearance
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
+  customer: { email: 'customer@example.com' },
+  customization: {
+    theme: 'dark', // 'light', 'dark', or 'system'
+    force_language: 'en',
+    show_order_details: true,
+    theme_config: {
+      font_size: 'md',
+      font_weight: 'normal',
+      radius: '8px',
+      pay_button_text: 'Complete Purchase',
+      light: {
+        bg_primary: '#ffffff',
+        text_primary: '#000000',
+        button_primary: '#0066ff'
+      }
+    }
+  },
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+### Feature Flags
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_example', quantity: 1 }],
+  customer: { email: 'customer@example.com' },
+  feature_flags: {
+    allow_discount_code: true,
+    allow_currency_selection: true,
+    allow_customer_editing_email: true,
+    allow_phone_number_collection: true,
+    require_phone_number: false,
+    allow_tax_id: true
+  },
+  return_url: 'https://yoursite.com/success'
+});
+```
+
+---
+
+## Post-Payment Flow
+
+### Return URL Handling
+
+After payment, the customer is redirected to your `return_url` with query parameters:
+
+```text
+https://yoursite.com/success?status=success&session_id=cks_123
+```
+
+Query parameters:
+- `status`: `success` or `failed`
+- `session_id`: Checkout session ID
 
 ### Verify Payment Server-Side
-Don't rely solely on the redirect. Always verify via webhook:
+
+Do not trust the browser redirect. Always verify via webhook:
 
 ```typescript
-// Webhook handler confirms payment
 app.post('/webhook', async (req, res) => {
-  const event = req.body;
-  
-  if (event.type === 'payment.succeeded') {
-    // This is the source of truth
-    await fulfillOrder(event.data);
+  try {
+    const event = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string
+      }
+    });
+
+    if (event.type === 'payment.succeeded') {
+      // Payment verified. Grant access here.
+      await grantAccess(event.data.customer_id);
+    }
+
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
   }
-  
-  res.json({ received: true });
 });
 ```
+
+Webhook signature verification is covered in the `webhook-integration` skill.
 
 ---
 
-## Advanced Options
+## Common Mistakes
 
-### Prefill Customer Info
-```typescript
-const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'prod_xxxxx', quantity: 1 }],
-  customer: {
-    email: 'customer@example.com',
-    name: 'John Doe',
-    phone: '+1234567890',
-    address: {
-      line1: '123 Main St',
-      city: 'San Francisco',
-      state: 'CA',
-      postal_code: '94105',
-      country: 'US',
-    },
-  },
-  return_url: 'https://yoursite.com/success',
-});
-```
+**1. Trusting the browser redirect**
+The return URL redirect is not proof of payment. Always verify via webhook before granting access or fulfilling the order.
 
-### Custom Success/Cancel URLs
-```typescript
-const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'prod_xxxxx', quantity: 1 }],
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yoursite.com/checkout/success?session_id={CHECKOUT_SESSION_ID}',
-});
-```
+**2. Using deprecated APIs**
+Do not use `client.payments.create()` or `client.subscriptions.create()` for new integrations. Both are deprecated. Use `client.checkoutSessions.create()`.
 
-### Subscription with Trial
-```typescript
-const session = await client.checkoutSessions.create({
-  product_cart: [{ product_id: 'prod_subscription', quantity: 1 }],
-  subscription_data: {
-    trial_period_days: 14,
-  },
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yoursite.com/success',
-});
-```
+**3. Forgetting the `environment` flag**
+The default is `live_mode`. Always set `environment: 'test_mode'` during development to avoid charging real cards.
 
----
+**4. Mixing `discount_code` and `discount_codes`**
+The singular `discount_code` is deprecated. Use the array `discount_codes` (max 20). They cannot be combined.
 
-## Error Handling
+**5. Amounts in wrong unit**
+All amounts are in the smallest currency unit (cents for USD). $10 is `1000`, not `10`.
 
-```typescript
-try {
-  const session = await client.checkoutSessions.create({...});
-} catch (error: any) {
-  if (error.status === 400) {
-    // Invalid parameters
-    console.error('Invalid request:', error.message);
-  } else if (error.status === 401) {
-    // Invalid API key
-    console.error('Authentication failed');
-  } else if (error.status === 404) {
-    // Product not found
-    console.error('Product not found');
-  } else {
-    console.error('Checkout error:', error);
-  }
-}
-```
+**6. Reusing checkout URLs**
+Checkout URLs are single-use. Create a new session for each checkout attempt.
+
+**7. Ignoring `confirm=true` behavior**
+When `confirm=true`, the session is finalized immediately and the checkout URL expires in 15 minutes instead of 24 hours. Use only when you have all required customer data.
+
+**8. Forgetting raw body for webhooks**
+Webhook signature verification requires the raw request body, not a re-serialized JSON object. Use `express.raw()` middleware.
 
 ---
 
 ## Resources
 
-- [Integration Guide](https://docs.dodopayments.com/developer-resources/integration-guide)
+- [Checkout Sessions Integration Guide](https://docs.dodopayments.com/developer-resources/integration-guide)
+- [Checkout Sessions API Reference](https://docs.dodopayments.com/api-reference/checkout-sessions/create)
 - [Overlay Checkout](https://docs.dodopayments.com/developer-resources/overlay-checkout)
-- [API Reference](https://docs.dodopayments.com/api-reference/checkout-sessions)
+- [Inline Checkout](https://docs.dodopayments.com/developer-resources/inline-checkout)
+- [Static Payment Links](https://docs.dodopayments.com/developer-resources/integration-guide)
+- [Webhook Integration](https://docs.dodopayments.com/developer-resources/webhooks)

--- a/dodo-payments/credit-based-billing/SKILL.md
+++ b/dodo-payments/credit-based-billing/SKILL.md
@@ -574,7 +574,7 @@ Return an application-level payment/credit-required response with a top-up or up
 2. **Calling invented balance methods.** Use `balances.retrieve(customerId, { credit_entitlement_id })`, not `balances.get(creditId, customerId)`.
 3. **Using the wrong ledger argument order.** `createLedgerEntry` receives `customerId` first; `credit_entitlement_id` belongs in the request object.
 4. **Using `type` or `description` for adjustments.** Confirmed fields are `entry_type` and `reason`.
-5. **Calling an unverified grants method.** No `creditEntitlements.balances.listGrants(...)` call is established here. Use the balance/ledger APIs or `customers.listCreditEntitlements(customerID)` for the confirmed customer-level read.
+5. **Getting the grants argument order wrong.** `creditEntitlements.balances.listGrants(customerID, params)` does exist and takes the customer id first, with the entitlement supplied in the params object. It returns a paginated page, so read `.items` rather than treating the result as an array. Use `customers.listCreditEntitlements(customerID)` when you want the customer-level summary instead.
 6. **Treating `available_balance` as the balance API field.** The confirmed balance response uses `balance` and `overage`; `available_balance` belongs to the dedicated low-balance webhook payload.
 7. **Choosing precision casually.** It supports `0–10` for custom units and cannot be changed after creation.
 8. **Using JavaScript floating point for credits.** API amounts are decimal strings. Preserve them as strings or use decimal arithmetic.

--- a/dodo-payments/credit-based-billing/SKILL.md
+++ b/dodo-payments/credit-based-billing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: credit-based-billing
-description: Complete guide for implementing credit-based billing with Dodo Payments using credit entitlements, balances, ledger entries, rollover, overage, and meter-based deduction.
+description: Complete guide for giving customers included, free, prepaid, promotional, or top-up credits using grants, balances, ledger deductions, rollover, expiry, alerts, and overage.
 ---
 
 # Dodo Payments Credit-Based Billing

--- a/dodo-payments/credit-based-billing/SKILL.md
+++ b/dodo-payments/credit-based-billing/SKILL.md
@@ -1,549 +1,510 @@
 ---
 name: credit-based-billing
-description: Guide for implementing credit-based billing with Dodo Payments - credit entitlements, balances, ledger management, rollover, overage, and meter-based deduction.
+description: Complete guide for implementing credit-based billing with Dodo Payments using credit entitlements, balances, ledger entries, rollover, overage, and meter-based deduction.
 ---
 
 # Dodo Payments Credit-Based Billing
 
-**Reference: [docs.dodopayments.com/features/credit-based-billing](https://docs.dodopayments.com/features/credit-based-billing)**
+Use this skill to build prepaid or included-credit billing for tokens, API calls, compute, storage, or currency-denominated value, with auditable grants and deductions.
 
-Grant customers a balance of credits (API calls, tokens, compute units, or any custom metric) and deduct from that balance as they consume your service.
+## When to use this skill
 
----
+- Include a recurring credit allowance in a subscription.
+- Sell one-time top-up packs or prepaid usage.
+- Deduct credits from metered AI, API, or compute consumption.
+- Grant promotional or support credits and record a reason.
+- Configure expiry, rollover, low-balance alerts, or overage.
+- Reconcile a customer's balance against an immutable ledger trail.
 
-## Overview
+## Choose the billing model
 
-Credit-based billing lets you:
-- **Issue credits** with subscriptions, one-time purchases, or via API
-- **Deduct automatically** via usage meters or manually via API
-- **Configure rollover** to carry unused credits forward
-- **Handle overage** when credits run out mid-cycle
-- **Set expiration** rules per credit entitlement
-- **Track everything** via a full audit ledger
+| Requirement | Choose | Why |
+|---|---|---|
+| A fixed product with no tracked consumption | Plain subscription or one-time payment | No balance or usage pipeline is needed. |
+| Bill each measured unit directly in money | Pure usage-based billing | A meter rates usage with `price_per_unit`; no prepaid pool is needed. |
+| Include or pre-sell a consumable allowance | Credit-based billing | Grants create a balance that usage can consume. |
+| Include credits, then charge beyond the allowance | Credits with overage | The credit pool is consumed first; configured overage handles the deficit. |
+| Combine a base fee, included credits, and metered use | Usage-based product linked to a credit entitlement | The meter converts usage units into credit deductions. |
 
-Credits work across all product types: subscriptions, one-time purchases, and usage-based billing.
+Credit-based and usage-based billing are complementary. Define and test meters with the `usage-based-billing` skill; this skill covers the credit side and the meter-to-credit link.
 
----
+## Core concepts
 
-## Core Concepts
+### Credit entitlements and grants
 
-### Credit Types
+A **credit entitlement** is the reusable definition of a credit unit and its lifecycle: name, unit, precision, expiry, rollover, and overage. A **grant** is an issuance of that credit to one customer. Grants can originate from:
 
-| Type | Description | Best For |
-|------|-------------|----------|
-| **Custom Unit** | Your own metric (tokens, API calls, compute hours) with configurable precision (0–3 decimals) | API calls, AI tokens, compute hours, messages |
-| **Fiat Credits** | Real currency value (USD, EUR, etc.) that depletes as customers use your service | Prepaid balances, promotional credits, compensation |
+- a subscription, reissued each billing cycle;
+- a one-time product or add-on;
+- a direct API ledger credit;
+- rollover from an earlier grant.
 
-### Credit Lifecycle
+Credits gate **how much** a customer can consume. The separate `entitlements` resource gates fulfillment such as feature access, files, or license delivery. Do not confuse these SDK namespaces:
 
-1. **Credits Issued** — Granted on purchase (subscription cycle or one-time) or via API
-2. **Credits Consumed** — Deducted via meter events or manual API calls
-3. **Credits Expire or Roll Over** — At cycle end, unused credits expire or carry forward
-4. **Overage Handling** — If balance hits zero, overage is forgiven, billed, or carried as deficit
+```text
+client.creditEntitlements             credit definitions and balances
+client.creditEntitlements.balances    customer credit balances and ledger
+client.entitlements                   feature/file/license entitlements
+client.entitlements.files             entitlement files
+client.entitlements.grants            fulfillment grants
+```
 
-### Grant Sources
+Use `client.customers.listCreditEntitlements(customerID)` for the customer-level credit-entitlement view. Do not substitute `client.customers.listEntitlements(...)`, which reads the other entitlement system.
 
-| Source | Description |
-|--------|-------------|
-| **Subscription** | Credits issued each billing cycle |
-| **One-Time** | Credits issued with a one-time payment |
-| **API** | Credits granted manually via API or dashboard |
-| **Rollover** | Credits carried over from a previous billing cycle |
+### Custom-unit and fiat credits
 
----
+| Credit model | Representation | Example |
+|---|---|---|
+| Custom unit | Application-defined units | tokens, calls, compute hours, GB-hours |
+| Fiat | Currency value | USD or EUR prepaid balance |
 
-## Quick Start
+Custom-unit precision is configurable from `0` through `10`; the dashboard default is `2`. Precision cannot be changed after creation, so choose it before issuing grants. Use `0` for indivisible units such as whole requests. Use decimal precision only when fractional credits are meaningful.
 
-### 1. Create a Credit Entitlement
+Fiat examples use currency minor units: `5,000` credits represents USD 50 in the documented OpenAI example. Do not infer a universal fiat precision rule beyond the documented minor-unit model. All monetary amounts are in the currency's smallest unit (for example, cents for USD).
+
+A product can carry up to **five** credit entitlements. Each can have independent issuance and lifecycle settings.
+
+### Balance and ledger
+
+The balance response includes `balance`, `overage`, `last_transaction_at`, identifiers, and timestamps. Treat credit amounts as decimal strings; do not pass them through binary floating-point arithmetic.
+
+Every transaction has a ledger record with:
+
+- `balance_before` and `balance_after`;
+- `overage_before` and `overage_after`;
+- amount and transaction type;
+- source references and grant ID;
+- description, metadata, and timestamp.
+
+This ledger is the audit trail and provides transaction-level balance snapshots. There is no separately documented historical balance-snapshots endpoint.
+
+## Initialize the TypeScript SDK
+
+Keep API keys server-side. Dodo Payments keys use `dodo_test_...` and `dodo_live_...` prefixes.
 
 ```typescript
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-});
-
-const credit = await client.creditEntitlements.create({
-  name: 'API Credits',
-  credit_type: 'custom_unit',
-  unit_name: 'API Calls',
-  precision: 0,
-  expiry_duration: 30, // days
-  rollover_enabled: false,
-  allow_overage: false,
+  bearerToken: process.env['DODO_PAYMENTS_API_KEY'],
+  environment: 'test_mode',
 });
 ```
 
-### 2. Attach Credits to a Product
+The SDK defaults to `live_mode` when `environment` is omitted. Use `test_mode` explicitly during development.
 
-In Dashboard → Products → Create/Edit Product → Entitlements → Attach Credits:
-- Select the credit entitlement
-- Set credits issued per billing cycle (subscriptions) or total (one-time)
-- Configure trial credits, proration, low balance threshold
+## Create and configure a credit entitlement
 
-### 3. Create Checkout with Credit Product
+The confirmed TypeScript method is `client.creditEntitlements.create(...)`.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env['DODO_PAYMENTS_API_KEY'],
+  environment: 'test_mode',
+});
+
+const tokenCredits = await client.creditEntitlements.create({
+  name: 'AI Token Credits',
+  description: 'Credits consumed by model token usage',
+  unit: 'token credit',
+  precision: 0,
+  expires_after_days: 30,
+  rollover_enabled: true,
+  rollover_percentage: 25,
+  rollover_timeframe_count: 1,
+  rollover_timeframe_interval: 'Month',
+  max_rollover_count: 2,
+  overage_enabled: true,
+  overage_behavior: 'invoice_at_billing',
+  overage_limit: 100000,
+  price_per_unit: '1',
+  currency: 'USD',
+});
+
+console.log(tokenCredits.id);
+```
+
+`price_per_unit` is a decimal string in the configured currency; monetary values use the currency's smallest unit. In this example, `'1'` is one cent per overage credit for USD.
+
+### Confirmed create options
+
+| Field | Required | Meaning and constraints |
+|---|---:|---|
+| `name` | Yes | Display name for the credit entitlement. |
+| `unit` | Yes | Unit label such as `API Calls`, `Tokens`, or `Credits`. |
+| `precision` | Yes | Decimal places, `0–10`; immutable after creation. |
+| `description` | No | Optional description. |
+| `expires_after_days` | No | Nullable number of days after issuance before expiry. |
+| `rollover_enabled` | Yes | Enables or disables carry-forward. |
+| `rollover_percentage` | No | Percentage carried forward, `0–100`. |
+| `rollover_timeframe_count` | No | Number of rollover-validity intervals. |
+| `rollover_timeframe_interval` | No | `Day`, `Week`, `Month`, or `Year`. |
+| `max_rollover_count` | No | Maximum consecutive rollovers before forfeiture. |
+| `overage_enabled` | Yes | Allows deficit handling after credits are exhausted. |
+| `overage_behavior` | No | End-of-cycle behavior from the exact enum below. |
+| `overage_limit` | No | Maximum allowed overage units. |
+| `price_per_unit` | Conditional | Decimal string; required when overage is enabled. |
+| `currency` | Conditional | Required when a price is present. Monetary values use the smallest currency unit. |
+
+### Configure rollover
+
+Rollover carries eligible unused credits into a new grant. Configure:
+
+1. `rollover_enabled: true`.
+2. `rollover_percentage` as the carry-forward cap from `0` through `100`.
+3. Both `rollover_timeframe_count` and `rollover_timeframe_interval`; neither should be supplied alone.
+4. `max_rollover_count` if credits may roll only a limited number of consecutive times.
+
+Rollover is applied before expiry; only the remainder expires.
+
+### Configure expiry
+
+The API represents expiry as nullable `expires_after_days`. The dashboard offers 7, 30, 60, 90, custom days, or never; its default is 30 days, and custom expiry has a one-day minimum. Use `null` for no API-configured expiry only where the current API form permits it.
+
+### Configure overage
+
+| Exact `overage_behavior` value | Result at billing-cycle end |
+|---|---|
+| `forgive_at_reset` | Do not charge and do not preserve the deficit. This is the default. |
+| `invoice_at_billing` | Charge the overage at billing, then reset it. |
+| `carry_deficit` | Preserve the negative balance. |
+| `carry_deficit_auto_repay` | Preserve the deficit and repay it from newly issued credits. |
+
+When `overage_enabled` is true, `price_per_unit` is required; when a price is present, `currency` is required. Use `overage_limit` to cap allowed overage units.
+
+When overage is disabled, Dodo stops deducting after the balance reaches zero. Meter processing is asynchronous, so this is not synchronous authorization for your application requests. Implement application-side enforcement when requests must be rejected immediately.
+
+## Attach credits to products and subscriptions
+
+Credits are attached to products as credit entitlements in the product creation or edit flow. Do not use `client.entitlements.grants` to attach or issue credit balances.
+
+### Subscription product
+
+In **Products → Create Product** or an existing product:
+
+1. Choose subscription pricing.
+2. Open **Entitlements & Credits** and attach an existing credit entitlement.
+3. Set the credits issued each billing period.
+4. Optionally set a low-balance notification amount, trial-credit amount, whether unused trial credits expire after trial, and credit proration for plan changes.
+5. Keep the entitlement's default rollover, overage, and expiry rules or customize them for this product.
+
+The customer receives a fresh grant each billing cycle.
+
+### One-time product or add-on
+
+Attach the credit entitlement to a single-payment product or add-on and configure the one-time amount. The purchase issues one grant. This is the supported shape for prepaid packs, top-ups, and promotional bundles.
+
+### Usage-based product
+
+Attach the credit entitlement to the same usage-based product as the meter. The confirmed meter attachment fields are:
+
+| Field | Purpose |
+|---|---|
+| `meter_id` | Meter to aggregate usage. |
+| `free_threshold` | Optional usage excluded before rating. |
+| `credit_entitlement_id` | Credit pool consumed by this meter. |
+| `meter_units_per_credit` | Usage units required to deduct one credit; required when `credit_entitlement_id` is set. |
+| `price_per_unit` | Direct per-unit monetary price when using pure usage pricing; decimal string. |
+
+Product attachment request shapes can evolve. Configure them in the dashboard or copy the current schema from the [Create Product API](https://docs.dodopayments.com/api-reference/products/post-products); do not invent an `entitlements`, `credits`, or `grants` payload.
+
+### Start checkout for an attached product
+
+Product purchase creates the customer grant; checkout does not accept an ad hoc credit amount.
 
 ```typescript
 const session = await client.checkoutSessions.create({
   product_cart: [
     {
-      product_id: 'prod_ai_pro_plan', // Product with credits attached
+      product_id: 'pdt_ai_pro_plan',
       quantity: 1,
-    }
+    },
   ],
   customer: { email: 'customer@example.com' },
-  return_url: 'https://yourapp.com/success',
+  return_url: 'https://app.example.com/billing/success',
 });
 
-// Redirect to session.checkout_url
+console.log(session);
 ```
 
-### 4. Deduct Credits via Usage Events
+Use `checkoutSessions.create`, not the deprecated `payments.create` or `subscriptions.create` methods.
+
+## Discover a customer's credit entitlements
+
+Use the customer resource when the application needs to discover all credit entitlements associated with a customer:
 
 ```typescript
-// Meter linked to credit entitlement deducts automatically
-await client.usageEvents.ingest({
-  events: [{
-    event_id: `gen_${Date.now()}_${crypto.randomUUID()}`,
-    customer_id: 'cus_abc123',
-    event_name: 'ai.generation',
-    timestamp: new Date().toISOString(),
-    metadata: { model: 'gpt-4', tokens: '1500' }
-  }]
-});
-```
-
-### 5. Check Balance
-
-```typescript
-const balance = await client.creditEntitlements.balances.get(
-  'cent_credit_id',
-  'cus_abc123'
+const customerCredits = await client.customers.listCreditEntitlements(
+  'cus_TV52uJWWXt2yIoBBxpjaa',
 );
 
-console.log(`Available: ${balance.available_balance}`);
-console.log(`Overage: ${balance.overage_balance}`);
+console.log(customerCredits);
 ```
 
----
+Use the balance resource below when the credit entitlement ID is already known and an exact balance is required.
 
-## API Reference
+## Read a customer's balance
 
-### Credit Entitlement CRUD
+The confirmed method takes the customer ID first and the credit entitlement ID inside the options object:
 
-| Operation | Method | Endpoint |
-|-----------|--------|----------|
-| Create | `POST` | `/credit-entitlements` |
-| List | `GET` | `/credit-entitlements` |
-| Get | `GET` | `/credit-entitlements/{id}` |
-| Update | `PATCH` | `/credit-entitlements/{id}` |
-| Delete | `DELETE` | `/credit-entitlements/{id}` |
-| Undelete | `POST` | `/credit-entitlements/{id}/undelete` |
+```typescript
+const customerCreditBalance = await client.creditEntitlements.balances.retrieve(
+  'cus_TV52uJWWXt2yIoBBxpjaa',
+  { credit_entitlement_id: 'cde_ztxm5XJsKxWucRWA3rjdM' },
+);
 
-### Balance & Ledger Operations
+console.log({
+  balance: customerCreditBalance.balance,
+  overage: customerCreditBalance.overage,
+  lastTransactionAt: customerCreditBalance.last_transaction_at,
+});
+```
 
-| Operation | Method | Endpoint |
-|-----------|--------|----------|
-| List All Balances | `GET` | `/credit-entitlements/{id}/balances` |
-| Get Customer Balance | `GET` | `/credit-entitlements/{id}/balances/{customer_id}` |
-| Create Ledger Entry | `POST` | `/credit-entitlements/{id}/balances/{customer_id}/ledger-entries` |
-| List Customer Ledger | `GET` | `/credit-entitlements/{id}/balances/{customer_id}/ledger` |
-| List Customer Grants | `GET` | `/credit-entitlements/{id}/balances/{customer_id}/grants` |
+`balance` and `overage` are decimal strings in the entitlement's credit unit. They are not currency amounts unless the entitlement itself represents fiat value.
 
----
+## Grant credits manually
 
-## Implementation Examples
+Manual credits are appropriate for promotions, migrations, refunds implemented as credit, and support gestures. Use a stable idempotency key derived from the business operation so a retry cannot grant twice.
 
-### TypeScript/Node.js
+```typescript
+async function grantSupportCredits(
+  customerId: string,
+  creditEntitlementId: string,
+  supportCaseId: string,
+): Promise<string> {
+  const entry = await client.creditEntitlements.balances.createLedgerEntry(
+    customerId,
+    {
+      credit_entitlement_id: creditEntitlementId,
+      amount: '500',
+      entry_type: 'credit',
+      expires_at: '2027-01-31T23:59:59Z',
+      idempotency_key: `support-credit:${supportCaseId}`,
+      reason: `Support gesture for case ${supportCaseId}`,
+      metadata: { support_case_id: supportCaseId },
+    },
+  );
 
-#### Create Credit Entitlement
+  return entry.id;
+}
+```
+
+`amount` is a decimal string backed by `NUMERIC(38,28)`; its integer part must be below `10^10`. `expires_at` applies to credits. Keep the amount within the entitlement's configured precision.
+
+If the same `idempotency_key` already exists, the API can return `409`. Treat that as a signal to reconcile the original operation, not as permission to generate a new key and retry the grant.
+
+## Deduct credits manually
+
+Use the same method with `entry_type: 'debit'`. Debits consume the oldest grants first (FIFO) and can return `400` when the balance is insufficient.
+
+```typescript
+async function deductJobCredits(
+  customerId: string,
+  creditEntitlementId: string,
+  jobId: string,
+  amount: string,
+): Promise<{ balanceAfter: string; overageAfter: string }> {
+  const entry = await client.creditEntitlements.balances.createLedgerEntry(
+    customerId,
+    {
+      credit_entitlement_id: creditEntitlementId,
+      amount,
+      entry_type: 'debit',
+      idempotency_key: `job-debit:${jobId}`,
+      reason: `Credit deduction for job ${jobId}`,
+      metadata: { job_id: jobId },
+    },
+  );
+
+  return {
+    balanceAfter: entry.balance_after,
+    overageAfter: entry.overage_after,
+  };
+}
+```
+
+Do not manually debit usage that is also connected to automatic meter-to-credit deduction; that charges the same consumption twice.
+
+## Read the ledger for an audit trail
+
+The SDK returns an auto-paginating iterable:
+
+```typescript
+for await (const entry of client.creditEntitlements.balances.listLedger(
+  'cus_TV52uJWWXt2yIoBBxpjaa',
+  { credit_entitlement_id: 'cde_ztxm5XJsKxWucRWA3rjdM' },
+)) {
+  console.log({
+    id: entry.id,
+    amount: entry.amount,
+    balanceBefore: entry.balance_before,
+    balanceAfter: entry.balance_after,
+    overageBefore: entry.overage_before,
+    overageAfter: entry.overage_after,
+    createdAt: entry.created_at,
+  });
+}
+```
+
+Persist the Dodo ledger entry ID with internal order, support-case, or job IDs. Reconciliation should compare ledger entries and source references rather than overwrite history from a cached balance.
+
+## Configure automatic meter-to-credit deduction
+
+1. Attach a credit entitlement to the usage-based product.
+2. Add the meter to the same product.
+3. Enable **Bill usage in Credits** for that meter.
+4. Set `credit_entitlement_id` and `meter_units_per_credit`.
+5. Optionally set `free_threshold`; usage under it is excluded.
+6. Ingest events whose case-sensitive `event_name` matches the meter.
+
+A background worker processes new usage approximately every minute, aggregates it according to the meter, converts meter units using `meter_units_per_credit`, and consumes the oldest non-expired grants first (FIFO). Multiple meters can consume one shared credit pool at different conversion rates.
+
+This delay is material: an accepted usage event does not imply that a balance read immediately afterward includes its deduction.
+
+Use the `usage-based-billing` skill to create the meter, choose `count`, `sum`, `max`, or `last`, define its filter, and validate event batching and metadata.
+
+## End-to-end AI token example
+
+Assume the dashboard/API configuration already has:
+
+- a custom-unit entitlement named `AI Token Credits`, precision `0`;
+- a subscription product that issues credits each cycle;
+- a `sum` meter whose case-sensitive event name is `ai.tokens` and key is `tokens`;
+- that meter linked through `credit_entitlement_id` and `meter_units_per_credit`;
+- a one-time product `pdt_ai_token_topup` with credits attached.
+
+The following server-side script records actual model usage, reads the credit balance, and creates a top-up checkout when your verified low-balance webhook flow prompts the customer:
 
 ```typescript
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+  bearerToken: process.env['DODO_PAYMENTS_API_KEY'],
+  environment: 'test_mode',
 });
 
-// Custom unit credit (AI tokens)
-const tokenCredit = await client.creditEntitlements.create({
-  name: 'AI Tokens',
-  credit_type: 'custom_unit',
-  unit_name: 'tokens',
-  precision: 0,
-  expiry_duration: 30,
-  rollover_enabled: true,
-  max_rollover_percentage: 25,
-  rollover_timeframe: 'month',
-  max_rollover_count: 3,
-  allow_overage: true,
-  overage_limit: 50000,
-  price_per_unit: 0.001,
-  overage_behavior: 'bill_overage_at_billing',
-});
+async function recordTokenUsage(
+  customerId: string,
+  generationId: string,
+  model: string,
+  promptTokens: number,
+  completionTokens: number,
+): Promise<number> {
+  const tokens = promptTokens + completionTokens;
+  const response = await client.usageEvents.ingest({
+    events: [
+      {
+        event_id: `generation:${generationId}`,
+        customer_id: customerId,
+        event_name: 'ai.tokens',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          tokens,
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          model,
+        },
+      },
+    ],
+  });
 
-// Fiat credit (USD balance)
-const usdCredit = await client.creditEntitlements.create({
-  name: 'Platform Credits',
-  credit_type: 'fiat',
-  unit_currency: 'USD',
-  expiry_duration: 90,
-  rollover_enabled: false,
-  allow_overage: false,
-});
-```
-
-#### Manual Credit/Debit via Ledger Entry
-
-```typescript
-// Grant credits manually (e.g., promotional bonus)
-await client.creditEntitlements.balances.createLedgerEntry(
-  'cent_credit_id',
-  'cus_abc123',
-  {
-    type: 'credit',
-    amount: '500',
-    description: 'Welcome bonus - 500 free API credits',
-    idempotency_key: `welcome_bonus_${customerId}`,
-  }
-);
-
-// Debit credits manually (e.g., service compensation deduction)
-await client.creditEntitlements.balances.createLedgerEntry(
-  'cent_credit_id',
-  'cus_abc123',
-  {
-    type: 'debit',
-    amount: '100',
-    description: 'Manual deduction for premium support',
-    idempotency_key: `support_deduction_${Date.now()}`,
-  }
-);
-```
-
-#### Query Customer Balance and Ledger
-
-```typescript
-// Get current balance
-const balance = await client.creditEntitlements.balances.get(
-  'cent_credit_id',
-  'cus_abc123'
-);
-console.log(`Balance: ${balance.available_balance}`);
-
-// List all balances for a credit entitlement
-const allBalances = await client.creditEntitlements.balances.list(
-  'cent_credit_id'
-);
-
-// Get full transaction history
-const ledger = await client.creditEntitlements.balances.listLedger(
-  'cent_credit_id',
-  'cus_abc123'
-);
-
-for (const entry of ledger.items) {
-  console.log(`${entry.type}: ${entry.amount} | Balance: ${entry.balance_after}`);
+  return response.ingested_count;
 }
 
-// List credit grants
-const grants = await client.creditEntitlements.balances.listGrants(
-  'cent_credit_id',
-  'cus_abc123'
-);
-```
+async function readTokenBalance(
+  customerId: string,
+  creditEntitlementId: string,
+): Promise<string> {
+  const response = await client.creditEntitlements.balances.retrieve(
+    customerId,
+    { credit_entitlement_id: creditEntitlementId },
+  );
+  return response.balance;
+}
 
-#### Update Credit Entitlement Settings
+async function createTopUpCheckout(customerEmail: string) {
+  return client.checkoutSessions.create({
+    product_cart: [
+      { product_id: 'pdt_ai_token_topup', quantity: 1 },
+    ],
+    customer: { email: customerEmail },
+    return_url: 'https://app.example.com/credits',
+  });
+}
 
-```typescript
-await client.creditEntitlements.update('cent_credit_id', {
-  rollover_enabled: true,
-  max_rollover_percentage: 50,
-  allow_overage: true,
-  overage_limit: 10000,
-  price_per_unit: 0.002,
-  overage_behavior: 'bill_overage_at_billing',
+async function main(): Promise<void> {
+  const customerId = 'cus_8VbC6JDZzPEqfBPUdpj0K';
+  const creditEntitlementId = 'cde_ztxm5XJsKxWucRWA3rjdM';
+
+  const ingested = await recordTokenUsage(
+    customerId,
+    'gen_01JZAIEXAMPLE',
+    'example-model',
+    1800,
+    700,
+  );
+  console.log({ ingested });
+
+  // Meter deduction is asynchronous; this read may still show the prior balance.
+  const balance = await readTokenBalance(customerId, creditEntitlementId);
+  console.log({ balance });
+
+  // Call this after a verified credit.balance_low event and customer action.
+  const topUp = await createTopUpCheckout('customer@example.com');
+  console.log(topUp);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
 });
 ```
 
-### Python
+The lifecycle is:
 
-```python
-from dodopayments import DodoPayments
-import os
-import uuid
-from datetime import datetime
+1. The model returns actual prompt and completion token counts.
+2. The app ingests one uniquely identified `ai.tokens` event.
+3. The meter aggregates the `tokens` metadata value.
+4. The worker converts units into credits and deducts FIFO from non-expired grants.
+5. Dodo emits `credit.deducted`; when configured threshold conditions are met, it emits `credit.balance_low`.
+6. The app notifies the customer and offers checkout for the attached top-up product.
 
-client = DodoPayments(bearer_token=os.environ["DODO_PAYMENTS_API_KEY"])
+Do not poll every minute to synthesize your own threshold event. Use the verified webhook and keep polling only for user-interface freshness.
 
-# Create credit entitlement
-credit = client.credit_entitlements.create(
-    name="AI Tokens",
-    credit_type="custom_unit",
-    unit_name="tokens",
-    precision=0,
-    expiry_duration=30,
-    rollover_enabled=True,
-    max_rollover_percentage=25,
-    allow_overage=True,
-    overage_limit=50000,
-    price_per_unit=0.001,
-    overage_behavior="bill_overage_at_billing",
-)
+## Handle credit webhooks
 
-# Grant credits manually
-client.credit_entitlements.balances.create_ledger_entry(
-    credit_entitlement_id="cent_credit_id",
-    customer_id="cus_abc123",
-    type="credit",
-    amount="500",
-    description="Promotional bonus",
-    idempotency_key=f"promo_{uuid.uuid4()}",
-)
+Webhook signature verification, raw-body handling, retries, and event deduplication are covered in the `webhook-integration` skill. Verify with `client.webhooks.unwrap()` before dispatching any event; never trust a parsed, unverified body.
 
-# Check balance
-balance = client.credit_entitlements.balances.get(
-    credit_entitlement_id="cent_credit_id",
-    customer_id="cus_abc123",
-)
-print(f"Available: {balance.available_balance}")
+All credit events except `credit.balance_low` use the full ledger payload.
 
-# Send usage events that deduct credits
-client.usage_events.ingest(events=[{
-    "event_id": f"api_{datetime.now().timestamp()}_{uuid.uuid4()}",
-    "customer_id": "cus_abc123",
-    "event_name": "ai.tokens",
-    "timestamp": datetime.now().isoformat(),
-    "metadata": {"tokens": "1500", "model": "gpt-4"}
-}])
-```
+| Exact event | Application action |
+|---|---|
+| `credit.added` | Refresh cached balance; correlate the grant or purchase and ledger entry. |
+| `credit.deducted` | Refresh cached balance and usage display; reconcile the source usage/job. |
+| `credit.expired` | Refresh balance; notify only if your product policy promises expiry notices. |
+| `credit.rolled_over` | Refresh balance and expose the new rollover grant in account history. |
+| `credit.rollover_forfeited` | Refresh balance and explain forfeiture according to the configured rollover limit. |
+| `credit.overage_charged` | Reconcile the overage charge with billing and customer-visible history. |
+| `credit.overage_reset` | Clear cached overage state after confirming the ledger payload. |
+| `credit.manual_adjustment` | Reconcile the adjustment with its internal support/admin operation. |
+| `credit.balance_low` | Deduplicate, refresh the authoritative balance, notify the customer, and offer upgrade or top-up. |
 
-### Go
+### Low-balance payload
 
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "time"
-
-    "github.com/dodopayments/dodopayments-go"
-    "github.com/google/uuid"
-)
-
-func main() {
-    client := dodopayments.NewClient(
-        option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
-    )
-
-    ctx := context.Background()
-
-    // Create credit entitlement
-    credit, err := client.CreditEntitlements.Create(ctx, &dodopayments.CreditEntitlementCreateParams{
-        Name:       "AI Tokens",
-        CreditType: "custom_unit",
-        UnitName:   "tokens",
-        Precision:  0,
-    })
-    if err != nil {
-        panic(err)
-    }
-
-    // Get customer balance
-    balance, err := client.CreditEntitlements.Balances.Get(ctx, credit.ID, "cus_abc123")
-    if err != nil {
-        panic(err)
-    }
-    fmt.Printf("Balance: %s\n", balance.AvailableBalance)
-
-    // Send usage events
-    _, err = client.UsageEvents.Ingest(ctx, &dodopayments.UsageEventIngestParams{
-        Events: []dodopayments.UsageEvent{{
-            EventID:    fmt.Sprintf("api_%d_%s", time.Now().Unix(), uuid.New().String()),
-            CustomerID: "cus_abc123",
-            EventName:  "ai.tokens",
-            Timestamp:  time.Now().Format(time.RFC3339),
-            Metadata: map[string]string{
-                "tokens": "1500",
-                "model":  "gpt-4",
-            },
-        }},
-    })
-    if err != nil {
-        panic(err)
-    }
-}
-```
-
----
-
-## Credit Settings
-
-### Rollover
-
-Carry unused credits forward to the next billing cycle:
-
-| Setting | Description |
-|---------|-------------|
-| **Rollover Enabled** | Toggle to allow unused credits to carry forward |
-| **Max Rollover Percentage** | Limit how much carries over (0–100%) |
-| **Rollover Timeframe** | How long rolled-over credits remain valid (day, week, month, year) |
-| **Max Rollover Count** | Maximum consecutive rollovers before credits are forfeited |
-
-**Example**: 200 unused credits at cycle end, 75% rollover → 150 credits carry forward, 50 forfeited.
-
-### Overage
-
-Controls what happens when a customer's balance reaches zero mid-cycle:
-
-| Setting | Description |
-|---------|-------------|
-| **Allow Overage** | Let customers continue past zero balance |
-| **Overage Limit** | Max credits consumable beyond balance |
-| **Price Per Unit** | Cost per additional credit (with currency) |
-| **Overage Behavior** | How overage is handled at cycle end |
-
-**Overage Behaviors:**
-
-| Behavior | Description |
-|----------|-------------|
-| **Forgive overage at reset** | Overage tracked but not billed (default) |
-| **Bill overage at billing** | Overage charged on next invoice |
-| **Carry over deficit** | Negative balance carries into next cycle |
-| **Carry over deficit (auto-repay)** | Deficit auto-repaid from new credits next cycle |
-
-### Expiration
-
-| Setting | Description |
-|---------|-------------|
-| **Credit Expiry** | Duration after issuance: 7, 30, 60, 90, custom days, or never |
-| **Trial Credits Expire After Trial** | Whether trial-specific credits expire when trial ends |
-
----
-
-## Webhook Events
-
-Credit-based billing fires these webhook events:
-
-| Event | Description |
-|-------|-------------|
-| `credit.added` | Credits granted to a customer |
-| `credit.deducted` | Credits consumed through usage or manual debit |
-| `credit.expired` | Unused credits expired |
-| `credit.rolled_over` | Credits carried forward to a new grant |
-| `credit.rollover_forfeited` | Credits forfeited at max rollover count |
-| `credit.overage_charged` | Overage charges applied |
-| `credit.manual_adjustment` | Manual credit/debit adjustment made |
-| `credit.balance_low` | Balance dropped below configured threshold |
-
-### Webhook Handler Example
-
-```typescript
-// app/api/webhooks/dodo/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-
-export async function POST(req: NextRequest) {
-  const event = await req.json();
-
-  switch (event.type) {
-    case 'credit.added':
-      await handleCreditAdded(event.data);
-      break;
-    case 'credit.deducted':
-      await handleCreditDeducted(event.data);
-      break;
-    case 'credit.balance_low':
-      await handleBalanceLow(event.data);
-      break;
-    case 'credit.expired':
-      await handleCreditExpired(event.data);
-      break;
-    case 'credit.overage_charged':
-      await handleOverageCharged(event.data);
-      break;
-  }
-
-  return NextResponse.json({ received: true });
-}
-
-async function handleCreditAdded(data: any) {
-  const { customer_id, credit_entitlement_id, amount, balance_after } = data;
-  
-  // Update internal records
-  await prisma.creditBalance.upsert({
-    where: { customerId_creditId: { customerId: customer_id, creditId: credit_entitlement_id } },
-    create: { customerId: customer_id, creditId: credit_entitlement_id, balance: balance_after },
-    update: { balance: balance_after },
-  });
-}
-
-async function handleCreditDeducted(data: any) {
-  const { customer_id, credit_entitlement_id, amount, balance_after } = data;
-
-  await prisma.creditBalance.update({
-    where: { customerId_creditId: { customerId: customer_id, creditId: credit_entitlement_id } },
-    data: { balance: balance_after },
-  });
-}
-
-async function handleBalanceLow(data: any) {
-  const {
-    customer_id,
-    credit_entitlement_name,
-    available_balance,
-    threshold_percent,
-  } = data;
-
-  // Notify the customer
-  await sendEmail(customer_id, {
-    subject: `Your ${credit_entitlement_name} balance is running low`,
-    body: `You have ${available_balance} credits remaining (${threshold_percent}% threshold reached). Consider upgrading your plan or purchasing additional credits.`,
-  });
-}
-
-async function handleCreditExpired(data: any) {
-  const { customer_id, credit_entitlement_id, amount, balance_after } = data;
-
-  await prisma.creditBalance.update({
-    where: { customerId_creditId: { customerId: customer_id, creditId: credit_entitlement_id } },
-    data: { balance: balance_after },
-  });
-
-  // Optionally notify customer
-  await sendCreditExpiryNotification(customer_id, amount);
-}
-
-async function handleOverageCharged(data: any) {
-  const { customer_id, credit_entitlement_id, amount, overage_after } = data;
-
-  // Track overage for billing
-  await prisma.overageRecord.create({
-    data: {
-      customerId: customer_id,
-      creditId: credit_entitlement_id,
-      amount,
-      overageBalance: overage_after,
-    },
-  });
-}
-```
-
-### Balance Low Payload
-
-The `credit.balance_low` event has a distinct payload:
+`credit.balance_low` has a dedicated payload:
 
 ```json
 {
-  "business_id": "bus_xxxxx",
+  "business_id": "bus_H4ekzPSlcg",
   "type": "credit.balance_low",
   "timestamp": "2025-08-04T06:15:00.000000Z",
   "data": {
     "payload_type": "CreditBalanceLow",
-    "customer_id": "cus_xxxxx",
-    "subscription_id": "sub_xxxxx",
-    "credit_entitlement_id": "cent_xxxxx",
+    "customer_id": "cus_8VbC6JDZzPEqfBPUdpj0K",
+    "subscription_id": "sub_7EeHq2ewQuadropD2ra",
+    "credit_entitlement_id": "cent_9xY2bKwQn5MjRpL8d",
     "credit_entitlement_name": "API Credits",
     "available_balance": "15",
     "subscription_credits_amount": "100",
@@ -553,390 +514,102 @@ The `credit.balance_low` event has a distinct payload:
 }
 ```
 
----
+### Low-balance notification flow
 
-## Usage Billing with Credits
+1. Verify the raw webhook and deduplicate by `webhook-id` as described in `webhook-integration`.
+2. Confirm `type === 'credit.balance_low'` and validate the dedicated payload.
+3. Map `customer_id` to the authenticated application account; do not accept a customer ID supplied by a browser.
+4. Read the current balance with `balances.retrieve(...)` because another grant or deduction may have occurred since emission.
+5. If the balance is still below your customer-notification policy, enqueue one notification keyed by webhook ID or threshold occurrence.
+6. Link to a one-time top-up checkout or plan-upgrade flow.
+7. Record notification delivery separately from the Dodo ledger; never manufacture a ledger entry for an email.
 
-When credits are linked to usage meters, meter events automatically deduct credits. A background worker processes events every minute, converts meter units to credits using your configured rate, and deducts using FIFO ordering (oldest grants first).
+## Enforce credits safely
 
-### How It Works
+### Best-effort balance gate
 
-1. **Your app sends usage events** — Each event includes customer ID, event name, and metadata
-2. **Meters aggregate events** — Using Count, Sum, Max, Last, or Unique Count
-3. **Credits are deducted automatically** — Converted at your configured `meter_units_per_credit` rate
-4. **Overage is tracked** — If balance reaches zero and overage is enabled, usage continues
-
-### Meter-Credit Configuration
-
-In Dashboard → Products → Usage-Based Product → Select Meter:
-1. Toggle **Bill usage in Credits**
-2. Select the credit entitlement
-3. Set **Meter units per credit** (e.g., 1000 API calls = 1 credit)
-4. Set **Free Threshold** (units free before credit deduction begins)
-
-### AI Token Billing Example
+For a precision-`0` entitlement, a server can perform a coarse pre-check with integer-safe parsing:
 
 ```typescript
-import DodoPayments from 'dodopayments';
-
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
-});
-
-// Track AI token usage — meter auto-deducts credits
-async function trackAIUsage(
+async function hasAtLeastWholeCredits(
   customerId: string,
-  promptTokens: number,
-  completionTokens: number,
-  model: string
-) {
-  const totalTokens = promptTokens + completionTokens;
-
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `ai_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: 'ai.tokens',
-      timestamp: new Date().toISOString(),
-      metadata: {
-        tokens: totalTokens.toString(),
-        prompt_tokens: promptTokens.toString(),
-        completion_tokens: completionTokens.toString(),
-        model,
-      }
-    }]
-  });
-}
-
-// After AI completion
-await trackAIUsage('cus_abc123', 500, 1200, 'gpt-4');
-```
-
-### API Rate Tracking Example
-
-```typescript
-// Middleware to track and deduct API credits
-async function trackAPICredit(customerId: string, req: Request) {
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: 'api.call',
-      timestamp: new Date().toISOString(),
-      metadata: {
-        endpoint: new URL(req.url).pathname,
-        method: req.method,
-      }
-    }]
-  });
-}
-```
-
----
-
-## Next.js Integration
-
-### Credit Balance API Route
-
-```typescript
-// app/api/credits/balance/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
-
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
-});
-
-export async function GET(req: NextRequest) {
-  const customerId = req.nextUrl.searchParams.get('customer_id');
-  const creditId = req.nextUrl.searchParams.get('credit_id');
-
-  if (!customerId || !creditId) {
-    return NextResponse.json({ error: 'Missing parameters' }, { status: 400 });
-  }
-
-  try {
-    const balance = await client.creditEntitlements.balances.get(creditId, customerId);
-
-    return NextResponse.json({
-      available: balance.available_balance,
-      overage: balance.overage_balance,
-    });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-}
-```
-
-### Manual Credit Grant API Route
-
-```typescript
-// app/api/credits/grant/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
-
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
-});
-
-export async function POST(req: NextRequest) {
-  const { customerId, creditId, amount, description } = await req.json();
-
-  try {
-    const entry = await client.creditEntitlements.balances.createLedgerEntry(
-      creditId,
-      customerId,
-      {
-        type: 'credit',
-        amount: amount.toString(),
-        description,
-        idempotency_key: `grant_${customerId}_${Date.now()}`,
-      }
-    );
-
-    return NextResponse.json({ success: true, balance_after: entry.balance_after });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-}
-```
-
-### Credit Balance Hook
-
-```typescript
-// hooks/useCreditBalance.ts
-import useSWR from 'swr';
-
-const fetcher = (url: string) => fetch(url).then(r => r.json());
-
-export function useCreditBalance(customerId: string, creditId: string) {
-  const { data, error, mutate } = useSWR(
-    `/api/credits/balance?customer_id=${customerId}&credit_id=${creditId}`,
-    fetcher,
-    { refreshInterval: 30000 } // Refresh every 30s
-  );
-
-  return {
-    available: data?.available,
-    overage: data?.overage,
-    isLoading: !error && !data,
-    isError: error,
-    refresh: mutate,
-  };
-}
-
-// Usage in component
-function CreditDisplay() {
-  const { available, isLoading } = useCreditBalance('cus_abc123', 'cent_xxxxx');
-
-  if (isLoading) return <div>Loading...</div>;
-
-  return (
-    <div>
-      <h3>Credits Remaining</h3>
-      <p className="text-3xl font-bold">{available}</p>
-    </div>
-  );
-}
-```
-
----
-
-## Common Patterns
-
-### Credit Top-Up (One-Time Purchase)
-
-Sell credit packs as one-time products:
-
-```typescript
-// Product: "500 API Credit Pack" with 500 credits attached
-const session = await client.checkoutSessions.create({
-  product_cart: [
-    { product_id: 'prod_credit_pack_500', quantity: 1 }
-  ],
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yourapp.com/credits/success',
-});
-```
-
-### Subscription with Credits + Overage
-
-```typescript
-// Product: Pro Plan - $49/month, 10,000 tokens included, $0.002/token overage
-// Credits attached in dashboard with:
-//   - Credits per cycle: 10000
-//   - Allow overage: true
-//   - Price per unit: $0.002
-//   - Overage behavior: Bill overage at billing
-
-const session = await client.checkoutSessions.create({
-  product_cart: [
-    { product_id: 'prod_pro_with_credits', quantity: 1 }
-  ],
-  subscription_data: { trial_period_days: 14 },
-  customer: { email: 'customer@example.com' },
-  return_url: 'https://yourapp.com/success',
-});
-```
-
-### Access Control Based on Credits
-
-```typescript
-// Middleware to check credit balance before allowing API access
-async function requireCredits(customerId: string, creditId: string): Promise<boolean> {
-  try {
-    const balance = await client.creditEntitlements.balances.get(creditId, customerId);
-    const available = parseFloat(balance.available_balance);
-    return available > 0;
-  } catch {
-    return false;
-  }
-}
-
-// Express middleware
-async function creditGate(req: Request, res: Response, next: Function) {
-  const customerId = req.headers['x-customer-id'] as string;
-  const hasCredits = await requireCredits(customerId, 'cent_api_credits');
-
-  if (!hasCredits) {
-    return res.status(402).json({
-      error: 'Insufficient credits',
-      message: 'Your credit balance is exhausted. Please upgrade your plan or purchase more credits.',
-    });
-  }
-
-  next();
-}
-```
-
-### Promotional Credit Grants
-
-```typescript
-// Grant promotional credits with idempotency
-async function grantPromoCredits(
-  customerId: string,
-  creditId: string,
-  amount: number,
-  promoCode: string
-) {
-  await client.creditEntitlements.balances.createLedgerEntry(
-    creditId,
+  creditEntitlementId: string,
+  required: bigint,
+): Promise<boolean> {
+  const response = await client.creditEntitlements.balances.retrieve(
     customerId,
-    {
-      type: 'credit',
-      amount: amount.toString(),
-      description: `Promotional credit: ${promoCode}`,
-      idempotency_key: `promo_${promoCode}_${customerId}`, // Prevents double-granting
-    }
+    { credit_entitlement_id: creditEntitlementId },
   );
+
+  return BigInt(response.balance) >= required;
 }
 ```
 
----
+Use this only for precision `0`. For fractional credits, use an arbitrary-precision decimal implementation that preserves the entitlement's configured precision.
 
-## Real-World Pricing Examples
+This read is not a reservation. Two concurrent requests can both observe enough balance, and automatic meter deductions may not yet be reflected.
 
-### AI SaaS Platform
+### Strict request enforcement
 
-```
-Plan      | Price    | Credits/Month  | Overage
-----------|----------|----------------|----------
-Starter   | $29/mo   | 10,000 tokens  | $0.003/token
-Pro       | $99/mo   | 100,000 tokens | $0.002/token
-Enterprise| $499/mo  | 1,000,000 tokens| $0.001/token
+Choose one of these patterns:
 
-Credit Config:
-  Type: Custom Unit ("AI Tokens"), Precision: 0
-  Rollover: 25% max, 1-month timeframe
-  Overage: Bill overage at billing
-  Meter: ai.generation (Sum on tokens)
-```
+- **Predictable fixed cost:** create an idempotent manual debit before serving. Treat an insufficient-balance `400` as denial. If work fails after debit, issue a separately idempotent compensating credit with a linked reason. Do not also meter the same usage.
+- **Variable cost such as AI tokens:** reserve estimated capacity atomically in your own datastore, enforce per-customer concurrency, ingest actual usage afterward, and reconcile local reservations with Dodo webhooks and ledger entries.
+- **Overage product:** authorize against the product's overage policy and your own risk limit, not merely `balance > 0`.
 
-### API Gateway
+Return an application-level payment/credit-required response with a top-up or upgrade path when authorization fails. Do not expose Dodo API errors or secrets to the client.
 
-```
-Plan      | Price    | Credits/Month  | Overage
-----------|----------|----------------|----------
-Free      | $0/mo    | 1,000 calls    | Blocked
-Developer | $19/mo   | 50,000 calls   | $0.001/call
-Business  | $99/mo   | 500,000 calls  | $0.0005/call
+### Race conditions to avoid
 
-Credit Config:
-  Type: Custom Unit ("API Calls"), Precision: 0
-  Rollover: Disabled
-  Overage: Free=disabled, Dev+=forgive at reset
-  Meter: api.request (Count)
-```
+- **Check then act:** a remote balance read followed by work is not atomic.
+- **Immediate post-event read:** the meter worker may not have processed the event.
+- **Parallel workers:** multiple jobs can consume the same apparent balance without a local reservation or atomic debit.
+- **Retry with new IDs:** changing `event_id` or `idempotency_key` after a timeout can duplicate usage or adjustments.
+- **Cache as authority:** webhook-maintained balances are useful for display, not strict authorization.
+- **Mixed deduction paths:** automatic meter deduction plus manual debit double-counts consumption.
 
-### Cloud Storage
+## Common mistakes
 
-```
-Plan      | Price    | Credits/Month  | Overage
-----------|----------|----------------|----------
-Personal  | $9/mo    | 100 GB-hours   | $0.05/GB-hour
-Team      | $49/mo   | 1,000 GB-hours | $0.03/GB-hour
-
-Credit Config:
-  Type: Custom Unit ("GB-hours"), Precision: 2
-  Rollover: 50% max, carries over once
-  Overage: Enabled with 200% limit
-  Meter: storage.usage (Sum)
-```
-
----
-
-## Credit Ledger
-
-Every credit operation is recorded with full audit trail:
-
-| Transaction Type | Description |
-|-----------------|-------------|
-| **Credit Added** | Credits granted (subscription, one-time, or API) |
-| **Credit Deducted** | Credits consumed through usage or manual debit |
-| **Credit Expired** | Credits expired without rollover |
-| **Credit Rolled Over** | Credits carried forward to the next period |
-| **Rollover Forfeited** | Rolled credits forfeited after max count reached |
-| **Overage Charged** | Usage beyond credit balance with overage enabled |
-| **Auto Top-Up** | Automatic credit replenishment at low balance |
-| **Manual Adjustment** | Credit or debit applied manually by merchant |
-| **Refund** | Credits refunded |
-
-Each ledger entry records balance before/after, overage before/after, description, and reference to the source.
-
----
-
-## Best Practices
-
-### 1. Start Simple
-Begin with a single credit type and no rollover. Add complexity based on customer usage patterns.
-
-### 2. Use Meaningful Units
-Name credits after what they represent ("API Calls", "AI Tokens") not generic terms.
-
-### 3. Set Low Balance Thresholds
-Configure thresholds and subscribe to `credit.balance_low` to alert customers before they run out.
-
-### 4. Use Idempotency Keys
-Always include idempotency keys for manual ledger entries to prevent double-granting:
-```typescript
-idempotency_key: `promo_${promoCode}_${customerId}`
-```
-
-### 5. Configure Expiry Thoughtfully
-Short expiry (7 days) drives urgency but may frustrate. 30–90 days is customer-friendly for most SaaS.
-
-### 6. Test the Full Cycle
-In test mode: create credits → attach to product → purchase → send usage events → verify deduction → test expiration and rollover.
-
-### 7. Monitor Overage
-If using "Bill overage at billing", monitor overage amounts to avoid unexpected charges for customers.
-
----
+1. **Confusing two resources.** `creditEntitlements` and `entitlements` are different. Credit balances do not live under `client.entitlements.grants`.
+2. **Calling invented balance methods.** Use `balances.retrieve(customerId, { credit_entitlement_id })`, not `balances.get(creditId, customerId)`.
+3. **Using the wrong ledger argument order.** `createLedgerEntry` receives `customerId` first; `credit_entitlement_id` belongs in the request object.
+4. **Using `type` or `description` for adjustments.** Confirmed fields are `entry_type` and `reason`.
+5. **Calling an unverified grants method.** No `creditEntitlements.balances.listGrants(...)` call is established here. Use the balance/ledger APIs or `customers.listCreditEntitlements(customerID)` for the confirmed customer-level read.
+6. **Treating `available_balance` as the balance API field.** The confirmed balance response uses `balance` and `overage`; `available_balance` belongs to the dedicated low-balance webhook payload.
+7. **Choosing precision casually.** It supports `0–10` for custom units and cannot be changed after creation.
+8. **Using JavaScript floating point for credits.** API amounts are decimal strings. Preserve them as strings or use decimal arithmetic.
+9. **Exceeding adjustment bounds.** Ledger amounts map to `NUMERIC(38,28)`, and the integer part must be below `10^10`.
+10. **Misstating monetary units.** Currency amounts use the smallest currency unit. Do not label cents as dollars.
+11. **Using unstable idempotency keys.** A timestamp or random key on every retry defeats deduplication. Derive the key from the immutable business operation.
+12. **Retrying an insufficient debit blindly.** Manual debits can return `400` for insufficient balance; route the customer to top-up or your overage policy.
+13. **Assuming event ingestion is synchronous deduction.** Meter-to-credit processing occurs approximately every minute.
+14. **Using Dodo's balance as a per-request lock.** The docs explicitly warn against strict authorization from asynchronously reported meter balances.
+15. **Mismatching meter names.** Usage `event_name` matching is case-sensitive.
+16. **Sending duplicate IDs within one batch.** Duplicate `event_id` values in the same ingestion request reject the entire request. Previously ingested IDs are ignored on retry.
+17. **Inventing a deduplication window.** Current docs require unique event IDs but do not publish a retention duration.
+18. **Getting conversion backward.** `meter_units_per_credit` is usage units required for one credit, and is required when `credit_entitlement_id` is set.
+19. **Ignoring the free threshold.** Usage under `free_threshold` is excluded before credit deduction.
+20. **Supplying one rollover timeframe field.** `rollover_timeframe_count` and `rollover_timeframe_interval` must be supplied together.
+21. **Using the wrong rollover enum case.** Confirmed values are `Day`, `Week`, `Month`, and `Year`.
+22. **Assuming expiry happens before rollover.** Rollover is applied first; only the remainder expires.
+23. **Inventing overage enum values.** Use only `forgive_at_reset`, `invoice_at_billing`, `carry_deficit`, or `carry_deficit_auto_repay`.
+24. **Omitting overage pricing dependencies.** Enabled overage requires `price_per_unit`; a price requires `currency`.
+25. **Attaching too many credits.** The current product limit is five credit entitlements.
+26. **Assuming checkout grants arbitrary credits.** Credits must already be attached to the purchased product or add-on.
+27. **Handling only the common webhooks.** Include `credit.overage_reset` and `credit.rollover_forfeited`, not only added, deducted, and low-balance events.
+28. **Parsing an unverified webhook.** Verify the raw body with `client.webhooks.unwrap()` as covered in `webhook-integration`; never hand-roll HMAC or trust re-serialized JSON.
+29. **Inventing historical snapshot APIs.** Use ledger `balance_before` and `balance_after` for transaction-level history.
+30. **Using deprecated purchase methods.** New checkout flows use `client.checkoutSessions.create(...)`, not `payments.create(...)` or `subscriptions.create(...)`.
+31. **Using the wrong host or key format.** Valid hosts are `https://test.dodopayments.com` and `https://live.dodopayments.com`; keys start with `dodo_test_` or `dodo_live_`.
 
 ## Resources
 
 - [Credit-Based Billing Guide](https://docs.dodopayments.com/features/credit-based-billing)
-- [Credit Entitlements API](https://docs.dodopayments.com/api-reference/credit-entitlements/create-credit-entitlement)
-- [Credit Webhook Events](https://docs.dodopayments.com/developer-resources/webhooks/intents/credit)
-- [Usage-Based Billing](https://docs.dodopayments.com/features/usage-based-billing/introduction)
-- [Subscription Integration](https://docs.dodopayments.com/developer-resources/subscription-integration-guide)
+- [Create Credit Entitlement API](https://docs.dodopayments.com/api-reference/credit-entitlements/create-credit-entitlement)
+- [Get Customer Balance API](https://docs.dodopayments.com/api-reference/credit-entitlements/get-customer-balance)
+- [Create Ledger Entry API](https://docs.dodopayments.com/api-reference/credit-entitlements/create-ledger-entry)
+- [List Customer Ledger API](https://docs.dodopayments.com/api-reference/credit-entitlements/list-customer-ledger)
+- [Credit Webhook Reference](https://docs.dodopayments.com/developer-resources/webhooks/intents/credit)
+- [Meter Guide](https://docs.dodopayments.com/features/usage-based-billing/meters)
+- [Usage Event Ingestion API](https://docs.dodopayments.com/api-reference/usage-events/ingest-events)
+- [Create Product API](https://docs.dodopayments.com/api-reference/products/post-products)

--- a/dodo-payments/customer-management/SKILL.md
+++ b/dodo-payments/customer-management/SKILL.md
@@ -49,11 +49,11 @@ const customer = await client.customers.create({
     tier: 'premium',
   },
 });
-console.log(customer.id); // cus_...
+console.log(customer.customer_id); // cus_...
 
 // List customers
 const customers = await client.customers.list({
-  limit: 10,
+  page_size: 10,
 });
 
 // Retrieve a customer
@@ -95,7 +95,10 @@ List and delete payment methods saved to a customer.
 ```typescript
 // List payment methods for a customer
 const methods = await client.customers.retrievePaymentMethods('cus_abc123');
-console.log(methods); // array of payment method objects
+console.log(methods);
+// {
+//   items: [{ payment_method_id: 'pm_xyz789', payment_method: 'card' }]
+// }
 
 // Delete a payment method
 await client.customers.deletePaymentMethod('pm_xyz789', {
@@ -113,14 +116,17 @@ Wallets hold real-money balances (USD, INR) that customers can spend on future p
 // List wallets for a customer
 const wallets = await client.customers.wallets.list('cus_abc123');
 console.log(wallets);
-// [
-//   { currency: 'USD', balance: 5000 },  // $50.00
-//   { currency: 'INR', balance: 100000 } // ₹1000.00
-// ]
+// {
+//   items: [
+//     { currency: 'USD', balance: 5000, customer_id: 'cus_abc123', ... },
+//     { currency: 'INR', balance: 100000, customer_id: 'cus_abc123', ... }
+//   ],
+//   total_balance_usd: 17000
+// }
 
 // List ledger entries
 const entries = await client.customers.wallets.ledgerEntries.list('cus_abc123', {
-  limit: 20,
+  page_size: 20,
 });
 
 // Create a ledger entry (credit or debit)
@@ -146,26 +152,46 @@ Entitlements are feature or file grants. There are three methods:
 // List credit entitlements (credit balances)
 const credits = await client.customers.listCreditEntitlements('cus_abc123');
 console.log(credits);
-// [
-//   { id: 'ent_credit_1', balance: 5000, currency: 'USD' }
-// ]
+// {
+//   items: [{
+//     credit_entitlement_id: 'cred_ent_1',
+//     balance: '5000',
+//     name: 'API Calls',
+//     overage: '0',
+//     unit: 'calls'
+//   }]
+// }
 
 // List feature/file entitlements
 const features = await client.customers.listEntitlements('cus_abc123');
 console.log(features);
-// [
-//   { id: 'ent_feature_1', name: 'Pro Features', type: 'feature' },
-//   { id: 'ent_file_1', name: 'Pro Bundle', type: 'file' }
-// ]
+// {
+//   items: [
+//     {
+//       grant_id: 'entg_feature_1',
+//       entitlement_id: 'ent_feature_1',
+//       entitlement_name: 'Pro Features',
+//       integration_type: 'feature_flag',
+//       status: 'delivered',
+//       created_at: '2026-01-01T00:00:00Z',
+//       updated_at: '2026-01-01T00:00:00Z'
+//     }
+//   ]
+// }
 
 // List individual grants (with revocation status)
 const grants = await client.customers.listEntitlementGrants('cus_abc123', {
   page_size: 50,
 });
 console.log(grants);
-// [
-//   { id: 'grant_1', entitlement_id: 'ent_feature_1', revoked: false }
-// ]
+// {
+//   items: [{
+//     id: 'entg_feature_1',
+//     entitlement_id: 'ent_feature_1',
+//     status: 'Delivered',
+//     revoked_at: null
+//   }]
+// }
 ```
 
 ## Linking Your App's Users to Dodo Customers
@@ -178,7 +204,7 @@ const customer = await client.customers.create({
   email: user.email,
   name: user.name,
 });
-await db.users.update(user.id, { dodo_customer_id: customer.id });
+await db.users.update(user.id, { dodo_customer_id: customer.customer_id });
 
 // Option 2: Use metadata to store your user ID
 const customer = await client.customers.create({
@@ -191,8 +217,8 @@ const customer = await client.customers.create({
 
 // Later, retrieve by email (not a direct API call, but common pattern)
 // You must store the mapping yourself or query Dodo's list endpoint
-const customers = await client.customers.list({ limit: 100 });
-const found = customers.find(c => c.email === user.email);
+const customers = await client.customers.list({ page_size: 100 });
+const found = customers.items.find(c => c.email === user.email);
 ```
 
 **Email matching pitfall:** if a user changes their email in your app, the Dodo customer email won't update automatically. Always sync email changes explicitly via `client.customers.update()`.
@@ -215,7 +241,7 @@ const customer = await client.customers.create({
 });
 const session = await client.checkoutSessions.create({
   product_cart: [...],
-  customer_id: customer.id, // Reuse the customer
+  customer: { customer_id: customer.customer_id }, // Reuse the customer
 });
 ```
 

--- a/dodo-payments/customer-management/SKILL.md
+++ b/dodo-payments/customer-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-management
-description: Guide for managing customers, self-service portals, payment methods, and customer wallets with Dodo Payments
+description: Guide for managing customer records, saved payment methods, monetary wallets, and hosted customer-portal sessions; subscription lifecycle and custom billing UI are covered separately.
 ---
 
 # Customer Management
@@ -160,7 +160,7 @@ console.log(features);
 
 // List individual grants (with revocation status)
 const grants = await client.customers.listEntitlementGrants('cus_abc123', {
-  limit: 50,
+  page_size: 50,
 });
 console.log(grants);
 // [

--- a/dodo-payments/customer-management/SKILL.md
+++ b/dodo-payments/customer-management/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: customer-management
+description: Guide for managing customers, self-service portals, payment methods, and customer wallets with Dodo Payments
+---
+
+# Customer Management
+
+Build customer records, hosted self-service portals, saved payment methods, and real-money wallet ledgers. This skill covers the full customer lifecycle: CRUD operations, payment method management, time-bound portal sessions, and idempotent wallet transactions.
+
+## When to use this skill
+
+- Creating, listing, retrieving, or updating customer records
+- Building a self-service customer portal for invoices, subscriptions, and payment methods
+- Managing saved payment methods and customer payment history
+- Implementing customer wallet balances and ledger entries for credits or refunds
+- Linking your app's user records to Dodo customers
+- Reading customer entitlements and credit balances
+
+## Core concepts
+
+**Customers** are records in Dodo that group payments, subscriptions, and portal access. Each customer has an ID (prefix `cus_`), email, name, and optional metadata.
+
+**Customer Portal** is a hosted, time-bound session that lets customers self-serve: view invoices, cancel subscriptions, change plans, update payment methods, recover on-hold subscriptions, and download license keys. You create a session and redirect to its link.
+
+**Payment Methods** are saved cards or other payment instruments linked to a customer. You can list and delete them; creation happens during checkout.
+
+**Customer Wallets** hold real-money balances (USD, INR) that customers can spend on future purchases. They are NOT the same as usage credits (see `credit-based-billing` skill). Wallet ledger entries are idempotent via `idempotency_key` to prevent duplicate charges.
+
+**Entitlements** are feature or file grants. `listCreditEntitlements` returns credit balances; `listEntitlements` returns feature/file grants; `listEntitlementGrants` lists individual grants with revocation status.
+
+## Customer CRUD
+
+Create, list, retrieve, and update customer records.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// Create a customer
+const customer = await client.customers.create({
+  email: 'alice@example.com',
+  name: 'Alice Chen',
+  metadata: {
+    userId: 'user_12345',
+    tier: 'premium',
+  },
+});
+console.log(customer.id); // cus_...
+
+// List customers
+const customers = await client.customers.list({
+  limit: 10,
+});
+
+// Retrieve a customer
+const retrieved = await client.customers.retrieve('cus_abc123');
+
+// Update a customer
+await client.customers.update('cus_abc123', {
+  name: 'Alice Chen-Smith',
+  metadata: { tier: 'enterprise' },
+});
+```
+
+## Customer Portal
+
+Create a time-bound session that redirects customers to a hosted portal. The portal is read-only for most actions; customers can view invoices, cancel subscriptions, change plans, update payment methods, recover on-hold subscriptions, and download license keys.
+
+```typescript
+// Create a portal session
+const session = await client.customers.customerPortal.create('cus_abc123', {
+  return_url: 'https://yourapp.com/dashboard',
+});
+
+// Redirect the customer
+window.location.href = session.link;
+```
+
+The portal session link expires after a short time. Customers cannot:
+- Create new subscriptions (use checkout for that)
+- Refund themselves
+- Change their email or name (contact support)
+- Access billing history beyond invoices
+
+If you need to rebuild any of these, you're duplicating the portal. Use it instead.
+
+## Saved Payment Methods
+
+List and delete payment methods saved to a customer.
+
+```typescript
+// List payment methods for a customer
+const methods = await client.customers.retrievePaymentMethods('cus_abc123');
+console.log(methods); // array of payment method objects
+
+// Delete a payment method
+await client.customers.deletePaymentMethod('pm_xyz789', {
+  customer_id: 'cus_abc123',
+});
+```
+
+Payment methods are created during checkout when the customer opts to save their card. You cannot create them directly via the API.
+
+## Customer Wallets
+
+Wallets hold real-money balances (USD, INR) that customers can spend on future purchases. They are distinct from usage credits. List wallet balances and create idempotent ledger entries.
+
+```typescript
+// List wallets for a customer
+const wallets = await client.customers.wallets.list('cus_abc123');
+console.log(wallets);
+// [
+//   { currency: 'USD', balance: 5000 },  // $50.00
+//   { currency: 'INR', balance: 100000 } // ₹1000.00
+// ]
+
+// List ledger entries
+const entries = await client.customers.wallets.ledgerEntries.list('cus_abc123', {
+  limit: 20,
+});
+
+// Create a ledger entry (credit or debit)
+// Amounts are in the smallest currency unit (cents for USD, paise for INR)
+await client.customers.wallets.ledgerEntries.create('cus_abc123', {
+  amount: 1000, // $10.00 in USD
+  currency: 'USD',
+  entry_type: 'credit', // or 'debit'
+  reason: 'Refund for order #12345',
+  idempotency_key: 'refund_order_12345_v1',
+});
+```
+
+**Idempotency is critical.** If your network fails after creating a ledger entry, retrying with the same `idempotency_key` returns the existing entry instead of creating a duplicate charge. Always use a stable, unique key per transaction.
+
+Wallets are real money. Do not create entries without idempotency keys, and do not expose wallet balances to the client without verification.
+
+## Reading Customer Entitlements
+
+Entitlements are feature or file grants. There are three methods:
+
+```typescript
+// List credit entitlements (credit balances)
+const credits = await client.customers.listCreditEntitlements('cus_abc123');
+console.log(credits);
+// [
+//   { id: 'ent_credit_1', balance: 5000, currency: 'USD' }
+// ]
+
+// List feature/file entitlements
+const features = await client.customers.listEntitlements('cus_abc123');
+console.log(features);
+// [
+//   { id: 'ent_feature_1', name: 'Pro Features', type: 'feature' },
+//   { id: 'ent_file_1', name: 'Pro Bundle', type: 'file' }
+// ]
+
+// List individual grants (with revocation status)
+const grants = await client.customers.listEntitlementGrants('cus_abc123', {
+  limit: 50,
+});
+console.log(grants);
+// [
+//   { id: 'grant_1', entitlement_id: 'ent_feature_1', revoked: false }
+// ]
+```
+
+## Linking Your App's Users to Dodo Customers
+
+Store the Dodo customer ID in your user record, or use metadata to link them.
+
+```typescript
+// Option 1: Store the Dodo customer ID in your database
+const customer = await client.customers.create({
+  email: user.email,
+  name: user.name,
+});
+await db.users.update(user.id, { dodo_customer_id: customer.id });
+
+// Option 2: Use metadata to store your user ID
+const customer = await client.customers.create({
+  email: user.email,
+  name: user.name,
+  metadata: {
+    app_user_id: user.id,
+  },
+});
+
+// Later, retrieve by email (not a direct API call, but common pattern)
+// You must store the mapping yourself or query Dodo's list endpoint
+const customers = await client.customers.list({ limit: 100 });
+const found = customers.find(c => c.email === user.email);
+```
+
+**Email matching pitfall:** if a user changes their email in your app, the Dodo customer email won't update automatically. Always sync email changes explicitly via `client.customers.update()`.
+
+## Common mistakes
+
+**Creating duplicate customers per checkout.** Each checkout should reuse an existing `customer_id` or create the customer once. Creating a new customer for every transaction fragments your customer data.
+
+```typescript
+// WRONG
+const session = await client.checkoutSessions.create({
+  product_cart: [...],
+  customer: { email: user.email }, // Creates a new customer each time
+});
+
+// RIGHT
+const customer = await client.customers.create({
+  email: user.email,
+  name: user.name,
+});
+const session = await client.checkoutSessions.create({
+  product_cart: [...],
+  customer_id: customer.id, // Reuse the customer
+});
+```
+
+**Building a bespoke billing UI instead of using the portal.** The portal handles invoices, cancellations, plan changes, payment method updates, and on-hold recovery. If you rebuild these, you're duplicating work and missing edge cases.
+
+**Mutating wallet balances without an idempotency key.** Retries will create duplicate entries and charge the customer twice.
+
+```typescript
+// WRONG
+await client.customers.wallets.ledgerEntries.create('cus_abc123', {
+  amount: 1000,
+  currency: 'USD',
+  entry_type: 'credit',
+  reason: 'Refund',
+  // No idempotency_key
+});
+
+// RIGHT
+await client.customers.wallets.ledgerEntries.create('cus_abc123', {
+  amount: 1000,
+  currency: 'USD',
+  entry_type: 'credit',
+  reason: 'Refund',
+  idempotency_key: 'refund_order_12345_v1',
+});
+```
+
+**Exposing portal links publicly.** Portal sessions are time-bound and tied to a customer ID. Don't log them or share them in URLs; generate them server-side and redirect immediately.
+
+**Confusing wallets with credits.** Wallets hold real money (USD, INR). Credits are usage-based entitlements. See the `credit-based-billing` skill for credit management.
+
+## Resources
+
+- [Customer Management](https://docs.dodopayments.com/features/customers)
+- [Customer Portal](https://docs.dodopayments.com/features/customer-portal)
+- [Customer Wallets](https://docs.dodopayments.com/features/customer-wallet)
+- [Customers API Reference](https://docs.dodopayments.com/api-reference/customers)

--- a/dodo-payments/discounts-and-promotions/SKILL.md
+++ b/dodo-payments/discounts-and-promotions/SKILL.md
@@ -53,11 +53,15 @@ const percentageDiscount = await client.discounts.create({
   }
 });
 
-// Flat discount: $10 off (1000 cents)
+// Flat discount: $10 off (1000 cents in currency_options)
 const flatDiscount = await client.discounts.create({
   type: 'flat',
   amount: 1000,
-  currency: 'USD',
+  currency_options: [{
+    currency: 'USD',
+    max_amount_possible: 1000,
+    is_default: true,
+  }],
   code: 'WELCOME10',
 });
 ```
@@ -91,10 +95,10 @@ console.log(discount.code, discount.type, discount.amount);
 ### Retrieve a discount by code
 
 ```typescript
-const discount = await client.discounts.retrieveByCode('SUMMER2025');
-if (discount) {
+try {
+  const discount = await client.discounts.retrieveByCode('SUMMER2025');
   console.log('Discount found:', discount.amount);
-} else {
+} catch (error) {
   console.log('Code not found or expired');
 }
 ```
@@ -131,13 +135,17 @@ const discount = await client.discounts.create({
 
 ### Flat discounts
 
-Expressed in the smallest currency unit. A $10 discount is `1000` (cents).
+For flat discounts, set the deduction per currency through `currency_options`. A $10 USD deduction is `max_amount_possible: 1000` (cents).
 
 ```typescript
 const discount = await client.discounts.create({
   type: 'flat',
   amount: 1000, // $10.00
-  currency: 'USD',
+  currency_options: [{
+    currency: 'USD',
+    max_amount_possible: 1000,
+    is_default: true,
+  }],
   code: 'FLAT10',
 });
 ```
@@ -153,21 +161,35 @@ const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'PREMIUM_ONLY',
-  product_ids: ['pdt_premium', 'pdt_enterprise'],
+  restricted_to: ['pdt_premium', 'pdt_enterprise'],
 });
 ```
 
 ### Customer eligibility
 
-Restrict a discount to specific customers:
+Restrict a discount to specific customers by creating it with `customer_eligibility: 'specific'`, then attaching customers through the discount-customer endpoint. `customer_ids` is not a `discounts.create` parameter.
 
 ```typescript
 const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'VIP_ONLY',
-  customer_ids: ['cus_vip_001', 'cus_vip_002'],
+  customer_eligibility: 'specific',
 });
+
+await fetch(
+  `https://test.dodopayments.com/discounts/${discount.discount_id}/customers`,
+  {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.DODO_PAYMENTS_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      customer_ids: ['cus_vip_001', 'cus_vip_002'],
+    }),
+  },
+);
 ```
 
 ### Date range
@@ -179,8 +201,8 @@ const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'SUMMER2025',
-  start_date: '2025-06-01T00:00:00Z',
-  expiration_date: '2025-08-31T23:59:59Z',
+  starts_at: '2025-06-01T00:00:00Z',
+  expires_at: '2025-08-31T23:59:59Z',
 });
 ```
 
@@ -193,7 +215,7 @@ const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'LIMITED_100',
-  max_redemptions: 100,
+  usage_limit: 100,
 });
 ```
 
@@ -206,7 +228,7 @@ const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'FIRST_3_MONTHS',
-  subscription_cycle_limit: 3, // applies to first 3 billing cycles only
+  subscription_cycles: 3, // applies to first 3 billing cycles only
 });
 ```
 
@@ -247,30 +269,26 @@ async function validateDiscount(code, productId) {
   try {
     const discount = await client.discounts.retrieveByCode(code);
     
-    if (!discount) {
-      return { valid: false, reason: 'Code not found' };
-    }
-    
     // Check expiration
-    if (discount.expiration_date && new Date(discount.expiration_date) < new Date()) {
+    if (discount.expires_at && new Date(discount.expires_at) < new Date()) {
       return { valid: false, reason: 'Code expired' };
     }
     
     // Check usage limit
-    if (discount.max_redemptions && discount.redemptions_used >= discount.max_redemptions) {
+    if (discount.usage_limit && discount.times_used >= discount.usage_limit) {
       return { valid: false, reason: 'Code exhausted' };
     }
     
     // Check product eligibility
-    if (discount.product_ids && discount.product_ids.length > 0) {
-      if (!discount.product_ids.includes(productId)) {
+    if (discount.restricted_to.length > 0) {
+      if (!discount.restricted_to.includes(productId)) {
         return { valid: false, reason: 'Code not valid for this product' };
       }
     }
     
     return { valid: true, discount };
   } catch (error) {
-    return { valid: false, reason: 'Validation error' };
+    return { valid: false, reason: 'Code not found or unavailable' };
   }
 }
 
@@ -285,11 +303,11 @@ if (result.valid) {
 
 ## Discounts on plan changes
 
-When a customer changes their subscription plan, discounts can be preserved, replaced, or cleared depending on the `discount_codes` parameter and the `preserve_on_plan_change` setting.
+When a customer changes their subscription plan, discounts can be preserved, replaced, or cleared depending on the `discount_codes` parameter and each discount's `preserve_on_plan_change` setting. Set `preserve_on_plan_change` through `discounts.create` or `discounts.update`; it is not a `subscriptions.changePlan` parameter.
 
 ### Behavior matrix
 
-| Scenario | `discount_codes` | `preserve_on_plan_change` | Result |
+| Scenario | `discount_codes` | Discount's `preserve_on_plan_change` | Result |
 |---|---|---|---|
 | Upgrade with no change | `undefined` | `true` | Existing discounts carry forward |
 | Upgrade with no change | `undefined` | `false` | Existing discounts are removed |
@@ -299,12 +317,16 @@ When a customer changes their subscription plan, discounts can be preserved, rep
 ### Example: preserve existing discounts
 
 ```typescript
+await client.discounts.update('dsc_existing', {
+  preserve_on_plan_change: true,
+});
+
 await client.subscriptions.changePlan('sub_123', {
   product_id: 'pdt_pro',
   quantity: 1,
   proration_billing_mode: 'prorated_immediately',
-  // Omit discount_codes and set preserve_on_plan_change to true
-  preserve_on_plan_change: true,
+  // Omit discount_codes. Existing discounts configured with
+  // preserve_on_plan_change: true carry forward.
 });
 ```
 
@@ -343,9 +365,13 @@ if (code.length > 0) {
 }
 
 // CORRECT: server-side validation
-const discount = await client.discounts.retrieveByCode(code);
-if (discount && isEligible(discount)) {
-  // proceed with checkout
+try {
+  const discount = await client.discounts.retrieveByCode(code);
+  if (isEligible(discount)) {
+    // proceed with checkout
+  }
+} catch (error) {
+  // Unknown or unavailable code; reject the checkout request.
 }
 ```
 
@@ -370,13 +396,16 @@ Passing `discount_codes: []` explicitly removes all discounts, even if `preserve
 // WRONG: removes all discounts
 await client.subscriptions.changePlan('sub_123', {
   product_id: 'pdt_pro',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
   discount_codes: [], // this clears discounts
 });
 
-// CORRECT: preserves existing discounts
+// CORRECT: preserves discounts whose preserve_on_plan_change property is true
 await client.subscriptions.changePlan('sub_123', {
   product_id: 'pdt_pro',
-  preserve_on_plan_change: true,
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
   // omit discount_codes
 });
 ```
@@ -390,22 +419,24 @@ A code can expire by date or by reaching its redemption limit. Always check both
 const discount = await client.discounts.retrieveByCode(code);
 applyDiscount(discount);
 
-// CORRECT: check expiration and usage
-const discount = await client.discounts.retrieveByCode(code);
-if (!discount) {
+// CORRECT: catch unknown codes, then check expiration and usage
+try {
+  const discount = await client.discounts.retrieveByCode(code);
+  if (discount.expires_at && new Date(discount.expires_at) < new Date()) {
+    showError('Code expired');
+  } else if (discount.usage_limit && discount.times_used >= discount.usage_limit) {
+    showError('Code exhausted');
+  } else {
+    applyDiscount(discount);
+  }
+} catch (error) {
   showError('Code not found');
-} else if (discount.expiration_date && new Date(discount.expiration_date) < new Date()) {
-  showError('Code expired');
-} else if (discount.max_redemptions && discount.redemptions_used >= discount.max_redemptions) {
-  showError('Code exhausted');
-} else {
-  applyDiscount(discount);
 }
 ```
 
 ### Confusing subscription-cycle limits with expiration dates
 
-A `subscription_cycle_limit` applies only to subscriptions and controls how many billing cycles the discount applies. An `expiration_date` is a hard cutoff for all uses of the code.
+`subscription_cycles` applies only to subscriptions and controls how many billing cycles the discount applies. `expires_at` is a hard cutoff for all uses of the code.
 
 ```typescript
 // Applies to first 3 billing cycles of any subscription
@@ -413,7 +444,7 @@ const discount = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'FIRST_3_MONTHS',
-  subscription_cycle_limit: 3,
+  subscription_cycles: 3,
 });
 
 // Expires on a specific date, regardless of billing cycles
@@ -421,7 +452,7 @@ const discount2 = await client.discounts.create({
   type: 'percentage',
   amount: 1500,
   code: 'SUMMER_ONLY',
-  expiration_date: '2025-08-31T23:59:59Z',
+  expires_at: '2025-08-31T23:59:59Z',
 });
 ```
 

--- a/dodo-payments/discounts-and-promotions/SKILL.md
+++ b/dodo-payments/discounts-and-promotions/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: discounts-and-promotions
+description: Guide for implementing discount codes and promotional pricing with Dodo Payments, including CRUD operations, eligibility rules, stacking, subscription-cycle limits, and plan-change preservation.
+---
+
+# Discounts and Promotions
+
+This skill covers discount codes, coupons, and promotional pricing in Dodo Payments. Use it when building discount management, applying codes at checkout, validating codes before showing prices, or handling discounts during subscription plan changes.
+
+## When to use this skill
+
+- Create, update, list, or delete discount codes
+- Apply discount codes at checkout or during plan changes
+- Validate a code before displaying adjusted pricing to the user
+- Configure eligibility rules, usage limits, or subscription-cycle restrictions
+- Handle the subtle semantics of discount preservation during plan upgrades/downgrades
+- Debug why a discount isn't applying or stacking as expected
+
+## Core concepts
+
+**Discount types:** Dodo supports both percentage and flat-amount discounts. Percentage amounts are expressed as integers where 1500 means 15% (100 = 1%). Flat amounts are in the smallest currency unit (cents for USD).
+
+**Discount code:** A human-readable string (e.g., `SUMMER2025`) that customers enter at checkout. Codes are case-sensitive.
+
+**Eligibility:** Discounts can be restricted to specific products, customers, or date ranges. A discount without restrictions applies to any product and any customer.
+
+**Stacking:** Multiple discount codes can be applied to a single checkout or subscription. They are applied in the order specified in the `discount_codes` array, up to a maximum of 20 codes.
+
+**Subscription-cycle limits:** A discount can be configured to apply only for a specific number of billing cycles (e.g., first 3 months only).
+
+**Preservation on plan change:** When a customer upgrades or downgrades their subscription, the `preserve_on_plan_change` setting and the `discount_codes` parameter control whether existing discounts carry forward.
+
+## Discount CRUD
+
+### Create a discount
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// Percentage discount: 15% off
+const percentageDiscount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500, // 15%
+  code: 'SUMMER2025',
+  metadata: {
+    campaign: 'summer_promo',
+    source: 'email_blast'
+  }
+});
+
+// Flat discount: $10 off (1000 cents)
+const flatDiscount = await client.discounts.create({
+  type: 'flat',
+  amount: 1000,
+  currency: 'USD',
+  code: 'WELCOME10',
+});
+```
+
+### List discounts
+
+```typescript
+const discounts = await client.discounts.list({
+  limit: 50,
+  offset: 0,
+});
+
+discounts.data.forEach(discount => {
+  console.log(`${discount.code}: ${discount.type} ${discount.amount}`);
+});
+```
+
+### Retrieve a discount by ID
+
+```typescript
+const discount = await client.discounts.retrieve('discount_id');
+console.log(discount.code, discount.type, discount.amount);
+```
+
+### Retrieve a discount by code
+
+```typescript
+const discount = await client.discounts.retrieveByCode('SUMMER2025');
+if (discount) {
+  console.log('Discount found:', discount.amount);
+} else {
+  console.log('Code not found or expired');
+}
+```
+
+### Update a discount
+
+```typescript
+await client.discounts.update('discount_id', {
+  metadata: { updated_at: new Date().toISOString() }
+});
+```
+
+### Delete a discount
+
+```typescript
+await client.discounts.delete('discount_id');
+```
+
+## Discount types and configuration
+
+**Important:** The feature documentation states that only percentage discounts are currently supported. However, the current OpenAPI schema defines both `flat` and `percentage` types with currency options. Follow the API reference when implementing. If you encounter unexpected behavior with flat discounts, verify with Dodo support whether flat discounts are fully enabled in your account.
+
+### Percentage discounts
+
+Expressed as an integer where 100 = 1%. A 15% discount is `1500`.
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500, // 15%
+  code: 'PERCENT15',
+});
+```
+
+### Flat discounts
+
+Expressed in the smallest currency unit. A $10 discount is `1000` (cents).
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'flat',
+  amount: 1000, // $10.00
+  currency: 'USD',
+  code: 'FLAT10',
+});
+```
+
+## Eligibility and restrictions
+
+### Product restrictions
+
+Limit a discount to specific products:
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'PREMIUM_ONLY',
+  product_ids: ['pdt_premium', 'pdt_enterprise'],
+});
+```
+
+### Customer eligibility
+
+Restrict a discount to specific customers:
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'VIP_ONLY',
+  customer_ids: ['cus_vip_001', 'cus_vip_002'],
+});
+```
+
+### Date range
+
+Set activation and expiration dates:
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'SUMMER2025',
+  start_date: '2025-06-01T00:00:00Z',
+  expiration_date: '2025-08-31T23:59:59Z',
+});
+```
+
+### Usage limits
+
+Limit the total number of times a code can be used:
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'LIMITED_100',
+  max_redemptions: 100,
+});
+```
+
+### Subscription-cycle limits
+
+Apply a discount only for the first N billing cycles:
+
+```typescript
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'FIRST_3_MONTHS',
+  subscription_cycle_limit: 3, // applies to first 3 billing cycles only
+});
+```
+
+## Applying codes at checkout
+
+### Single code
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_abc', quantity: 1 }],
+  discount_codes: ['SUMMER2025'],
+  customer: { email: 'user@example.com' },
+  return_url: 'https://yoursite.com/return'
+});
+
+window.location.href = session.checkout_url;
+```
+
+### Multiple codes (stacking)
+
+Codes are applied in the order specified. Maximum 20 codes per checkout:
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_abc', quantity: 1 }],
+  discount_codes: ['WELCOME10', 'BLACKFRIDAY20', 'LOYALTY5'],
+  customer: { email: 'user@example.com' },
+  return_url: 'https://yoursite.com/return'
+});
+```
+
+## Validating codes before checkout
+
+Validate a code and check its eligibility before showing adjusted pricing:
+
+```typescript
+async function validateDiscount(code, productId) {
+  try {
+    const discount = await client.discounts.retrieveByCode(code);
+    
+    if (!discount) {
+      return { valid: false, reason: 'Code not found' };
+    }
+    
+    // Check expiration
+    if (discount.expiration_date && new Date(discount.expiration_date) < new Date()) {
+      return { valid: false, reason: 'Code expired' };
+    }
+    
+    // Check usage limit
+    if (discount.max_redemptions && discount.redemptions_used >= discount.max_redemptions) {
+      return { valid: false, reason: 'Code exhausted' };
+    }
+    
+    // Check product eligibility
+    if (discount.product_ids && discount.product_ids.length > 0) {
+      if (!discount.product_ids.includes(productId)) {
+        return { valid: false, reason: 'Code not valid for this product' };
+      }
+    }
+    
+    return { valid: true, discount };
+  } catch (error) {
+    return { valid: false, reason: 'Validation error' };
+  }
+}
+
+// Usage
+const result = await validateDiscount('SUMMER2025', 'pdt_abc');
+if (result.valid) {
+  console.log('Discount applies:', result.discount.amount);
+} else {
+  console.log('Cannot apply:', result.reason);
+}
+```
+
+## Discounts on plan changes
+
+When a customer changes their subscription plan, discounts can be preserved, replaced, or cleared depending on the `discount_codes` parameter and the `preserve_on_plan_change` setting.
+
+### Behavior matrix
+
+| Scenario | `discount_codes` | `preserve_on_plan_change` | Result |
+|---|---|---|---|
+| Upgrade with no change | `undefined` | `true` | Existing discounts carry forward |
+| Upgrade with no change | `undefined` | `false` | Existing discounts are removed |
+| Upgrade with no change | `[]` (empty array) | any | Existing discounts are removed |
+| Upgrade with replacement | `['NEW_CODE']` | any | Only `NEW_CODE` applies; old discounts removed |
+
+### Example: preserve existing discounts
+
+```typescript
+await client.subscriptions.changePlan('sub_123', {
+  product_id: 'pdt_pro',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+  // Omit discount_codes and set preserve_on_plan_change to true
+  preserve_on_plan_change: true,
+});
+```
+
+### Example: replace discounts on upgrade
+
+```typescript
+await client.subscriptions.changePlan('sub_123', {
+  product_id: 'pdt_pro',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+  discount_codes: ['UPGRADE20'], // replaces old discounts
+});
+```
+
+### Example: remove all discounts on downgrade
+
+```typescript
+await client.subscriptions.changePlan('sub_123', {
+  product_id: 'pdt_basic',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+  discount_codes: [], // empty array removes all discounts
+});
+```
+
+## Common mistakes
+
+### Validating discounts client-side only
+
+Never trust client-side validation. Always validate on the server before applying a discount at checkout. A user can modify the discount code in the browser.
+
+```typescript
+// WRONG: client-side only
+if (code.length > 0) {
+  applyDiscount(code);
+}
+
+// CORRECT: server-side validation
+const discount = await client.discounts.retrieveByCode(code);
+if (discount && isEligible(discount)) {
+  // proceed with checkout
+}
+```
+
+### Assuming codes stack unconditionally
+
+Discounts stack in order, but eligibility rules still apply. If a code is restricted to a product not in the cart, it won't apply even if other codes do.
+
+```typescript
+// Both codes may not apply if they have conflicting restrictions
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_basic', quantity: 1 }],
+  discount_codes: ['PREMIUM_ONLY', 'BASIC_ONLY'], // one or both may fail
+  return_url: 'https://yoursite.com/return'
+});
+```
+
+### Losing a discount on upgrade by passing an empty array
+
+Passing `discount_codes: []` explicitly removes all discounts, even if `preserve_on_plan_change` is true. Omit the parameter entirely if you want to preserve existing discounts.
+
+```typescript
+// WRONG: removes all discounts
+await client.subscriptions.changePlan('sub_123', {
+  product_id: 'pdt_pro',
+  discount_codes: [], // this clears discounts
+});
+
+// CORRECT: preserves existing discounts
+await client.subscriptions.changePlan('sub_123', {
+  product_id: 'pdt_pro',
+  preserve_on_plan_change: true,
+  // omit discount_codes
+});
+```
+
+### Not handling expired or exhausted codes
+
+A code can expire by date or by reaching its redemption limit. Always check both before showing a discount to the user.
+
+```typescript
+// WRONG: assumes code is always valid
+const discount = await client.discounts.retrieveByCode(code);
+applyDiscount(discount);
+
+// CORRECT: check expiration and usage
+const discount = await client.discounts.retrieveByCode(code);
+if (!discount) {
+  showError('Code not found');
+} else if (discount.expiration_date && new Date(discount.expiration_date) < new Date()) {
+  showError('Code expired');
+} else if (discount.max_redemptions && discount.redemptions_used >= discount.max_redemptions) {
+  showError('Code exhausted');
+} else {
+  applyDiscount(discount);
+}
+```
+
+### Confusing subscription-cycle limits with expiration dates
+
+A `subscription_cycle_limit` applies only to subscriptions and controls how many billing cycles the discount applies. An `expiration_date` is a hard cutoff for all uses of the code.
+
+```typescript
+// Applies to first 3 billing cycles of any subscription
+const discount = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'FIRST_3_MONTHS',
+  subscription_cycle_limit: 3,
+});
+
+// Expires on a specific date, regardless of billing cycles
+const discount2 = await client.discounts.create({
+  type: 'percentage',
+  amount: 1500,
+  code: 'SUMMER_ONLY',
+  expiration_date: '2025-08-31T23:59:59Z',
+});
+```
+
+## Resources
+
+- [Discounts feature guide](https://docs.dodopayments.com/features/discount-codes)
+- [Create discount API](https://docs.dodopayments.com/api-reference/discounts/create-discount)
+- [Checkout Sessions API](https://docs.dodopayments.com/developer-resources/checkout-session)
+- [Subscription plan changes](https://docs.dodopayments.com/api-reference/subscriptions/change-plan)

--- a/dodo-payments/discounts-and-promotions/SKILL.md
+++ b/dodo-payments/discounts-and-promotions/SKILL.md
@@ -66,13 +66,19 @@ const flatDiscount = await client.discounts.create({
 
 ```typescript
 const discounts = await client.discounts.list({
-  limit: 50,
-  offset: 0,
+  page_size: 50,
+  page_number: 0,
 });
 
-discounts.data.forEach(discount => {
+// Paginated responses expose `items`.
+for (const discount of discounts.items) {
   console.log(`${discount.code}: ${discount.type} ${discount.amount}`);
-});
+}
+
+// Or let the SDK walk every page for you:
+for await (const discount of client.discounts.list()) {
+  console.log(discount.code);
+}
 ```
 
 ### Retrieve a discount by ID

--- a/dodo-payments/framework-adapters/SKILL.md
+++ b/dodo-payments/framework-adapters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: framework-adapters
-description: Guide for implementing Dodo Payments checkout, customer portal, and webhooks using official framework adapter packages for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex.
+description: Guide for mounting official @dodopayments/* checkout, portal, and verified-webhook route handlers in supported web frameworks; use domain skills for payment and lifecycle logic.
 ---
 
 # Framework Adapters

--- a/dodo-payments/framework-adapters/SKILL.md
+++ b/dodo-payments/framework-adapters/SKILL.md
@@ -17,13 +17,24 @@ Use this skill when you need to integrate Dodo Payments into a web framework usi
 
 ## What framework adapters do
 
-Dodo publishes `@dodopayments/*` packages that wrap the core SDK with framework-specific route handlers. Instead of writing your own HTTP handlers, you import `Checkout`, `CustomerPortal`, or `Webhooks` from your framework's adapter and mount them directly in your routes.
+Dodo publishes `@dodopayments/*` packages that wrap the core SDK with framework-specific route handlers. Instead of writing your own HTTP handlers, you import the adapter's handlers and mount them directly in your routes.
 
 Each adapter exposes three handler families:
 
 - **Checkout:** static (GET only), dynamic (POST with cart), or session (POST with pre-built session).
 - **CustomerPortal:** generates a time-bound portal session link.
 - **Webhooks:** verifies webhook signatures and dispatches typed events.
+
+**Export names are not uniform across adapters.** Most export `Checkout` / `CustomerPortal` / `Webhooks`, but two differ, and the return shapes differ as well. Check this table before writing imports:
+
+| Adapter | Checkout export | Portal export | Handler shape |
+|---|---|---|---|
+| `nextjs`, `hono`, `astro`, `bun`, `remix`, `tanstack` | `Checkout` | `CustomerPortal` | returns a request handler |
+| `express` | `checkoutHandler` (lowercase) | `CustomerPortal` | returns `(req, res)` |
+| `fastify` | `Checkout` | `CustomerPortal` | returns `{ getHandler, postHandler }` |
+| `sveltekit` | `Checkout` | `CustomerPortal` | returns `{ GET, POST }` / `{ GET }` |
+| `nuxt` | `checkoutHandler` (auto-imported) | `customerPortalHandler` | no import statement |
+| `convex` | `DodoPayments` component | — | `createDodoWebhookHandler` |
 
 The adapters handle raw body preservation for webhook verification, environment variable mapping, and framework-specific request/response shapes. Checkout payload design belongs to the `checkout-integration` skill; webhook business logic belongs to `webhook-integration`; portal behavior belongs to `customer-management`.
 
@@ -73,6 +84,20 @@ DODO_PAYMENTS_WEBHOOK_SECRET=your-webhook-secret
 
 **Webhook key naming:** Some adapters reference `DODO_PAYMENTS_WEBHOOK_KEY`, others use `DODO_PAYMENTS_WEBHOOK_SECRET`. Check your framework's adapter docs and dashboard configuration to use the correct variable name.
 
+### Narrowing `environment`
+
+Adapter configs type `environment` as `Pick<ClientOptions, "environment">`, i.e. the literal union `"test_mode" | "live_mode"`. `process.env.X` is `string | undefined`, which does **not** assign to it — passing it directly is a type error in every adapter.
+
+Define this helper once and import it wherever you construct an adapter config:
+
+```typescript
+// lib/dodo-env.ts
+export const dodoEnvironment =
+  process.env.DODO_PAYMENTS_ENVIRONMENT === "live_mode" ? "live_mode" : "test_mode";
+```
+
+Defaulting to `test_mode` is deliberate: a missing or misspelled variable must never silently resolve to live mode. Every example below uses `dodoEnvironment`.
+
 ## Next.js
 
 **Package:** `@dodopayments/nextjs`  
@@ -87,14 +112,14 @@ import { Checkout } from "@dodopayments/nextjs";
 export const GET = Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "static",
 });
 
 export const POST = Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 });
 ```
@@ -107,7 +132,7 @@ import { CustomerPortal } from "@dodopayments/nextjs";
 
 export const GET = CustomerPortal({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
 });
 ```
 
@@ -131,23 +156,26 @@ export const POST = Webhooks({
 
 ### Checkout
 
+The Express adapter names its checkout export `checkoutHandler` in lowercase, unlike every other adapter. `import { Checkout } from "@dodopayments/express"` does not resolve.
+
 ```typescript
 import express from "express";
-import { Checkout } from "@dodopayments/express";
+import { checkoutHandler } from "@dodopayments/express";
+import { dodoEnvironment } from "./lib/dodo-env";
 
 const app = express();
 
-app.get("/api/checkout", Checkout({
+app.get("/api/checkout", checkoutHandler({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "static",
 }));
 
-app.post("/api/checkout", Checkout({
+app.post("/api/checkout", checkoutHandler({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 }));
 ```
@@ -159,7 +187,7 @@ import { CustomerPortal } from "@dodopayments/express";
 
 app.get("/api/customer-portal", CustomerPortal({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
 }));
 ```
 
@@ -186,29 +214,31 @@ Fastify requires a string body parser to preserve the raw body for webhook verif
 
 ### Checkout
 
+`Checkout(config)` returns an object with `getHandler` and `postHandler`, not a single callable. Build it once and mount each method, rather than calling the result.
+
 ```typescript
 import Fastify from "fastify";
 import { Checkout } from "@dodopayments/fastify";
+import { dodoEnvironment } from "./lib/dodo-env";
 
 const fastify = Fastify();
 
-fastify.get("/api/checkout", async (request, reply) => {
-  return Checkout({
-    bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-    returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-    environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
-    type: "static",
-  })(request);
+const staticCheckout = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: dodoEnvironment,
+  type: "static",
 });
 
-fastify.post("/api/checkout", async (request, reply) => {
-  return Checkout({
-    bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-    returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-    environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
-    type: "session",
-  })(request);
+const sessionCheckout = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: dodoEnvironment,
+  type: "session",
 });
+
+fastify.get("/api/checkout", staticCheckout.getHandler);
+fastify.post("/api/checkout", sessionCheckout.postHandler);
 ```
 
 ### Webhooks
@@ -245,14 +275,14 @@ const app = new Hono();
 app.get("/api/checkout", Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "static",
 }));
 
 app.post("/api/checkout", Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 }));
 ```
@@ -264,7 +294,7 @@ import { CustomerPortal } from "@dodopayments/hono";
 
 app.get("/api/customer-portal", CustomerPortal({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
 }));
 ```
 
@@ -341,7 +371,7 @@ import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
 const checkoutHandler = Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 });
 
@@ -358,7 +388,7 @@ import type { LoaderFunctionArgs } from "@remix-run/node";
 
 const portalHandler = CustomerPortal({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
 });
 
 export const loader = ({ request }: LoaderFunctionArgs) => portalHandler(request);
@@ -441,13 +471,14 @@ export default defineNuxtConfig({
 
 ### Checkout
 
+The Nuxt module registers its handlers with `addServerImportsDir`, so `checkoutHandler`, `customerPortalHandler`, and `Webhooks` are **auto-imported** inside `server/`. Do not import them from `@dodopayments/nuxt` — that entry point exports only the Nuxt module itself, and a named import from it will not resolve.
+
 ```typescript
 // server/routes/api/checkout.ts
-import { Checkout } from "@dodopayments/nuxt";
-
+// checkoutHandler and useRuntimeConfig are auto-imported by the module.
 const config = useRuntimeConfig();
 
-export default Checkout({
+export default checkoutHandler({
   bearerToken: config.private.bearerToken,
   returnUrl: config.private.returnUrl,
   environment: config.private.environment,
@@ -459,8 +490,7 @@ export default Checkout({
 
 ```typescript
 // server/routes/api/webhook.ts
-import { Webhooks } from "@dodopayments/nuxt";
-
+// Webhooks and useRuntimeConfig are auto-imported by the module.
 const config = useRuntimeConfig();
 
 export default Webhooks({
@@ -477,28 +507,29 @@ export default Webhooks({
 
 ### Checkout
 
+`Checkout(config)` returns a plain `(request: Request) => Promise<Response>`, so export it directly as the route's method handler. The adapter's own documented usage is `export const GET = Checkout(config)`.
+
 ```typescript
 // src/routes/api/checkout.ts
 import { Checkout } from "@dodopayments/tanstack";
-import { createServerFileRoute } from "@tanstack/react-start/server";
+import { dodoEnvironment } from "./lib/dodo-env";
 
-export const ServerRoute = createServerFileRoute("/api/checkout").methods({
-  GET: async ({ request }) =>
-    Checkout({
-      bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-      returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-      environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
-      type: "static",
-    })(request),
-  POST: async ({ request }) =>
-    Checkout({
-      bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-      returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-      environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
-      type: "session",
-    })(request),
+export const GET = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: dodoEnvironment,
+  type: "static",
+});
+
+export const POST = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: dodoEnvironment,
+  type: "session",
 });
 ```
+
+TanStack Start's server-route definition API has changed across releases (`createServerFileRoute` was removed). Wrap these exports in whatever route helper your installed version provides; the adapter handlers themselves are unaffected.
 
 ## Bun
 
@@ -512,13 +543,13 @@ import { Checkout, CustomerPortal } from "@dodopayments/bun";
 const checkoutHandler = Checkout({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
   returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 });
 
 const portalHandler = CustomerPortal({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
 });
 
 Bun.serve({

--- a/dodo-payments/framework-adapters/SKILL.md
+++ b/dodo-payments/framework-adapters/SKILL.md
@@ -1,0 +1,607 @@
+---
+name: framework-adapters
+description: Guide for implementing Dodo Payments checkout, customer portal, and webhooks using official framework adapter packages for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex.
+---
+
+# Framework Adapters
+
+Use this skill when you need to integrate Dodo Payments into a web framework using the official adapter packages. Framework adapters handle route plumbing, environment configuration, and handler setup so you don't build checkout, portal, and webhook routes from scratch.
+
+## When to use this skill
+
+- You're building a checkout flow in Next.js, Express, Fastify, Hono, Astro, Remix, SvelteKit, Nuxt, TanStack, Bun, or Convex.
+- You need to set up a customer portal session endpoint.
+- You're adding webhook handlers that verify signatures and dispatch events.
+- You want framework-idiomatic route placement and environment variable handling.
+- You need to choose between static, dynamic, or session checkout modes.
+
+## What framework adapters do
+
+Dodo publishes `@dodopayments/*` packages that wrap the core SDK with framework-specific route handlers. Instead of writing your own HTTP handlers, you import `Checkout`, `CustomerPortal`, or `Webhooks` from your framework's adapter and mount them directly in your routes.
+
+Each adapter exposes three handler families:
+
+- **Checkout:** static (GET only), dynamic (POST with cart), or session (POST with pre-built session).
+- **CustomerPortal:** generates a time-bound portal session link.
+- **Webhooks:** verifies webhook signatures and dispatches typed events.
+
+The adapters handle raw body preservation for webhook verification, environment variable mapping, and framework-specific request/response shapes. Checkout payload design belongs to the `checkout-integration` skill; webhook business logic belongs to `webhook-integration`; portal behavior belongs to `customer-management`.
+
+## Framework selection and installation
+
+| Framework | Package | Install |
+|---|---|---|
+| Next.js | `@dodopayments/nextjs` | `npm install @dodopayments/nextjs` |
+| Express | `@dodopayments/express` | `npm install @dodopayments/express` |
+| Fastify | `@dodopayments/fastify` | `npm install @dodopayments/fastify` |
+| Hono | `@dodopayments/hono` | `npm install @dodopayments/hono` |
+| Astro | `@dodopayments/astro` | `npm install @dodopayments/astro` |
+| Remix | `@dodopayments/remix` | `npm install @dodopayments/remix` |
+| SvelteKit | `@dodopayments/sveltekit` | `npm install @dodopayments/sveltekit` |
+| Nuxt | `@dodopayments/nuxt` | `npm install @dodopayments/nuxt` |
+| TanStack Start | `@dodopayments/tanstack` | `npm install @dodopayments/tanstack` |
+| Bun | `@dodopayments/bun` | `bun add @dodopayments/bun` |
+| Convex | `@dodopayments/convex` | `npm install @dodopayments/convex` |
+
+## Environment variables
+
+Most adapters use these standard names:
+
+```env
+DODO_PAYMENTS_API_KEY=dodo_test_...
+DODO_PAYMENTS_WEBHOOK_KEY=your-webhook-secret
+DODO_PAYMENTS_ENVIRONMENT=test_mode
+DODO_PAYMENTS_RETURN_URL=https://yourdomain.com/checkout/success
+```
+
+**Nuxt** uses private runtime config prefixes:
+
+```env
+NUXT_PRIVATE_BEARER_TOKEN=dodo_test_...
+NUXT_PRIVATE_WEBHOOK_KEY=your-webhook-secret
+NUXT_PRIVATE_ENVIRONMENT=test_mode
+NUXT_PRIVATE_RETURNURL=https://yourdomain.com/checkout/success
+```
+
+**Convex** uses dashboard environment variables (not local `.env`):
+
+```env
+DODO_PAYMENTS_API_KEY=dodo_test_...
+DODO_PAYMENTS_ENVIRONMENT=test_mode
+DODO_PAYMENTS_WEBHOOK_SECRET=your-webhook-secret
+```
+
+**Webhook key naming:** Some adapters reference `DODO_PAYMENTS_WEBHOOK_KEY`, others use `DODO_PAYMENTS_WEBHOOK_SECRET`. Check your framework's adapter docs and dashboard configuration to use the correct variable name.
+
+## Next.js
+
+**Package:** `@dodopayments/nextjs`  
+**Route placement:** `app/api/checkout/route.ts`, `app/api/customer-portal/route.ts`, `app/api/webhook/route.ts`
+
+### Checkout (choose one mode per route)
+
+```typescript
+// app/api/checkout/route.ts
+import { Checkout } from "@dodopayments/nextjs";
+
+export const GET = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "static",
+});
+
+export const POST = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+});
+```
+
+### Customer Portal
+
+```typescript
+// app/api/customer-portal/route.ts
+import { CustomerPortal } from "@dodopayments/nextjs";
+
+export const GET = CustomerPortal({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+});
+```
+
+### Webhooks
+
+```typescript
+// app/api/webhook/route.ts
+import { Webhooks } from "@dodopayments/nextjs";
+
+export const POST = Webhooks({
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook received:", payload.type);
+  },
+});
+```
+
+## Express
+
+**Package:** `@dodopayments/express`
+
+### Checkout
+
+```typescript
+import express from "express";
+import { Checkout } from "@dodopayments/express";
+
+const app = express();
+
+app.get("/api/checkout", Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "static",
+}));
+
+app.post("/api/checkout", Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+}));
+```
+
+### Customer Portal
+
+```typescript
+import { CustomerPortal } from "@dodopayments/express";
+
+app.get("/api/customer-portal", CustomerPortal({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+}));
+```
+
+### Webhooks
+
+```typescript
+import { Webhooks } from "@dodopayments/express";
+
+app.use(express.raw({ type: "application/json" }));
+
+app.post("/api/webhook", Webhooks({
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+}));
+```
+
+## Fastify
+
+**Package:** `@dodopayments/fastify`
+
+Fastify requires a string body parser to preserve the raw body for webhook verification.
+
+### Checkout
+
+```typescript
+import Fastify from "fastify";
+import { Checkout } from "@dodopayments/fastify";
+
+const fastify = Fastify();
+
+fastify.get("/api/checkout", async (request, reply) => {
+  return Checkout({
+    bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+    returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+    environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+    type: "static",
+  })(request);
+});
+
+fastify.post("/api/checkout", async (request, reply) => {
+  return Checkout({
+    bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+    returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+    environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+    type: "session",
+  })(request);
+});
+```
+
+### Webhooks
+
+```typescript
+import { Webhooks } from "@dodopayments/fastify";
+
+fastify.addContentTypeParser(
+  "application/json",
+  { parseAs: "string" },
+  (req, body, done) => done(null, body)
+);
+
+fastify.post("/api/webhook", Webhooks({
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+}));
+```
+
+## Hono
+
+**Package:** `@dodopayments/hono`
+
+### Checkout
+
+```typescript
+import { Hono } from "hono";
+import { Checkout } from "@dodopayments/hono";
+
+const app = new Hono();
+
+app.get("/api/checkout", Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "static",
+}));
+
+app.post("/api/checkout", Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+}));
+```
+
+### Customer Portal
+
+```typescript
+import { CustomerPortal } from "@dodopayments/hono";
+
+app.get("/api/customer-portal", CustomerPortal({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+}));
+```
+
+### Webhooks
+
+```typescript
+import { Webhooks } from "@dodopayments/hono";
+
+app.post("/api/webhook", Webhooks({
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+}));
+```
+
+## Astro
+
+**Package:** `@dodopayments/astro`  
+**Route placement:** `src/pages/api/checkout.ts`, `src/pages/api/customer-portal.ts`, `src/pages/api/webhook.ts`
+
+Disable prerendering for checkout routes.
+
+### Checkout
+
+```typescript
+// src/pages/api/checkout.ts
+import { Checkout } from "@dodopayments/astro";
+
+export const prerender = false;
+
+export const GET = Checkout({
+  bearerToken: import.meta.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: import.meta.env.DODO_PAYMENTS_RETURN_URL,
+  environment: import.meta.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "static",
+});
+
+export const POST = Checkout({
+  bearerToken: import.meta.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: import.meta.env.DODO_PAYMENTS_RETURN_URL,
+  environment: import.meta.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+});
+```
+
+### Webhooks
+
+```typescript
+// src/pages/api/webhook.ts
+import { Webhooks } from "@dodopayments/astro";
+
+export const prerender = false;
+
+export const POST = Webhooks({
+  webhookKey: import.meta.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+});
+```
+
+## Remix
+
+**Package:** `@dodopayments/remix`
+
+### Checkout
+
+```typescript
+// app/routes/api.checkout.tsx
+import { Checkout } from "@dodopayments/remix";
+import type { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+
+const checkoutHandler = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+});
+
+export const loader = ({ request }: LoaderFunctionArgs) => checkoutHandler(request);
+export const action = ({ request }: ActionFunctionArgs) => checkoutHandler(request);
+```
+
+### Customer Portal
+
+```typescript
+// app/routes/api.customer-portal.tsx
+import { CustomerPortal } from "@dodopayments/remix";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+const portalHandler = CustomerPortal({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+});
+
+export const loader = ({ request }: LoaderFunctionArgs) => portalHandler(request);
+```
+
+### Webhooks
+
+```typescript
+// app/routes/api.webhook.tsx
+import { Webhooks } from "@dodopayments/remix";
+import type { ActionFunctionArgs } from "@remix-run/node";
+
+export const action = ({ request }: ActionFunctionArgs) =>
+  Webhooks({
+    webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+    onPayload: async (payload) => {
+      console.log("Webhook:", payload.type);
+    },
+  })(request);
+```
+
+## SvelteKit
+
+**Package:** `@dodopayments/sveltekit`  
+**Route placement:** `src/routes/api/checkout/+server.ts`, `src/routes/api/customer-portal/+server.ts`, `src/routes/api/webhook/+server.ts`
+
+### Checkout
+
+```typescript
+// src/routes/api/checkout/+server.ts
+import { Checkout } from "@dodopayments/sveltekit";
+import { DODO_PAYMENTS_API_KEY, DODO_PAYMENTS_RETURN_URL, DODO_PAYMENTS_ENVIRONMENT } from "$env/static/private";
+
+const checkoutHandler = Checkout({
+  bearerToken: DODO_PAYMENTS_API_KEY,
+  returnUrl: DODO_PAYMENTS_RETURN_URL,
+  environment: DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+});
+
+export const GET = checkoutHandler;
+export const POST = checkoutHandler;
+```
+
+### Webhooks
+
+```typescript
+// src/routes/api/webhook/+server.ts
+import { Webhooks } from "@dodopayments/sveltekit";
+import { DODO_PAYMENTS_WEBHOOK_KEY } from "$env/static/private";
+
+export const POST = Webhooks({
+  webhookKey: DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+});
+```
+
+## Nuxt
+
+**Package:** `@dodopayments/nuxt`
+
+Add the module to `nuxt.config.ts` and configure runtime variables:
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["@dodopayments/nuxt"],
+  runtimeConfig: {
+    private: {
+      bearerToken: process.env.NUXT_PRIVATE_BEARER_TOKEN,
+      webhookKey: process.env.NUXT_PRIVATE_WEBHOOK_KEY,
+      environment: process.env.NUXT_PRIVATE_ENVIRONMENT,
+      returnUrl: process.env.NUXT_PRIVATE_RETURNURL,
+    },
+  },
+});
+```
+
+### Checkout
+
+```typescript
+// server/routes/api/checkout.ts
+import { Checkout } from "@dodopayments/nuxt";
+
+const config = useRuntimeConfig();
+
+export default Checkout({
+  bearerToken: config.private.bearerToken,
+  returnUrl: config.private.returnUrl,
+  environment: config.private.environment,
+  type: "session",
+});
+```
+
+### Webhooks
+
+```typescript
+// server/routes/api/webhook.ts
+import { Webhooks } from "@dodopayments/nuxt";
+
+const config = useRuntimeConfig();
+
+export default Webhooks({
+  webhookKey: config.private.webhookKey,
+  onPayload: async (payload) => {
+    console.log("Webhook:", payload.type);
+  },
+});
+```
+
+## TanStack Start
+
+**Package:** `@dodopayments/tanstack`
+
+### Checkout
+
+```typescript
+// src/routes/api/checkout.ts
+import { Checkout } from "@dodopayments/tanstack";
+import { createServerFileRoute } from "@tanstack/react-start/server";
+
+export const ServerRoute = createServerFileRoute("/api/checkout").methods({
+  GET: async ({ request }) =>
+    Checkout({
+      bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+      returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+      environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+      type: "static",
+    })(request),
+  POST: async ({ request }) =>
+    Checkout({
+      bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+      returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+      environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+      type: "session",
+    })(request),
+});
+```
+
+## Bun
+
+**Package:** `@dodopayments/bun`
+
+### Checkout and Portal
+
+```typescript
+import { Checkout, CustomerPortal } from "@dodopayments/bun";
+
+const checkoutHandler = Checkout({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  returnUrl: process.env.DODO_PAYMENTS_RETURN_URL,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  type: "session",
+});
+
+const portalHandler = CustomerPortal({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+});
+
+Bun.serve({
+  port: 3000,
+  fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/checkout") {
+      return checkoutHandler(request);
+    }
+    if (url.pathname === "/api/customer-portal" && request.method === "GET") {
+      return portalHandler(request);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+```
+
+## Convex
+
+**Package:** `@dodopayments/convex`
+
+Convex uses a component-based architecture. Register the component in `convex.config.ts`:
+
+```typescript
+// convex/convex.config.ts
+import { defineApp } from "convex/server";
+import dodopayments from "@dodopayments/convex/convex.config";
+
+const app = defineApp();
+app.use(dodopayments);
+export default app;
+```
+
+Then use the component in your actions and HTTP routes:
+
+```typescript
+// convex/checkout.ts
+import { mutation } from "./_generated/server";
+import { components } from "./_generated/server";
+
+export const createCheckoutSession = mutation({
+  args: { customerId: v.string() },
+  handler: async (ctx, args) => {
+    const dodo = components.dodopayments;
+    return dodo.checkout.createSession(ctx, {
+      customerId: args.customerId,
+      // ... checkout params
+    });
+  },
+});
+```
+
+Convex only supports session checkout, not static or dynamic modes.
+
+## Common mistakes
+
+1. **Duplicate POST handlers:** Next.js and Astro docs show two `export const POST` declarations. Choose one checkout mode per route or add routing logic to dispatch between them.
+
+2. **Wrong webhook variable name:** Check whether your adapter uses `DODO_PAYMENTS_WEBHOOK_KEY` or `DODO_PAYMENTS_WEBHOOK_SECRET`. The docs are inconsistent; use the name your adapter actually references.
+
+3. **Forgetting raw body preservation:** Webhook handlers must receive the raw request body, not a re-parsed JSON object. Fastify requires an explicit string body parser; Express needs `express.raw()`; other frameworks handle this automatically. Webhook signature verification is covered in the `webhook-integration` skill.
+
+4. **Mixing framework conventions:** Each framework has its own request/response shape. Don't try to use a Next.js handler in Express or vice versa. Use the adapter for your framework.
+
+5. **Hardcoding secrets:** Always read API keys and webhook secrets from environment variables, never from code or config files.
+
+6. **Skipping environment setup:** The adapters won't work without `DODO_PAYMENTS_API_KEY` and `DODO_PAYMENTS_ENVIRONMENT`. Set these before testing.
+
+7. **Using `@dodopayments/core` directly:** The core package is an internal dependency, not a documented public entry point. Use the framework adapter for your stack.
+
+## Resources
+
+- [Framework Adapters Overview](https://docs.dodopayments.com/developer-resources/framework-adaptors)
+- [Next.js Adapter](https://docs.dodopayments.com/developer-resources/nextjs-adaptor)
+- [Express Adapter](https://docs.dodopayments.com/developer-resources/express-adaptor)
+- [Fastify Adapter](https://docs.dodopayments.com/developer-resources/fastify-adaptor)
+- [Hono Adapter](https://docs.dodopayments.com/developer-resources/hono-adaptor)
+- [Astro Adapter](https://docs.dodopayments.com/developer-resources/astro-adaptor)
+- [Remix Adapter](https://docs.dodopayments.com/developer-resources/remix-adaptor)
+- [SvelteKit Adapter](https://docs.dodopayments.com/developer-resources/sveltekit-adaptor)
+- [Nuxt Adapter](https://docs.dodopayments.com/developer-resources/nuxt-adaptor)
+- [TanStack Adapter](https://docs.dodopayments.com/developer-resources/tanstack-adaptor)
+- [Bun Adapter](https://docs.dodopayments.com/developer-resources/bun-adaptor)
+- [Convex Component](https://docs.dodopayments.com/developer-resources/convex-component)

--- a/dodo-payments/framework-adapters/SKILL.md
+++ b/dodo-payments/framework-adapters/SKILL.md
@@ -326,17 +326,23 @@ import { Checkout } from "@dodopayments/astro";
 
 export const prerender = false;
 
+// Astro reads env from import.meta.env, which is typed as string - so it needs
+// the same narrowing as process.env. Define this alongside the other helper in
+// lib/dodo-env.ts if you use both.
+const dodoEnvironment =
+  import.meta.env.DODO_PAYMENTS_ENVIRONMENT === "live_mode" ? "live_mode" : "test_mode";
+
 export const GET = Checkout({
   bearerToken: import.meta.env.DODO_PAYMENTS_API_KEY,
   returnUrl: import.meta.env.DODO_PAYMENTS_RETURN_URL,
-  environment: import.meta.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "static",
 });
 
 export const POST = Checkout({
   bearerToken: import.meta.env.DODO_PAYMENTS_API_KEY,
   returnUrl: import.meta.env.DODO_PAYMENTS_RETURN_URL,
-  environment: import.meta.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment: dodoEnvironment,
   type: "session",
 });
 ```

--- a/dodo-payments/license-keys/SKILL.md
+++ b/dodo-payments/license-keys/SKILL.md
@@ -142,7 +142,7 @@ async function listCustomerKeys(customerId: string) {
     key: key.key,
     status: key.status,
     expiresAt: key.expires_at,
-    activationsUsed: key.activations_used,
+    activationsUsed: key.instances_count,
     activationsLimit: key.activations_limit,
   }));
 }
@@ -158,7 +158,7 @@ console.log({
   key: key.key,
   status: key.status,
   expiresAt: key.expires_at,
-  activationsUsed: key.activations_used,
+  activationsUsed: key.instances_count,
   activationsLimit: key.activations_limit,
 });
 ```
@@ -168,7 +168,7 @@ console.log({
 ```typescript
 // Disable a key or adjust its activation limit
 await client.licenseKeys.update('lk_abc123', {
-  status: 'disabled',
+  disabled: true,
   // or adjust activations_limit
   activations_limit: 10,
 });
@@ -179,6 +179,7 @@ await client.licenseKeys.update('lk_abc123', {
 ```typescript
 const newKey = await client.licenseKeys.create({
   customer_id: 'cus_abc123',
+  key: 'PREMIUM-AAAA-BBBB-CCCC',
   product_id: 'pdt_abc123',
   activations_limit: 5,
   expires_at: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
@@ -533,12 +534,17 @@ export async function POST(req: NextRequest) {
     });
 
     if (event.type === 'entitlement_grant.delivered') {
-      const { customer_id, license_key, external_id } = event.data;
+      const { customer_id, id, license_key } = event.data;
+
+      // Delivered grants for other entitlement types do not include a license key.
+      if (!license_key) {
+        return NextResponse.json({ received: true });
+      }
 
       // Store in your database
       await prisma.license.create({
         data: {
-          externalId: external_id,
+          externalId: id,
           key: license_key.key,
           customerId: customer_id,
           expiresAt: license_key.expires_at ? new Date(license_key.expires_at) : null,
@@ -564,7 +570,7 @@ export async function POST(req: NextRequest) {
 
       for (const licenseKeyId of licenseKeyIds) {
         await client.licenseKeys.update(licenseKeyId, {
-          status: 'disabled',
+          disabled: true,
         });
       }
     }

--- a/dodo-payments/license-keys/SKILL.md
+++ b/dodo-payments/license-keys/SKILL.md
@@ -5,71 +5,45 @@ description: Guide for implementing license key management with Dodo Payments - 
 
 # Dodo Payments License Keys
 
-**Reference: [docs.dodopayments.com/features/license-keys](https://docs.dodopayments.com/features/license-keys)**
-
 License keys authorize access to your digital products. Use them for software licensing, per-seat controls, and gating premium features.
 
----
+## When to use this skill
 
-## Overview
+- Implementing end-user license activation and validation flows
+- Building merchant dashboards to manage customer license keys
+- Handling license expiry, activation limits, and subscription-linked revocation
+- Integrating license checks into desktop apps, CLIs, or web services
+- Reacting to license lifecycle webhooks
 
-License keys are unique tokens that:
-- Authorize access to software, plugins, CLIs
-- Limit activations per user or device
-- Gate downloads, updates, or premium features
-- Can be linked to subscriptions or one-time purchases
+## Core concepts
 
----
+**License Key Entitlements** deliver keys when a product is purchased. The entitlement config supplies activation limits, optional duration, and fulfillment mode (auto or manual).
 
-## Creating License Keys
+**Three distinct resources:**
 
-### In Dashboard
+1. **`client.licenses.*`** — end-user activation flow (public, no API key required)
+   - `activate()` — activate a key on a device
+   - `validate()` — check if a key is valid
+   - `deactivate()` — free an activation slot
 
-1. Go to Dashboard → License Keys
-2. Click "Create License Key"
-3. Configure settings:
-   - **Expiry Date**: Duration or "no expiry" for perpetual
-   - **Activation Limit**: Max concurrent activations (1, 5, unlimited)
-   - **Activation Instructions**: Steps for customers
+2. **`client.licenseKeys.*`** — merchant-side key management (requires API key)
+   - `list()`, `retrieve()`, `create()`, `update()` — manage keys for your customers
 
-4. Save the license key configuration
+3. **`client.licenseKeyInstances.*`** — per-device activation instances (requires API key)
+   - `list()`, `retrieve()`, `update()` — track active devices per key
 
-### Auto-Generation on Purchase
+**Activation limits:** blank/null means unlimited; otherwise it's the maximum concurrent activations. Attempting to activate beyond the limit returns `422`.
 
-License keys can be automatically generated when a product is purchased:
-
-1. Configure your product with license key settings
-2. When purchased, a key is generated and emailed to customer
-3. `license_key.created` webhook is fired
-
----
-
-## API Reference
-
-### Public Endpoints (No API Key Required)
-
-These endpoints can be called directly from client applications:
-
-| Endpoint | Description |
-|----------|-------------|
-| `POST /licenses/activate` | Activate a license key |
-| `POST /licenses/deactivate` | Deactivate an instance |
-| `POST /licenses/validate` | Check if key is valid |
-
-### Authenticated Endpoints (API Key Required)
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /license_keys` | List all license keys |
-| `GET /license_keys/:id` | Get license key details |
-| `PATCH /license_keys/:id` | Update license key |
-| `GET /license_key_instances` | List activation instances |
+**Expiry semantics:**
+- One-time-payment keys honor the entitlement duration.
+- Subscription-issued keys have no independent expiry; validity follows subscription state. On hold disables them temporarily; cancellation or expiry disables them permanently.
+- Imported keys use nullable `expires_at`; null means perpetual.
 
 ---
 
-## Implementation Examples
+## End-User Activation Flow
 
-### Activate a License Key
+### Activate a license key
 
 ```typescript
 import DodoPayments from 'dodopayments';
@@ -87,18 +61,21 @@ async function activateLicense(licenseKey: string, deviceName: string) {
     return {
       success: true,
       instanceId: response.id,
-      message: 'License activated successfully',
+      customerId: response.customer.customer_id,
+      productId: response.product.product_id,
     };
   } catch (error: any) {
-    return {
-      success: false,
-      message: error.message || 'Activation failed',
-    };
+    if (error.status === 422) {
+      return { success: false, error: 'Activation limit reached' };
+    }
+    return { success: false, error: error.message || 'Activation failed' };
   }
 }
 ```
 
-### Validate a License Key
+Response includes `id` (instance ID), `business_id`, `name`, `license_key_id`, `created_at`, customer details, and product details.
+
+### Validate a license key
 
 ```typescript
 import DodoPayments from 'dodopayments';
@@ -111,19 +88,16 @@ async function validateLicense(licenseKey: string) {
       license_key: licenseKey,
     });
 
-    return {
-      valid: response.valid,
-      activations: response.activations_count,
-      maxActivations: response.activations_limit,
-      expiresAt: response.expires_at,
-    };
+    return { valid: response.valid };
   } catch (error) {
     return { valid: false };
   }
 }
 ```
 
-### Deactivate a License
+Optional: pass `license_key_instance_id` to validate a specific instance.
+
+### Deactivate a license
 
 ```typescript
 import DodoPayments from 'dodopayments';
@@ -137,23 +111,119 @@ async function deactivateLicense(licenseKey: string, instanceId: string) {
       license_key_instance_id: instanceId,
     });
 
-    return { success: true, message: 'License deactivated' };
+    return { success: true };
   } catch (error: any) {
-    return { success: false, message: error.message };
+    return { success: false, error: error.message };
   }
 }
 ```
 
 ---
 
+## Merchant-Side Key Management
+
+### List customer license keys
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+async function listCustomerKeys(customerId: string) {
+  const keys = await client.licenseKeys.list({
+    customer_id: customerId,
+  });
+
+  return keys.items.map(key => ({
+    id: key.id,
+    key: key.key,
+    status: key.status,
+    expiresAt: key.expires_at,
+    activationsUsed: key.activations_used,
+    activationsLimit: key.activations_limit,
+  }));
+}
+```
+
+### Retrieve a single license key
+
+```typescript
+const key = await client.licenseKeys.retrieve('lk_abc123');
+
+console.log({
+  id: key.id,
+  key: key.key,
+  status: key.status,
+  expiresAt: key.expires_at,
+  activationsUsed: key.activations_used,
+  activationsLimit: key.activations_limit,
+});
+```
+
+### Update a license key
+
+```typescript
+// Disable a key or adjust its activation limit
+await client.licenseKeys.update('lk_abc123', {
+  status: 'disabled',
+  // or adjust activations_limit
+  activations_limit: 10,
+});
+```
+
+### Create a license key (manual issuance)
+
+```typescript
+const newKey = await client.licenseKeys.create({
+  customer_id: 'cus_abc123',
+  product_id: 'pdt_abc123',
+  activations_limit: 5,
+  expires_at: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+});
+
+console.log(newKey.key); // The actual license key string
+```
+
+---
+
+## List Activation Instances
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// List all instances for a specific license key
+for await (const instance of client.licenseKeyInstances.list({
+  license_key_id: 'lk_abc123',
+})) {
+  console.log({
+    id: instance.id,
+    name: instance.name,
+    createdAt: instance.created_at,
+  });
+}
+```
+
+Optional query fields: `page_size` (default 10, max 100), `page_number` (default 0), `license_key_id`, and `grant_id`.
+
+---
+
 ## Desktop App Integration
 
-### Electron App Example
+### Electron app example
 
 ```typescript
 // main/license.ts
 import Store from 'electron-store';
 import DodoPayments from 'dodopayments';
+import os from 'os';
 
 const store = new Store();
 const client = new DodoPayments();
@@ -166,21 +236,19 @@ interface LicenseInfo {
 
 export async function activateLicense(licenseKey: string): Promise<boolean> {
   try {
-    // Get device identifier
     const deviceName = `${os.hostname()} - ${os.platform()}`;
-    
+
     const response = await client.licenses.activate({
       license_key: licenseKey,
       name: deviceName,
     });
 
-    // Store license info locally
     const licenseInfo: LicenseInfo = {
       key: licenseKey,
       instanceId: response.id,
       activatedAt: new Date().toISOString(),
     };
-    
+
     store.set('license', licenseInfo);
     return true;
   } catch (error) {
@@ -191,7 +259,7 @@ export async function activateLicense(licenseKey: string): Promise<boolean> {
 
 export async function checkLicense(): Promise<boolean> {
   const license = store.get('license') as LicenseInfo | undefined;
-  
+
   if (!license) {
     return false;
   }
@@ -203,10 +271,10 @@ export async function checkLicense(): Promise<boolean> {
 
     return response.valid;
   } catch (error) {
-    // If offline, trust local license (with optional grace period)
+    // If offline, trust local license with a grace period
     const activatedAt = new Date(license.activatedAt);
     const daysSinceActivation = (Date.now() - activatedAt.getTime()) / (1000 * 60 * 60 * 24);
-    
+
     // Allow 30-day offline grace period
     return daysSinceActivation < 30;
   }
@@ -214,7 +282,7 @@ export async function checkLicense(): Promise<boolean> {
 
 export async function deactivateLicense(): Promise<boolean> {
   const license = store.get('license') as LicenseInfo | undefined;
-  
+
   if (!license) {
     return true;
   }
@@ -234,7 +302,7 @@ export async function deactivateLicense(): Promise<boolean> {
 }
 ```
 
-### React Component for License Input
+### React component for license input
 
 ```tsx
 // components/LicenseActivation.tsx
@@ -254,9 +322,8 @@ export function LicenseActivation({ onActivated }: Props) {
     setError(null);
 
     try {
-      // Call main process (Electron IPC)
       const success = await window.electronAPI.activateLicense(licenseKey);
-      
+
       if (success) {
         onActivated();
       } else {
@@ -273,7 +340,7 @@ export function LicenseActivation({ onActivated }: Props) {
     <div className="license-form">
       <h2>Activate Your License</h2>
       <p>Enter your license key to unlock all features.</p>
-      
+
       <input
         type="text"
         value={licenseKey}
@@ -281,16 +348,12 @@ export function LicenseActivation({ onActivated }: Props) {
         placeholder="XXXX-XXXX-XXXX-XXXX"
         disabled={loading}
       />
-      
+
       {error && <p className="error">{error}</p>}
-      
+
       <button onClick={handleActivate} disabled={loading || !licenseKey}>
         {loading ? 'Activating...' : 'Activate License'}
       </button>
-      
-      <a href="https://yoursite.com/purchase" target="_blank">
-        Don't have a license? Purchase here
-      </a>
     </div>
   );
 }
@@ -300,7 +363,7 @@ export function LicenseActivation({ onActivated }: Props) {
 
 ## CLI Tool Integration
 
-### Node.js CLI Example
+### Node.js CLI example
 
 ```typescript
 // src/license.ts
@@ -308,7 +371,18 @@ import Conf from 'conf';
 import DodoPayments from 'dodopayments';
 import { machineIdSync } from 'node-machine-id';
 
-const config = new Conf({ projectName: 'your-cli' });
+interface StoredLicense {
+  key: string;
+  instanceId: string;
+  machineId: string;
+}
+
+interface CliStore {
+  license?: StoredLicense;
+}
+
+// Typing the store keeps `config.get('license')` strongly typed at every call site.
+const config = new Conf<CliStore>({ projectName: 'your-cli' });
 const client = new DodoPayments();
 
 export async function activate(licenseKey: string): Promise<void> {
@@ -329,9 +403,7 @@ export async function activate(licenseKey: string): Promise<void> {
 
     console.log('License activated successfully!');
   } catch (error: any) {
-    if (error.status === 400) {
-      console.error('Invalid license key.');
-    } else if (error.status === 403) {
+    if (error.status === 422) {
       console.error('Activation limit reached. Deactivate another device first.');
     } else {
       console.error('Activation failed:', error.message);
@@ -341,7 +413,7 @@ export async function activate(licenseKey: string): Promise<void> {
 }
 
 export async function checkLicense(): Promise<boolean> {
-  const license = config.get('license') as any;
+  const license = config.get('license');
 
   if (!license) {
     return false;
@@ -359,7 +431,7 @@ export async function checkLicense(): Promise<boolean> {
 }
 
 export async function deactivate(): Promise<void> {
-  const license = config.get('license') as any;
+  const license = config.get('license');
 
   if (!license) {
     console.log('No active license found.');
@@ -379,7 +451,6 @@ export async function deactivate(): Promise<void> {
   }
 }
 
-// Middleware to check license before commands
 export function requireLicense() {
   return async () => {
     const valid = await checkLicense();
@@ -392,7 +463,7 @@ export function requireLicense() {
 }
 ```
 
-### CLI Commands
+### CLI commands
 
 ```typescript
 // src/cli.ts
@@ -419,7 +490,6 @@ program
     console.log(valid ? 'License: Active' : 'License: Not activated');
   });
 
-// Protected command example
 program
   .command('generate')
   .description('Generate something (requires license)')
@@ -435,150 +505,186 @@ program.parse();
 
 ## Webhook Integration
 
-### Handle License Key Creation
+### Handle license key delivery
+
+When a product with licensing enabled is purchased, an `entitlement_grant.delivered` webhook fires with the license key details:
 
 ```typescript
 // app/api/webhooks/dodo/route.ts
-export async function POST(req: NextRequest) {
-  const event = await req.json();
-
-  if (event.type === 'license_key.created') {
-    const { id, key, product_id, customer_id, expires_at } = event.data;
-
-    // Store in your database
-    await prisma.license.create({
-      data: {
-        externalId: id,
-        key: key,
-        productId: product_id,
-        customerId: customer_id,
-        expiresAt: expires_at ? new Date(expires_at) : null,
-        status: 'active',
-      },
-    });
-
-    // Optional: Send custom email with activation instructions
-    await sendLicenseEmail(customer_id, key, product_id);
-  }
-
-  return NextResponse.json({ received: true });
-}
-```
-
----
-
-## Server-Side Validation
-
-For sensitive operations, validate server-side with your API key:
-
-```typescript
-// app/api/validate-license/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
 });
 
 export async function POST(req: NextRequest) {
-  const { licenseKey } = await req.json();
-
   try {
-    // Get detailed license info (requires API key)
-    const licenses = await client.licenseKeys.list({
-      license_key: licenseKey,
+    const body = await req.text();
+    const event = client.webhooks.unwrap(body, {
+      headers: {
+        'webhook-id': req.headers.get('webhook-id') || '',
+        'webhook-signature': req.headers.get('webhook-signature') || '',
+        'webhook-timestamp': req.headers.get('webhook-timestamp') || '',
+      },
     });
 
-    if (licenses.items.length === 0) {
-      return NextResponse.json({ valid: false, error: 'License not found' });
+    if (event.type === 'entitlement_grant.delivered') {
+      const { customer_id, license_key, external_id } = event.data;
+
+      // Store in your database
+      await prisma.license.create({
+        data: {
+          externalId: external_id,
+          key: license_key.key,
+          customerId: customer_id,
+          expiresAt: license_key.expires_at ? new Date(license_key.expires_at) : null,
+          activationsLimit: license_key.activations_limit,
+          status: 'active',
+        },
+      });
+
+      // Send email with activation instructions
+      await sendLicenseEmail(customer_id, license_key.key);
     }
 
-    const license = licenses.items[0];
+    if (event.type === 'subscription.cancelled') {
+      const { customer_id } = event.data;
 
-    // Check various conditions
-    const valid = 
-      license.status === 'active' &&
-      (!license.expires_at || new Date(license.expires_at) > new Date());
+      // Revoke associated license keys
+      const licenses = await client.licenseKeys.list({ customer_id });
 
-    return NextResponse.json({
-      valid,
-      status: license.status,
-      activationsUsed: license.activations_count,
-      activationsLimit: license.activations_limit,
-      expiresAt: license.expires_at,
-    });
-  } catch (error: any) {
-    return NextResponse.json({ valid: false, error: error.message }, { status: 500 });
+      for (const license of licenses.items) {
+        await client.licenseKeys.update(license.id, {
+          status: 'disabled',
+        });
+      }
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error('Webhook error:', error);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 }
 ```
 
----
+**Webhook events:**
 
-## Best Practices
-
-### 1. Keep Limits Clear
-Choose sensible defaults for expiry and activations based on your product type.
-
-### 2. Guide Users
-Provide precise activation instructions:
-- "Paste the key in Settings → License"
-- "Run: `mycli activate <key>`"
-- Include self-serve documentation links
-
-### 3. Validate Server-Side
-For critical access control, always validate on your server before granting access.
-
-### 4. Handle Offline Gracefully
-Allow a grace period for offline use in desktop/CLI apps.
-
-### 5. Monitor Events
-Use webhooks to detect abuse patterns and automate revocations.
-
-### 6. Provide Easy Deactivation
-Let users deactivate devices themselves to manage their activation slots.
+- `entitlement_grant.delivered` — license key issued (current, recommended)
+- `entitlement_grant.revoked` — license key revoked
+- `license_key.created` — legacy event (still fires, but use `entitlement_grant.*` for new integrations)
 
 ---
 
-## Common Patterns
+## Common Mistakes
 
-### Feature Gating
+### 1. Validating only at install time
+
+Don't validate once and trust forever. Validate periodically (e.g., weekly) to catch revoked or expired keys.
 
 ```typescript
-async function canAccessFeature(feature: string, licenseKey: string) {
-  const { valid } = await validateLicense(licenseKey);
-  
-  if (!valid) return false;
+// Bad: validate once
+if (await validateLicense(key)) {
+  store.set('trusted', true);
+}
 
-  // Map features to license tiers
-  const featureTiers = {
-    'basic-export': ['starter', 'pro', 'enterprise'],
-    'advanced-export': ['pro', 'enterprise'],
-    'api-access': ['enterprise'],
-  };
-
-  const license = await getLicenseDetails(licenseKey);
-  return featureTiers[feature]?.includes(license.tier);
+// Good: validate on each startup
+const isValid = await validateLicense(key);
+if (!isValid) {
+  // Fail closed
+  process.exit(1);
 }
 ```
 
-### Subscription-Linked Licenses
+### 2. Not handling activation-limit errors
 
-When license is linked to a subscription:
+When a user hits the activation limit, they need a clear path to deactivate an old device.
 
 ```typescript
-// Handle subscription.cancelled webhook
-if (event.type === 'subscription.cancelled') {
-  const { customer_id } = event.data;
-  
-  // Disable associated license keys
-  const licenses = await client.licenseKeys.list({ customer_id });
-  
-  for (const license of licenses.items) {
-    await client.licenseKeys.update(license.id, {
-      status: 'disabled',
-    });
+try {
+  await client.licenses.activate({ license_key: key, name: deviceName });
+} catch (error: any) {
+  if (error.status === 422) {
+    // Show UI: "You've reached your activation limit. Deactivate a device first."
+    // Provide a list of active instances so they can choose which to remove.
   }
+}
+```
+
+### 3. Trusting client-side validation alone
+
+Always validate on your server before granting access to sensitive features.
+
+```typescript
+// Bad: trust the client
+if (localStorage.getItem('license_valid')) {
+  showPremiumFeature();
+}
+
+// Good: validate server-side
+const response = await fetch('/api/validate-license', {
+  method: 'POST',
+  body: JSON.stringify({ licenseKey }),
+});
+const { valid } = await response.json();
+if (valid) {
+  showPremiumFeature();
+}
+```
+
+### 4. Hardcoding license keys
+
+Never embed keys in client code or version control.
+
+```typescript
+// Bad
+const LICENSE_KEY = 'PRO-AAAA-BBBB-CCCC-DDDD';
+
+// Good
+const licenseKey = process.env.DODO_LICENSE_KEY;
+// or read from user input / secure storage
+```
+
+### 5. Not storing the instance ID
+
+The instance ID is required for deactivation. Store it alongside the key.
+
+```typescript
+// Bad: only store the key
+store.set('license_key', key);
+
+// Good: store both
+store.set('license', {
+  key,
+  instanceId: response.id,
+  activatedAt: new Date().toISOString(),
+});
+```
+
+### 6. Failing open on validation errors
+
+If validation fails (network error, server down), fail closed. Don't grant access.
+
+```typescript
+// Bad: assume valid if offline
+try {
+  const valid = await validateLicense(key);
+  return valid;
+} catch {
+  return true; // WRONG: grants access on error
+}
+
+// Good: fail closed, with optional grace period
+try {
+  const valid = await validateLicense(key);
+  return valid;
+} catch {
+  // Only trust local cache if within grace period
+  const lastValidated = store.get('last_validated_at');
+  const daysSince = (Date.now() - lastValidated) / (1000 * 60 * 60 * 24);
+  return daysSince < 30;
 }
 ```
 
@@ -586,6 +692,10 @@ if (event.type === 'subscription.cancelled') {
 
 ## Resources
 
-- [License Keys Documentation](https://docs.dodopayments.com/features/license-keys)
-- [API Reference](https://docs.dodopayments.com/api-reference/license-keys)
-- [Video Tutorial](https://www.youtube.com/watch?v=BNuLTXok8dQ)
+- [License Keys Guide](https://docs.dodopayments.com/features/license-keys)
+- [Activate License API](https://docs.dodopayments.com/api-reference/licenses/activate-license)
+- [Validate License API](https://docs.dodopayments.com/api-reference/licenses/validate-license)
+- [Deactivate License API](https://docs.dodopayments.com/api-reference/licenses/deactivate-license)
+- [License Key Instances API](https://docs.dodopayments.com/api-reference/licenses/get-license-key-instances)
+- [Entitlement Grant Webhooks](https://docs.dodopayments.com/developer-resources/webhooks/intents/entitlement-grant)
+- [Webhook Verification](https://docs.dodopayments.com/developer-resources/webhooks/verification)

--- a/dodo-payments/license-keys/SKILL.md
+++ b/dodo-payments/license-keys/SKILL.md
@@ -36,7 +36,7 @@ License keys authorize access to your digital products. Use them for software li
 
 **Expiry semantics:**
 - One-time-payment keys honor the entitlement duration.
-- Subscription-issued keys have no independent expiry; validity follows subscription state. On hold disables them temporarily; cancellation or expiry disables them permanently.
+- Subscription-issued keys have no independent expiry; validity follows subscription state. On hold disables them temporarily. An immediate cancellation disables them permanently, but when `cancel_at_next_billing_date` is set, keep them active until the subscription reaches the end of its term.
 - Imported keys use nullable `expires_at`; null means perpetual.
 
 ---
@@ -509,6 +509,8 @@ program.parse();
 
 When a product with licensing enabled is purchased, an `entitlement_grant.delivered` webhook fires with the license key details:
 
+Persist a local license-to-subscription association during fulfillment. Cancellation handling must query that association by `subscription_id`; filtering only by customer would also revoke keys for unrelated products or subscriptions.
+
 ```typescript
 // app/api/webhooks/dodo/route.ts
 import { NextRequest, NextResponse } from 'next/server';
@@ -549,14 +551,19 @@ export async function POST(req: NextRequest) {
       await sendLicenseEmail(customer_id, license_key.key);
     }
 
-    if (event.type === 'subscription.cancelled') {
-      const { customer_id } = event.data;
+    if (event.type === 'subscription.cancelled' || event.type === 'subscription.expired') {
+      const { subscription_id, cancel_at_next_billing_date } = event.data;
 
-      // Revoke associated license keys
-      const licenses = await client.licenseKeys.list({ customer_id });
+      // End-of-period cancellation keeps access active until the term expires.
+      if (event.type === 'subscription.cancelled' && cancel_at_next_billing_date) {
+        return NextResponse.json({ received: true });
+      }
 
-      for (const license of licenses.items) {
-        await client.licenseKeys.update(license.id, {
+      // Query your persisted license-to-subscription mapping.
+      const licenseKeyIds = await getLicenseKeyIdsForSubscription(subscription_id);
+
+      for (const licenseKeyId of licenseKeyIds) {
+        await client.licenseKeys.update(licenseKeyId, {
           status: 'disabled',
         });
       }
@@ -575,6 +582,8 @@ export async function POST(req: NextRequest) {
 - `entitlement_grant.delivered` — license key issued (current, recommended)
 - `entitlement_grant.revoked` — license key revoked
 - `license_key.created` — legacy event (still fires, but use `entitlement_grant.*` for new integrations)
+- `subscription.cancelled` — disable only this subscription's keys for immediate cancellation
+- `subscription.expired` — disable this subscription's keys when its term ends
 
 ---
 

--- a/dodo-payments/localized-pricing/SKILL.md
+++ b/dodo-payments/localized-pricing/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: localized-pricing
+description: Guide for implementing localized pricing, adaptive currency, and purchasing power parity with Dodo Payments
+---
+
+# Localized Pricing, Adaptive Currency, and PPP
+
+This skill covers three distinct mechanisms for pricing in multiple countries and currencies. Developers often confuse them. This skill disambiguates them, shows how to implement each, and explains their interactions with plan changes, proration, and tax.
+
+## When to use this skill
+
+- You need to set fixed prices for specific countries or currencies.
+- You want to offer live foreign-exchange conversion at checkout.
+- You're considering purchasing power parity discounts for emerging markets.
+- You're unsure whether to use localized pricing or adaptive currency.
+- You need to handle billing-country and currency resolution, fallback behavior, or plan changes with localized prices.
+
+## Core concepts
+
+### Three mechanisms, three purposes
+
+| Mechanism | What it does | Who controls it | When prices change |
+|---|---|---|---|
+| **Localized Pricing** | Developer sets fixed prices per country/currency | You (via API) | Only when you update them |
+| **Adaptive Currency** | Live FX conversion at checkout time | Dodo (live rates) | Every transaction, based on current rates |
+| **PPP Discounts** | Third-party tools generate discount codes for low-income regions | ParityDeals, Evendeals, or similar | Per tool's schedule |
+
+**Key distinction:** Localized prices are static. Adaptive currency is dynamic. PPP is a discount mechanism, not a pricing mode.
+
+### Localized Pricing
+
+Set fixed prices for specific countries and currencies. Once created, a localized price does not change unless you update it. It does not track exchange rates.
+
+Use localized pricing when you want predictable, region-specific pricing that you control.
+
+### Adaptive Currency
+
+Enable live foreign-exchange conversion at checkout. The customer sees their local currency, and Dodo converts the base price using current rates.
+
+Use adaptive currency when you want to offer checkout in any currency without manually setting prices for each one.
+
+### PPP (Purchasing Power Parity)
+
+Third-party services like ParityDeals or Evendeals generate discount codes for customers in low-income countries. These are not a native Dodo API feature. You integrate them by accepting the discount codes they generate and passing them to Dodo at checkout.
+
+Use PPP when you want to offer affordability-based discounts without building your own detection logic.
+
+## Product pricing mode
+
+Every product has a `pricing_mode` that determines how prices are resolved:
+
+- `by_country`: Dodo looks up a localized price by the customer's billing country.
+- `by_currency`: Dodo looks up a localized price by the customer's billing currency.
+
+Set the mode once per product via `client.products.update(...)`. You cannot mix modes on the same product.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// Set pricing mode to by_country
+await client.products.update('pdt_premium_plan', {
+  pricing_mode: 'by_country',
+});
+
+// Or by_currency
+await client.products.update('pdt_premium_plan', {
+  pricing_mode: 'by_currency',
+});
+```
+
+## Localized Pricing CRUD
+
+Localized prices are nested under products. All amounts are in the smallest currency unit (cents for USD, paise for INR).
+
+### Create a localized price
+
+```typescript
+// ₹999.00 for customers in India
+const localizedPrice = await client.products.localizedPrices.create('pdt_premium_plan', {
+  currency: 'INR',
+  country_code: 'IN',
+  amount: 99900, // 999.00 in paise
+});
+```
+
+### List localized prices for a product
+
+```typescript
+const prices = await client.products.localizedPrices.list('pdt_premium_plan');
+console.log(prices);
+```
+
+### Retrieve a specific localized price
+
+```typescript
+const price = await client.products.localizedPrices.retrieve('pdt_premium_plan', 'lp_abc123');
+console.log(price.amount, price.currency, price.country_code);
+```
+
+### Update a localized price
+
+```typescript
+await client.products.localizedPrices.update('pdt_premium_plan', 'lp_abc123', {
+  amount: 109900, // Update to ₹1099.00
+});
+```
+
+### Archive a localized price
+
+```typescript
+await client.products.localizedPrices.archive('pdt_premium_plan', 'lp_abc123');
+```
+
+Archived prices are soft-deleted. They no longer apply to new checkouts but remain in your history.
+
+## Adaptive Currency at checkout
+
+Enable adaptive currency by passing `billing_currency` to a checkout session. Dodo converts the base product price using live rates.
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    {
+      product_id: 'pdt_premium_plan',
+      quantity: 1,
+    },
+  ],
+  billing_currency: 'AED', // Customer sees price in AED
+  return_url: 'https://example.com/return',
+});
+
+// Redirect customer to checkout
+window.location.href = session.checkout_url;
+```
+
+Adaptive currency is also available on subscription creation and plan changes. Check the API reference for `billing_currency` support on the specific endpoint you're using.
+
+## Billing country and currency resolution
+
+Dodo resolves the customer's billing country and currency in this order:
+
+1. Explicit `billing_country` or `billing_currency` passed to checkout.
+2. Customer's stored address (if the customer exists in Dodo).
+3. IP geolocation (if available).
+4. Fallback to your product's base price and currency.
+
+If no localized price exists for the resolved country or currency, Dodo falls back to the base price. This fallback is automatic and does not raise an error.
+
+## Interaction with plan changes and proration
+
+When a customer changes plans, localized prices apply to the new plan using the same billing country or currency as the original subscription.
+
+Proration is calculated using the new plan's localized price (if one exists for the customer's country/currency).
+
+```typescript
+await client.subscriptions.changePlan('sub_abc123', {
+  product_id: 'pdt_enterprise_plan',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+});
+```
+
+The new plan's localized price is used for the prorated amount.
+
+## Tax behavior with localized pricing
+
+Tax is calculated on the localized price, not the base price. If you set a localized price of ₹999.00 for India, tax is applied to that amount.
+
+Tax-inclusive pricing works the same way: the localized price is treated as the tax-inclusive total.
+
+## Common mistakes
+
+### Mistake 1: Assuming localized prices auto-update with exchange rates
+
+Localized prices are fixed. If you set INR 999.00 today, it remains 999.00 until you manually update it. It does not track USD/INR rates.
+
+If you want live FX conversion, use adaptive currency instead.
+
+### Mistake 2: Confusing `by_country` and `by_currency`
+
+- `by_country`: Dodo matches the customer's billing country to a localized price's `country_code`.
+- `by_currency`: Dodo matches the customer's billing currency to a localized price's `currency`.
+
+A customer in India using a USD card will match `by_currency: USD` but not `by_country: IN` (unless you also set a USD price for India).
+
+### Mistake 3: Forgetting a fallback price
+
+If you set `pricing_mode: by_country` but don't create a localized price for a customer's country, Dodo falls back to the base price in the base currency. This is usually not what you want.
+
+Always create localized prices for your target markets before enabling the mode.
+
+### Mistake 4: Mixing localized pricing and adaptive currency
+
+You can use both on the same product, but they serve different purposes. Localized pricing is for fixed, region-specific prices. Adaptive currency is for live FX conversion.
+
+If you set a localized price for India and also enable adaptive currency, the localized price takes precedence for customers in India.
+
+### Mistake 5: Expecting PPP to be a native Dodo API
+
+PPP discounts are generated by third-party services like ParityDeals or Evendeals. Dodo does not have a built-in PPP API. You integrate PPP by accepting discount codes from these services and passing them to Dodo at checkout.
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_premium_plan', quantity: 1 }],
+  discount_codes: ['PPP_DISCOUNT_CODE_FROM_PARITY_DEALS'],
+  return_url: 'https://example.com/return',
+});
+```
+
+### Mistake 6: Not handling missing localized prices in production
+
+Always test your fallback behavior. If a customer's country or currency has no localized price, they see the base price. Decide whether that's acceptable or whether you need to block checkout for unsupported regions.
+
+## Resources
+
+- [Localized Pricing](https://docs.dodopayments.com/features/localized-pricing)
+- [Adaptive Currency](https://docs.dodopayments.com/features/adaptive-currency)
+- [Purchasing Power Parity](https://docs.dodopayments.com/features/purchasing-power-parity)
+- [Checkout Sessions API](https://docs.dodopayments.com/developer-resources/checkout-session)
+- [Products API](https://docs.dodopayments.com/api-reference/products/post-products)

--- a/dodo-payments/localized-pricing/SKILL.md
+++ b/dodo-payments/localized-pricing/SKILL.md
@@ -98,14 +98,17 @@ console.log(prices);
 ### Retrieve a specific localized price
 
 ```typescript
-const price = await client.products.localizedPrices.retrieve('pdt_premium_plan', 'lp_abc123');
+const price = await client.products.localizedPrices.retrieve('lp_abc123', {
+  product_id: 'pdt_premium_plan',
+});
 console.log(price.amount, price.currency, price.country_code);
 ```
 
 ### Update a localized price
 
 ```typescript
-await client.products.localizedPrices.update('pdt_premium_plan', 'lp_abc123', {
+await client.products.localizedPrices.update('lp_abc123', {
+  product_id: 'pdt_premium_plan',
   amount: 109900, // Update to ₹1099.00
 });
 ```
@@ -113,7 +116,9 @@ await client.products.localizedPrices.update('pdt_premium_plan', 'lp_abc123', {
 ### Archive a localized price
 
 ```typescript
-await client.products.localizedPrices.archive('pdt_premium_plan', 'lp_abc123');
+await client.products.localizedPrices.archive('lp_abc123', {
+  product_id: 'pdt_premium_plan',
+});
 ```
 
 Archived prices are soft-deleted. They no longer apply to new checkouts but remain in your history.
@@ -144,7 +149,7 @@ Adaptive currency is also available on subscription creation and plan changes. C
 
 Dodo resolves the customer's billing country and currency in this order:
 
-1. Explicit `billing_country` or `billing_currency` passed to checkout.
+1. Explicit `billing_address.country` or `billing_currency` passed to checkout.
 2. Customer's stored address (if the customer exists in Dodo).
 3. IP geolocation (if available).
 4. Fallback to your product's base price and currency.

--- a/dodo-payments/mobile-checkout/SKILL.md
+++ b/dodo-payments/mobile-checkout/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for implementing mobile in-app checkout with Dodo Payments ac
 
 # Mobile In-App Checkout
 
-This skill covers integrating Dodo Payments checkout into native and cross-platform mobile apps. It applies when you're building iOS, Android, React Native, or Flutter applications that need to accept payments without redirecting to a web browser.
+This skill covers integrating Dodo Payments hosted checkout into native and cross-platform mobile apps using secure system browser contexts.
 
 ## When to use this skill
 
@@ -24,7 +24,7 @@ Your backend creates the checkout session and returns a URL. The mobile app open
 
 1. **Backend:** Create a checkout session via `client.checkoutSessions.create(...)` and return the `checkout_url` to your mobile app.
 2. **Mobile app:** Call the platform-specific SDK with the checkout URL and a registered return URL scheme.
-3. **Browser context:** The SDK opens the URL in SFSafariViewController (iOS), Chrome Custom Tabs (Android), or a native webview (React Native/Flutter).
+3. **Browser context:** The SDK opens the URL in a secure system browser: SFSafariViewController on iOS and Chrome Custom Tabs on Android.
 4. **Return:** After payment, the browser navigates to your return URL. The SDK captures the result and passes it to your app.
 5. **Verification:** Query the checkout session or listen for a webhook to confirm the payment before granting access.
 
@@ -127,35 +127,49 @@ Add the Dodo Payments Flutter package to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  dodo_payments_flutter: ^1.0.0
+  dodopayments_checkout: ^1.0.2
 ```
 
 ### Setup
 
-Register the deep-link handler in your main app:
+The package uses `DodoCheckout.instance`. On iOS, register the return URL scheme and forward incoming links from your deep-link listener. Run `flutter pub add app_links` if you use the `app_links` approach shown here:
 
 ```dart
-import 'package:dodo_payments_flutter/dodo_payments_flutter.dart';
+import 'dart:async';
 
-void main() {
-  DodoCheckout.handleDeepLink();
-  runApp(MyApp());
+import 'package:app_links/app_links.dart';
+import 'package:dodopayments_checkout/dodopayments_checkout.dart';
+
+late final StreamSubscription<Uri> checkoutLinkSubscription;
+
+void listenForCheckoutReturns() {
+  checkoutLinkSubscription = AppLinks().uriLinkStream.listen((uri) {
+    unawaited(DodoCheckout.instance.handleOpenURL(uri.toString()));
+  });
 }
 ```
+
+Start the listener from your root state object's `initState` and cancel `checkoutLinkSubscription` from `dispose`. `handleOpenURL` is required on iOS and safely returns `false` on Android.
 
 ### Starting checkout
 
 ```dart
-import 'package:dodo_payments_flutter/dodo_payments_flutter.dart';
+import 'package:dodopayments_checkout/dodopayments_checkout.dart';
 
-final result = await DodoCheckout.start(
-  checkoutUrl: 'https://checkout.dodopayments.com/...',
-  returnUrl: 'myapp://checkout/return',
+final result = await DodoCheckout.instance.start(
+  CheckoutParams(
+    checkoutUrl: Uri.parse('https://checkout.dodopayments.com/...'),
+    returnUrl: Uri.parse('myapp://checkout/return'),
+    onEvent: (event) => print(event.type),
+  ),
 );
 
 switch (result.status) {
   case CheckoutStatus.succeeded:
-    await verifyPaymentOnBackend(result.paymentId);
+    final paymentId = result.paymentId;
+    if (paymentId != null) {
+      await verifyPaymentOnBackend(paymentId);
+    }
     showSuccess();
     break;
   case CheckoutStatus.failed:
@@ -173,22 +187,22 @@ switch (result.status) {
 }
 ```
 
-### Deep-link registration
+### Return URL registration
 
-In `android/app/src/main/AndroidManifest.xml`:
+On Android, set the callback scheme in `android/app/build.gradle.kts`. The package's native checkout dependency supplies the intent filter, so do not add one manually:
 
-```xml
-<activity android:name=".MainActivity">
-  <intent-filter>
-    <action android:name="android.intent.action.VIEW" />
-    <category android:name="android.intent.category.DEFAULT" />
-    <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="myapp" android:host="checkout" android:path="/return" />
-  </intent-filter>
-</activity>
+```kotlin
+android {
+  defaultConfig {
+    minSdk = 23
+    manifestPlaceholders["dodoCallbackScheme"] = "myapp"
+  }
+}
 ```
 
-In `ios/Runner/Info.plist`:
+Remove an empty `android:taskAffinity=""` from `MainActivity` if the generated Flutter manifest contains it; it can prevent Custom Tabs from returning correctly on some devices.
+
+On iOS, register the same scheme in `ios/Runner/Info.plist`:
 
 ```xml
 <key>CFBundleURLTypes</key>
@@ -386,10 +400,9 @@ Query the checkout session to confirm payment:
 ```typescript
 const session = await client.checkoutSessions.retrieve(sessionId);
 
-if (session.status === 'succeeded') {
-  const paymentId = session.payment_id;
-  // Grant access
-  await grantAccess(customerId);
+if (session.payment_status === 'succeeded' && session.payment_id) {
+  const payment = await client.payments.retrieve(session.payment_id);
+  await grantAccess(payment.customer.customer_id);
 }
 ```
 
@@ -495,13 +508,14 @@ if (abandoned) {
 }
 ```
 
-## Package name note
+## Package names
 
-The research documents `@dodopayments/react-native-checkout` as the official React Native package. Older references may mention `@dodopayments/react-native`, which does not exist on npm. Use `@dodopayments/react-native-checkout`.
+Use `@dodopayments/react-native-checkout` for React Native and `dodopayments_checkout` for Flutter. The similarly named `@dodopayments/react-native` and `dodo_payments_flutter` packages do not exist.
 
 ## Resources
 
 - [Mobile Integration](https://docs.dodopayments.com/developer-resources/mobile-integration)
 - [React Native SDK](https://docs.dodopayments.com/developer-resources/sdks/react-native)
+- [Flutter SDK](https://pub.dev/packages/dodopayments_checkout)
 - [Selling Digital Goods on iOS](https://docs.dodopayments.com/features/appstore-digital-goods)
 - [Webhook Integration](https://docs.dodopayments.com/developer-resources/webhooks/intents) (for payment verification)

--- a/dodo-payments/mobile-checkout/SKILL.md
+++ b/dodo-payments/mobile-checkout/SKILL.md
@@ -1,0 +1,496 @@
+---
+name: mobile-checkout
+description: Guide for implementing mobile in-app checkout with Dodo Payments across React Native, Flutter, iOS, and Android platforms.
+---
+
+# Mobile In-App Checkout
+
+This skill covers integrating Dodo Payments checkout into native and cross-platform mobile apps. It applies when you're building iOS, Android, React Native, or Flutter applications that need to accept payments without redirecting to a web browser.
+
+## When to use this skill
+
+- Building a React Native app with Turbo Module checkout integration
+- Adding checkout to a Flutter app via native bridge
+- Implementing iOS checkout with SFSafariViewController
+- Implementing Android checkout with Chrome Custom Tabs
+- Registering custom URL schemes and deep links for payment return
+- Handling abandoned checkout sessions and recovery flows
+- Confirming payment authority server-side before granting access
+
+## Core principle: Backend creates, mobile opens
+
+Your backend creates the checkout session and returns a URL. The mobile app opens that URL in a secure browser context. Your API key must never be embedded in the app binary. The mobile SDK result is informational only; always verify the payment server-side via webhook or API before unlocking features or granting access.
+
+## Architecture overview
+
+1. **Backend:** Create a checkout session via `client.checkoutSessions.create(...)` and return the `checkout_url` to your mobile app.
+2. **Mobile app:** Call the platform-specific SDK with the checkout URL and a registered return URL scheme.
+3. **Browser context:** The SDK opens the URL in SFSafariViewController (iOS), Chrome Custom Tabs (Android), or a native webview (React Native/Flutter).
+4. **Return:** After payment, the browser navigates to your return URL. The SDK captures the result and passes it to your app.
+5. **Verification:** Query the checkout session or listen for a webhook to confirm the payment before granting access.
+
+## React Native (Turbo Module)
+
+### Installation
+
+```bash
+npm install @dodopayments/react-native-checkout
+```
+
+For Expo projects, add the plugin to `app.json`:
+
+```json
+{
+  "expo": {
+    "scheme": "myapp",
+    "plugins": [
+      [
+        "@dodopayments/react-native-checkout",
+        { "scheme": "myappcheckout" }
+      ]
+    ]
+  }
+}
+```
+
+The plugin registers a custom URL scheme (`myappcheckout://`) that the checkout flow uses to return to your app.
+
+### Setup
+
+Register the URL listener at app startup:
+
+```typescript
+import { Linking } from 'react-native';
+import { DodoCheckout } from '@dodopayments/react-native-checkout';
+
+// Required for iOS return-URL handling
+Linking.addEventListener('url', ({ url }) => DodoCheckout.handleOpenURL(url));
+```
+
+### Starting checkout
+
+```typescript
+const result = await DodoCheckout.start({
+  checkoutUrl: 'https://checkout.dodopayments.com/...',  // from your backend
+  returnUrl: 'myappcheckout://checkout/return',          // must match registered scheme
+  onEvent: (e) => console.log(e.type),                   // optional event logging
+});
+
+switch (result.status) {
+  case 'succeeded':
+    // Payment succeeded. Verify server-side before granting access.
+    await verifyPaymentOnBackend(result.paymentId);
+    showSuccess();
+    break;
+  case 'failed':
+    // Payment failed. Show error to user.
+    showFailure();
+    break;
+  case 'cancelled':
+    // User cancelled. Dismiss checkout.
+    dismiss();
+    break;
+  case 'pending':
+    // Payment is pending (e.g., awaiting 3D Secure). Show waiting state.
+    showPending();
+    break;
+  case 'expired':
+    // Checkout session expired. Prompt user to start a new checkout.
+    showExpired();
+    break;
+}
+```
+
+### Abandoned session recovery
+
+If the app crashes or is backgrounded during checkout, recover the session:
+
+```typescript
+import { DodoCheckout } from '@dodopayments/react-native-checkout';
+
+const abandoned = await DodoCheckout.getAbandonedSession();
+if (abandoned) {
+  // Reconcile abandoned.sessionId with your backend
+  // Decide whether to resume or start fresh
+  await DodoCheckout.clearAbandonedSession();
+}
+```
+
+### Android minSdk requirement
+
+React Native checkout requires Android minSdk 24 or higher. Note: the general mobile documentation mentions minSdk 23, but React Native specifically requires 24.
+
+## Flutter
+
+### Installation
+
+Add the Dodo Payments Flutter package to `pubspec.yaml`:
+
+```yaml
+dependencies:
+  dodo_payments_flutter: ^1.0.0
+```
+
+### Setup
+
+Register the deep-link handler in your main app:
+
+```dart
+import 'package:dodo_payments_flutter/dodo_payments_flutter.dart';
+
+void main() {
+  DodoCheckout.handleDeepLink();
+  runApp(MyApp());
+}
+```
+
+### Starting checkout
+
+```dart
+import 'package:dodo_payments_flutter/dodo_payments_flutter.dart';
+
+final result = await DodoCheckout.start(
+  checkoutUrl: 'https://checkout.dodopayments.com/...',
+  returnUrl: 'myapp://checkout/return',
+);
+
+switch (result.status) {
+  case CheckoutStatus.succeeded:
+    await verifyPaymentOnBackend(result.paymentId);
+    showSuccess();
+    break;
+  case CheckoutStatus.failed:
+    showFailure();
+    break;
+  case CheckoutStatus.cancelled:
+    dismiss();
+    break;
+  case CheckoutStatus.pending:
+    showPending();
+    break;
+  case CheckoutStatus.expired:
+    showExpired();
+    break;
+}
+```
+
+### Deep-link registration
+
+In `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<activity android:name=".MainActivity">
+  <intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="myapp" android:host="checkout" android:path="/return" />
+  </intent-filter>
+</activity>
+```
+
+In `ios/Runner/Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+## iOS (native)
+
+### Setup
+
+Use `SFSafariViewController` to open the checkout URL:
+
+```swift
+import SafariServices
+
+let checkoutURL = URL(string: "https://checkout.dodopayments.com/...")!
+let safariVC = SFSafariViewController(url: checkoutURL)
+present(safariVC, animated: true)
+```
+
+### Deep-link handling
+
+Register your custom URL scheme in `Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+Handle the return in your app delegate:
+
+```swift
+func application(
+  _ app: UIApplication,
+  open url: URL,
+  options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+) -> Bool {
+  if url.scheme == "myapp" && url.host == "checkout" {
+    // Parse the result from the URL query parameters
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let status = components?.queryItems?.first(where: { $0.name == "status" })?.value
+    
+    switch status {
+    case "succeeded":
+      let paymentId = components?.queryItems?.first(where: { $0.name == "payment_id" })?.value
+      verifyPaymentOnBackend(paymentId: paymentId)
+    case "cancelled":
+      dismiss()
+    case "expired":
+      showExpired()
+    default:
+      break
+    }
+    return true
+  }
+  return false
+}
+```
+
+## Android (native)
+
+### Setup
+
+Use Chrome Custom Tabs to open the checkout URL:
+
+```kotlin
+import androidx.browser.customtabs.CustomTabsIntent
+import android.net.Uri
+
+val checkoutUri = Uri.parse("https://checkout.dodopayments.com/...")
+val customTabsIntent = CustomTabsIntent.Builder().build()
+customTabsIntent.launchUrl(context, checkoutUri)
+```
+
+### Deep-link handling
+
+Register your custom URL scheme in `AndroidManifest.xml`:
+
+```xml
+<activity android:name=".CheckoutReturnActivity">
+  <intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="myapp" android:host="checkout" android:path="/return" />
+  </intent-filter>
+</activity>
+```
+
+Handle the return in your activity:
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+  super.onCreate(savedInstanceState)
+  
+  val uri = intent.data
+  if (uri?.scheme == "myapp" && uri.host == "checkout") {
+    val status = uri.getQueryParameter("status")
+    val paymentId = uri.getQueryParameter("payment_id")
+    
+    when (status) {
+      "succeeded" -> verifyPaymentOnBackend(paymentId)
+      "cancelled" -> dismiss()
+      "expired" -> showExpired()
+    }
+  }
+}
+```
+
+## Backend: Creating checkout sessions
+
+Always create checkout sessions on your backend. Never embed your API key in the mobile app.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+app.post('/api/mobile-checkout', async (req, res) => {
+  const { customerId, productId } = req.body;
+  
+  const session = await client.checkoutSessions.create({
+    product_cart: [{ product_id: productId, quantity: 1 }],
+    customer_id: customerId,
+    return_url: 'myapp://checkout/return',
+  });
+  
+  res.json({ checkout_url: session.checkout_url });
+});
+```
+
+## Verifying payment server-side
+
+Never grant access based on the mobile SDK result alone. Always verify via webhook or API.
+
+### Via webhook
+
+Listen for `payment.succeeded` webhooks. Webhook signature verification is covered in the `webhook-integration` skill.
+
+```typescript
+app.post('/webhook', async (req, res) => {
+  const event = client.webhooks.unwrap(req.body.toString(), {
+    headers: {
+      'webhook-id': req.headers['webhook-id'] as string,
+      'webhook-signature': req.headers['webhook-signature'] as string,
+      'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+    },
+  });
+  
+  if (event.type === 'payment.succeeded') {
+    const paymentId = event.data.payment_id;
+    const customerId = event.data.customer_id;
+    
+    // Grant access to the customer
+    await grantAccess(customerId);
+  }
+  
+  res.json({ received: true });
+});
+```
+
+### Via API
+
+Query the checkout session to confirm payment:
+
+```typescript
+const session = await client.checkoutSessions.retrieve(sessionId);
+
+if (session.status === 'succeeded') {
+  const paymentId = session.payment_id;
+  // Grant access
+  await grantAccess(customerId);
+}
+```
+
+## Selling digital goods on iOS
+
+If you're selling digital goods (software, in-app features, subscriptions) on iOS, Apple requires you to use in-app purchase APIs for certain categories. Dodo Payments can handle the payment processing, but you must comply with App Store guidelines:
+
+- Digital content (ebooks, music, software) must use in-app purchase.
+- Physical goods and services can use alternative payment methods.
+- Subscriptions for digital content must use in-app purchase.
+
+Consult Apple's App Store Review Guidelines and consider whether your product category requires in-app purchase. If it does, integrate StoreKit 2 alongside Dodo Payments for compliance.
+
+## Common mistakes
+
+### Embedding the API key in the app
+
+Never include your API key in the app binary or client-side code. Always create checkout sessions on your backend.
+
+```typescript
+// WRONG
+const client = new DodoPayments({
+  bearerToken: 'dodo_live_abc123...',  // Never hardcode
+});
+
+// CORRECT
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,  // Backend only
+});
+```
+
+### Trusting the mobile SDK result
+
+The SDK result is informational. Always verify server-side before granting access.
+
+```typescript
+// WRONG
+if (result.status === 'succeeded') {
+  grantAccess();  // No verification
+}
+
+// CORRECT
+if (result.status === 'succeeded') {
+  const verified = await verifyPaymentOnBackend(result.paymentId);
+  if (verified) {
+    grantAccess();
+  }
+}
+```
+
+### Forgetting URL scheme registration
+
+If you don't register the custom URL scheme, the app won't receive the return callback and checkout will appear to hang.
+
+- React Native: Use the Expo plugin or manually register in `Info.plist` and `AndroidManifest.xml`.
+- Flutter: Register in both `Info.plist` and `AndroidManifest.xml`.
+- iOS: Add `CFBundleURLTypes` to `Info.plist`.
+- Android: Add an intent filter with the scheme in `AndroidManifest.xml`.
+
+### Not handling all result statuses
+
+Always handle all five statuses: `succeeded`, `failed`, `cancelled`, `pending`, and `expired`. Each requires different UX.
+
+```typescript
+// WRONG
+if (result.status === 'succeeded') {
+  showSuccess();
+}
+
+// CORRECT
+switch (result.status) {
+  case 'succeeded':
+    showSuccess();
+    break;
+  case 'failed':
+    showFailure();
+    break;
+  case 'cancelled':
+    dismiss();
+    break;
+  case 'pending':
+    showPending();
+    break;
+  case 'expired':
+    showExpired();
+    break;
+}
+```
+
+### Ignoring abandoned sessions
+
+If the app crashes or is backgrounded during checkout, the session is abandoned. Always check for and recover abandoned sessions on app startup.
+
+```typescript
+// WRONG
+// No recovery logic
+
+// CORRECT
+const abandoned = await DodoCheckout.getAbandonedSession();
+if (abandoned) {
+  // Reconcile and clear
+  await DodoCheckout.clearAbandonedSession();
+}
+```
+
+## Package name note
+
+The research documents `@dodopayments/react-native-checkout` as the official React Native package. Older references may mention `@dodopayments/react-native`, which does not exist on npm. Use `@dodopayments/react-native-checkout`.
+
+## Resources
+
+- [Mobile Integration](https://docs.dodopayments.com/developer-resources/mobile-integration)
+- [React Native SDK](https://docs.dodopayments.com/developer-resources/sdks/react-native)
+- [Selling Digital Goods on iOS](https://docs.dodopayments.com/features/appstore-digital-goods)
+- [Webhook Integration](https://docs.dodopayments.com/developer-resources/webhooks/intents) (for payment verification)

--- a/dodo-payments/mobile-checkout/SKILL.md
+++ b/dodo-payments/mobile-checkout/SKILL.md
@@ -11,8 +11,7 @@ This skill covers integrating Dodo Payments checkout into native and cross-platf
 
 - Building a React Native app with Turbo Module checkout integration
 - Adding checkout to a Flutter app via native bridge
-- Implementing iOS checkout with SFSafariViewController
-- Implementing Android checkout with Chrome Custom Tabs
+- Implementing native iOS or Android checkout with secure browser contexts
 - Registering custom URL schemes and deep links for payment return
 - Handling abandoned checkout sessions and recovery flows
 - Confirming payment authority server-side before granting access
@@ -325,12 +324,24 @@ const client = new DodoPayments({
   environment: 'test_mode',
 });
 
-app.post('/api/mobile-checkout', async (req, res) => {
-  const { customerId, productId } = req.body;
+const MOBILE_PRODUCTS = new Map([
+  ['starter', 'pdt_starter123'],
+  ['pro', 'pdt_pro456'],
+]);
+
+app.post('/api/mobile-checkout', requireAuth, async (req, res) => {
+  const productId = MOBILE_PRODUCTS.get(req.body.plan);
+
+  if (!productId) {
+    return res.status(400).json({ error: 'Invalid plan' });
+  }
+
+  // requireAuth derives this mapping from the authenticated server-side session.
+  const customerId = req.auth.dodoCustomerId;
   
   const session = await client.checkoutSessions.create({
     product_cart: [{ product_id: productId, quantity: 1 }],
-    customer_id: customerId,
+    customer: { customer_id: customerId },
     return_url: 'myapp://checkout/return',
   });
   
@@ -358,7 +369,7 @@ app.post('/webhook', async (req, res) => {
   
   if (event.type === 'payment.succeeded') {
     const paymentId = event.data.payment_id;
-    const customerId = event.data.customer_id;
+    const customerId = event.data.customer.customer_id;
     
     // Grant access to the customer
     await grantAccess(customerId);

--- a/dodo-payments/product-catalog-management/SKILL.md
+++ b/dodo-payments/product-catalog-management/SKILL.md
@@ -20,7 +20,7 @@ This skill covers the full product lifecycle: creating products with pricing mod
 **Product model:** Every product has exactly one pricing model selected at creation. The three models are:
 
 - `one_time_price`: charge once per purchase.
-- `recurring_price`: charge on a billing cycle (daily, weekly, monthly, yearly).
+- `recurring_price`: charge on a configurable payment frequency and subscription period.
 - `usage_based_price`: charge per unit consumed (see `usage-based-billing` skill for meter setup).
 
 Pricing is nested inside the product object. There is no separate top-level Price resource.
@@ -32,7 +32,7 @@ Pricing is nested inside the product object. There is no separate top-level Pric
 - `price`: amount in the smallest currency unit (cents for USD).
 - `discount`: optional discount amount in the same unit.
 
-**Tax category:** Required at product creation. Dodo uses this to calculate and collect sales tax. Common values include `digital_products`, `physical_goods`, `services`. Consult your tax jurisdiction or the Dodo dashboard for the full list.
+**Tax category:** Required at product creation. Dodo uses this to calculate and collect sales tax. Supported values are `digital_products`, `saas`, `e_book`, and `edtech`.
 
 **Lifecycle:** Products support `list`, `retrieve`, `update`, and `archive`/`unarchive`. There is no delete endpoint. Archived products remain in your history but don't appear in new checkouts.
 
@@ -61,10 +61,11 @@ const product = await client.products.create({
     currency: 'USD',
     price: 9900, // $99.00
     discount: 0,
+    purchasing_power_parity: false,
   },
 });
 
-console.log(product.id); // pdt_...
+console.log(product.product_id); // pdt_...
 ```
 
 For recurring products, specify the billing cycle:
@@ -72,13 +73,17 @@ For recurring products, specify the billing cycle:
 ```typescript
 const subscription = await client.products.create({
   name: 'Premium Plan',
-  tax_category: 'services',
+  tax_category: 'saas',
   price: {
     type: 'recurring_price',
     currency: 'USD',
     price: 2999, // $29.99/month
     discount: 0,
-    billing_cycle: 'monthly',
+    payment_frequency_count: 1,
+    payment_frequency_interval: 'Month',
+    subscription_period_count: 1,
+    subscription_period_interval: 'Month',
+    purchasing_power_parity: false,
   },
 });
 ```
@@ -88,7 +93,7 @@ This skill is the canonical source for product creation request shapes. For a us
 ```typescript
 const metered = await client.products.create({
   name: 'API Calls',
-  tax_category: 'services',
+  tax_category: 'saas',
   price: {
     type: 'usage_based_price',
     currency: 'USD',
@@ -157,7 +162,7 @@ import fs from 'node:fs';
 
 // Request a presigned upload URL
 const uploadUrl = await client.products.images.update('pdt_pro_bundle', {
-  filename: 'product.png',
+  force_update: true,
 });
 
 // Upload immediately (within 60 seconds)
@@ -180,19 +185,13 @@ Add-ons are optional extras customers can purchase alongside a product. Create t
 // Create an add-on
 const addon = await client.addons.create({
   name: 'Priority Support',
-  tax_category: 'services',
-  price: {
-    type: 'one_time_price',
-    currency: 'USD',
-    price: 4900, // $49.00
-    discount: 0,
-  },
+  tax_category: 'saas',
+  currency: 'USD',
+  price: 4900, // $49.00
 });
 
 // Upload an image for the add-on
-const addonImageUrl = await client.addons.images.update(addon.id, {
-  filename: 'addon.png',
-});
+const addonImageUrl = await client.addons.updateImages(addon.id);
 
 // List add-ons
 const addons = await client.addons.list();
@@ -207,14 +206,23 @@ Group products into collections for themed checkouts. Collections have nested gr
 const collection = await client.productCollections.create({
   name: 'Starter Bundle',
   description: 'Everything you need to get started',
+  groups: [
+    {
+      group_name: 'Core Tools',
+      products: [
+        { product_id: 'pdt_tool_a' },
+        { product_id: 'pdt_tool_b' },
+      ],
+    },
+  ],
 });
 
-// Add groups and items
+// Add another group later
 await client.productCollections.groups.create(collection.id, {
-  name: 'Core Tools',
-  items: [
-    { product_id: 'pdt_tool_a', quantity: 1 },
-    { product_id: 'pdt_tool_b', quantity: 1 },
+  group_name: 'Optional Tools',
+  products: [
+    { product_id: 'pdt_tool_c' },
+    { product_id: 'pdt_tool_d' },
   ],
 });
 
@@ -236,24 +244,30 @@ Entitlements grant customers access to downloadable files. Create an entitlement
 // Create an entitlement
 const entitlement = await client.entitlements.create({
   name: 'Pro Bundle Files',
+  integration_type: 'digital_files',
+  integration_config: {
+    digital_file_ids: [],
+  },
 });
 
-// Upload a file
-await client.entitlements.files.upload(entitlement.id, {
-  file: fs.createReadStream('./pro-bundle.zip'),
-  filename: 'pro-bundle.zip',
+// Upload and attach a file; the response identifies the attached file
+const { file_id } = await client.entitlements.files.upload(entitlement.id);
+
+// Attach the entitlement to a product
+await client.products.update('pdt_pro_bundle', {
+  entitlements: [{ entitlement_id: entitlement.id }],
 });
 
-// Grant access to a customer
-await client.entitlements.grants.create(entitlement.id, {
-  customer_id: 'cus_customer_123',
-});
+// A grant is produced by fulfillment when the customer purchases the product.
+// Grants can be listed, revoked, or fulfilled with a manually managed license key;
+// they cannot be created directly through the SDK.
 
 // List grants for a customer
 const grants = await client.customers.listEntitlementGrants('cus_customer_123');
 
 // Generate a download URL (valid for roughly 15 minutes)
-const downloadUrl = grants[0].download_url;
+const grant = grants.items[0];
+const downloadUrl = grant?.digital_product_delivery?.files[0]?.download_url;
 ```
 
 ## Short links

--- a/dodo-payments/product-catalog-management/SKILL.md
+++ b/dodo-payments/product-catalog-management/SKILL.md
@@ -83,7 +83,7 @@ const subscription = await client.products.create({
 });
 ```
 
-For usage-based products, reference the meter you created in the `usage-based-billing` skill:
+This skill is the canonical source for product creation request shapes. For a usage-based product, create the meter as described in the `usage-based-billing` skill, then attach it through the singular `price.meters` array:
 
 ```typescript
 const metered = await client.products.create({
@@ -92,11 +92,25 @@ const metered = await client.products.create({
   price: {
     type: 'usage_based_price',
     currency: 'USD',
-    price_per_unit: 100, // $1.00 per 100 calls
-    meter_id: 'mtr_api_calls',
+    discount: 0,
+    fixed_price: 0, // No fixed monthly charge; amounts use the smallest currency unit
+    payment_frequency_count: 1,
+    payment_frequency_interval: 'Month',
+    subscription_period_count: 1,
+    subscription_period_interval: 'Month',
+    purchasing_power_parity: false,
+    meters: [
+      {
+        meter_id: 'mtr_api_calls',
+        price_per_unit: '0.01',
+        free_threshold: 1000,
+      },
+    ],
   },
 });
 ```
+
+`price_per_unit` is a decimal string in the configured currency's smallest unit. The optional `free_threshold` excludes that many aggregated units before per-unit charging begins.
 
 ## Listing and retrieving products
 

--- a/dodo-payments/product-catalog-management/SKILL.md
+++ b/dodo-payments/product-catalog-management/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: product-catalog-management
+description: Guide for creating and managing products, pricing, add-ons, product collections, images, and digital product delivery
+---
+
+# Product Catalog Management
+
+This skill covers the full product lifecycle: creating products with pricing models, managing add-ons and collections, uploading product images, and delivering digital files to customers.
+
+## When to use this skill
+
+- You need to create or update products with one-time, recurring, or usage-based pricing.
+- You're building a product collection or storefront.
+- You need to upload product images or deliver digital files to customers.
+- You're managing add-ons or product variants.
+- You need to understand why a product update failed or why pricing can't be changed.
+
+## Core concepts
+
+**Product model:** Every product has exactly one pricing model selected at creation. The three models are:
+
+- `one_time_price`: charge once per purchase.
+- `recurring_price`: charge on a billing cycle (daily, weekly, monthly, yearly).
+- `usage_based_price`: charge per unit consumed (see `usage-based-billing` skill for meter setup).
+
+Pricing is nested inside the product object. There is no separate top-level Price resource.
+
+**Pricing structure:** Each price object contains:
+
+- `type`: one of the three models above.
+- `currency`: ISO 4217 code (e.g., `USD`, `AED`, `INR`).
+- `price`: amount in the smallest currency unit (cents for USD).
+- `discount`: optional discount amount in the same unit.
+
+**Tax category:** Required at product creation. Dodo uses this to calculate and collect sales tax. Common values include `digital_products`, `physical_goods`, `services`. Consult your tax jurisdiction or the Dodo dashboard for the full list.
+
+**Lifecycle:** Products support `list`, `retrieve`, `update`, and `archive`/`unarchive`. There is no delete endpoint. Archived products remain in your history but don't appear in new checkouts.
+
+**Images:** Presigned upload URLs expire after 60 seconds. Download the URL immediately after requesting it.
+
+**Digital delivery:** Entitlements grant customers access to files. Download URLs expire after roughly 15 minutes.
+
+## Creating a product
+
+All products require a name, a pricing model, and a tax category.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// One-time purchase
+const product = await client.products.create({
+  name: 'Pro Bundle',
+  tax_category: 'digital_products',
+  price: {
+    type: 'one_time_price',
+    currency: 'USD',
+    price: 9900, // $99.00
+    discount: 0,
+  },
+});
+
+console.log(product.id); // pdt_...
+```
+
+For recurring products, specify the billing cycle:
+
+```typescript
+const subscription = await client.products.create({
+  name: 'Premium Plan',
+  tax_category: 'services',
+  price: {
+    type: 'recurring_price',
+    currency: 'USD',
+    price: 2999, // $29.99/month
+    discount: 0,
+    billing_cycle: 'monthly',
+  },
+});
+```
+
+For usage-based products, reference the meter you created in the `usage-based-billing` skill:
+
+```typescript
+const metered = await client.products.create({
+  name: 'API Calls',
+  tax_category: 'services',
+  price: {
+    type: 'usage_based_price',
+    currency: 'USD',
+    price_per_unit: 100, // $1.00 per 100 calls
+    meter_id: 'mtr_api_calls',
+  },
+});
+```
+
+## Listing and retrieving products
+
+```typescript
+// List all products
+const products = await client.products.list();
+
+// Retrieve a single product
+const product = await client.products.retrieve('pdt_pro_bundle');
+```
+
+## Updating a product
+
+You can update the name, description, and metadata. You cannot change the pricing model or price of a live product. Create a new product instead.
+
+```typescript
+await client.products.update('pdt_pro_bundle', {
+  name: 'Pro Bundle (Updated)',
+  description: 'Includes all pro features',
+  metadata: {
+    category: 'software',
+    tier: 'premium',
+  },
+});
+```
+
+## Archiving and unarchiving
+
+Archive a product to hide it from new checkouts without deleting it:
+
+```typescript
+await client.products.archive('pdt_pro_bundle');
+
+// Restore it later
+await client.products.unarchive('pdt_pro_bundle');
+```
+
+## Product images
+
+Upload a product image via presigned URL. The URL is valid for 60 seconds.
+
+```typescript
+import fs from 'node:fs';
+
+// Request a presigned upload URL
+const uploadUrl = await client.products.images.update('pdt_pro_bundle', {
+  filename: 'product.png',
+});
+
+// Upload immediately (within 60 seconds)
+const response = await fetch(uploadUrl.url, {
+  method: 'PUT',
+  body: fs.readFileSync('./product.png'),
+  headers: { 'Content-Type': 'image/png' },
+});
+
+if (!response.ok) {
+  throw new Error('Image upload failed');
+}
+```
+
+## Add-ons
+
+Add-ons are optional extras customers can purchase alongside a product. Create them independently, then reference them in checkout.
+
+```typescript
+// Create an add-on
+const addon = await client.addons.create({
+  name: 'Priority Support',
+  tax_category: 'services',
+  price: {
+    type: 'one_time_price',
+    currency: 'USD',
+    price: 4900, // $49.00
+    discount: 0,
+  },
+});
+
+// Upload an image for the add-on
+const addonImageUrl = await client.addons.images.update(addon.id, {
+  filename: 'addon.png',
+});
+
+// List add-ons
+const addons = await client.addons.list();
+```
+
+## Product collections
+
+Group products into collections for themed checkouts. Collections have nested groups and items.
+
+```typescript
+// Create a collection
+const collection = await client.productCollections.create({
+  name: 'Starter Bundle',
+  description: 'Everything you need to get started',
+});
+
+// Add groups and items
+await client.productCollections.groups.create(collection.id, {
+  name: 'Core Tools',
+  items: [
+    { product_id: 'pdt_tool_a', quantity: 1 },
+    { product_id: 'pdt_tool_b', quantity: 1 },
+  ],
+});
+
+// Checkout with a collection
+const session = await client.checkoutSessions.create({
+  product_collection_id: collection.id,
+  product_cart: [], // Required: pass an empty array for collection checkout
+  return_url: 'https://yoursite.com/return',
+});
+
+window.location.href = session.checkout_url;
+```
+
+## Digital product delivery
+
+Entitlements grant customers access to downloadable files. Create an entitlement, upload files, and generate download links.
+
+```typescript
+// Create an entitlement
+const entitlement = await client.entitlements.create({
+  name: 'Pro Bundle Files',
+});
+
+// Upload a file
+await client.entitlements.files.upload(entitlement.id, {
+  file: fs.createReadStream('./pro-bundle.zip'),
+  filename: 'pro-bundle.zip',
+});
+
+// Grant access to a customer
+await client.entitlements.grants.create(entitlement.id, {
+  customer_id: 'cus_customer_123',
+});
+
+// List grants for a customer
+const grants = await client.customers.listEntitlementGrants('cus_customer_123');
+
+// Generate a download URL (valid for roughly 15 minutes)
+const downloadUrl = grants[0].download_url;
+```
+
+## Short links
+
+Create short, shareable links to products:
+
+```typescript
+const shortLink = await client.products.shortLinks.create('pdt_pro_bundle', {
+  slug: 'pro-bundle-deal',
+});
+
+console.log(shortLink.short_url); // https://dodo.link/pro-bundle-deal
+```
+
+## Localized pricing
+
+For country or currency-specific pricing, use the `localized-pricing` skill. Do not hardcode prices in the client.
+
+## Common mistakes
+
+**Expecting a delete endpoint:** Products don't have a delete method. Archive them instead. Archived products remain in your history for reconciliation.
+
+**Trying to change the pricing model:** Once a product is created with `one_time_price`, you can't change it to `recurring_price`. Create a new product and migrate customers to it.
+
+**Hardcoding prices in the client:** Always fetch the product catalog from the API. Prices change, and your client code will become stale. Read `client.products.retrieve(id)` to get the current price.
+
+**Forgetting the tax category:** Every product requires a `tax_category`. Dodo uses this to calculate and remit sales tax. Omitting it will cause the create request to fail.
+
+**Uploading images after the 60-second window:** Request the presigned URL and upload immediately. If the URL expires, request a new one.
+
+**Passing a non-empty product_cart for collection checkout:** Collection checkout requires `product_cart: []`. The collection itself defines what's in the cart.
+
+**Confusing purchasing_power_parity with localized pricing:** The OpenAPI schema includes a `purchasing_power_parity` field in examples, but it's marked unavailable. Use the `localized-pricing` skill for country and currency pricing instead.
+
+## Resources
+
+- [Products](https://docs.dodopayments.com/features/products)
+- [Create product API](https://docs.dodopayments.com/api-reference/products/post-products)
+- [Product Collections](https://docs.dodopayments.com/features/product-collections)
+- [Digital Product Delivery](https://docs.dodopayments.com/features/digital-product-delivery)
+- [Add-ons](https://docs.dodopayments.com/features/addons)

--- a/dodo-payments/refunds-and-disputes/SKILL.md
+++ b/dodo-payments/refunds-and-disputes/SKILL.md
@@ -48,14 +48,14 @@ console.log(refund.status); // 'pending', 'succeeded', 'review', or 'failed'
 
 ### Partial refund by item
 
-To refund only specific items from a payment, pass the `items` array with the item IDs and quantities you want to refund:
+To refund only specific items from a payment, pass the `items` array with each item ID and the amount to refund in the smallest currency unit. Omit `amount` to refund the whole item:
 
 ```typescript
 const partialRefund = await client.refunds.create({
   payment_id: 'pay_abc123',
   items: [
-    { item_id: 'item_1', quantity: 1 },
-    { item_id: 'item_2', quantity: 2 },
+    { item_id: 'item_1', amount: 1000 },
+    { item_id: 'item_2', amount: 2500 },
   ],
 });
 ```
@@ -75,9 +75,7 @@ Each refund has one of four statuses:
 
 ```typescript
 // List all refunds
-const refunds = await client.refunds.list({
-  payment_id: 'pay_abc123',
-});
+const refunds = await client.refunds.list();
 
 // Retrieve a specific refund
 const refund = await client.refunds.retrieve('ref_xyz789');
@@ -95,9 +93,14 @@ import express from 'express';
 const app = express();
 app.use(express.raw({ type: 'application/json' }));
 
+// `environment` is a narrow union, but env vars are `string | undefined`.
+// Narrow explicitly rather than casting, and default to test mode so a missing
+// variable can never accidentally hit live.
+const environment = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live_mode' : 'test_mode';
+
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment,
   webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
 });
 
@@ -114,14 +117,14 @@ app.post('/webhook', async (req, res) => {
     if (event.type === 'refund.succeeded') {
       const refund = event.data;
       // Refund succeeded; revoke access if needed
-      await revokeCustomerAccess(refund.customer_id);
+      await revokeCustomerAccess(refund.customer.customer_id);
       await updateRefundRecord(refund.refund_id, 'succeeded');
     }
 
     if (event.type === 'refund.failed') {
       const refund = event.data;
       // Refund failed; keep access active, alert support
-      await logRefundFailure(refund.refund_id, refund.failure_reason);
+      await logRefundFailure(refund.refund_id, refund.reason);
     }
 
     res.json({ received: true });
@@ -143,7 +146,7 @@ const disputes = await client.disputes.list();
 
 // Retrieve a specific dispute
 const dispute = await client.disputes.retrieve('dis_abc123');
-console.log(dispute.status);
+console.log(dispute.dispute_status);
 console.log(dispute.amount); // in smallest currency unit
 ```
 
@@ -163,7 +166,14 @@ A dispute moves through seven events. Each event requires a different action fro
 
 ### Handle dispute webhooks
 
+Webhook dispute payloads intentionally contain no customer field. Resolve the customer with an extra `disputes.retrieve()` call: the webhook's `dispute_id` identifies the dispute, and the returned `GetDispute` includes `customer`. Without this lookup, access-control handlers would receive `undefined`.
+
 ```typescript
+async function resolveDisputeCustomerId(disputeId: string) {
+  const dispute = await client.disputes.retrieve(disputeId);
+  return dispute.customer.customer_id;
+}
+
 app.post('/webhook', async (req, res) => {
   try {
     const event = client.webhooks.unwrap(req.body.toString(), {
@@ -178,7 +188,8 @@ app.post('/webhook', async (req, res) => {
       const dispute = event.data;
       // Record the dispute and revoke access
       await recordDispute(dispute.dispute_id, dispute.payment_id, dispute.amount);
-      await revokeCustomerAccess(dispute.customer_id);
+      const customerId = await resolveDisputeCustomerId(dispute.dispute_id);
+      await revokeCustomerAccess(customerId);
       // Gather evidence from your system and submit via dashboard
       // (no evidence-submission API exists; use the Dodo dashboard)
     }
@@ -187,7 +198,8 @@ app.post('/webhook', async (req, res) => {
       const dispute = event.data;
       // Funds retained; restore normal state
       await markDisputeResolved(dispute.dispute_id, 'won');
-      await restoreCustomerAccess(dispute.customer_id);
+      const customerId = await resolveDisputeCustomerId(dispute.dispute_id);
+      await restoreCustomerAccess(customerId);
     }
 
     if (event.type === 'dispute.lost') {
@@ -228,33 +240,41 @@ When a dispute opens, gather your evidence (order confirmation, delivery proof, 
 A common pattern for managing access during disputes:
 
 ```typescript
-async function handleDisputeLifecycle(dispute) {
-  switch (dispute.status) {
-    case 'opened':
+async function handleDisputeLifecycle(
+  dispute: Awaited<ReturnType<typeof client.disputes.retrieve>>,
+) {
+  const customerId = dispute.customer.customer_id;
+
+  switch (dispute.dispute_status) {
+    case 'dispute_opened':
       // Revoke access immediately
-      await revokeCustomerAccess(dispute.customer_id);
+      await revokeCustomerAccess(customerId);
       break;
 
-    case 'won':
+    case 'dispute_won':
       // You won; restore access
-      await restoreCustomerAccess(dispute.customer_id);
+      await restoreCustomerAccess(customerId);
       break;
 
-    case 'lost':
+    case 'dispute_lost':
       // You lost; keep access revoked
       // (do nothing)
       break;
 
-    case 'accepted':
+    case 'dispute_accepted':
       // You conceded; funds go to the cardholder and access stays revoked
       break;
 
-    case 'cancelled':
+    case 'dispute_cancelled':
       // Cancellation is not a win; reconcile separately and keep access revoked
       break;
 
-    case 'expired':
+    case 'dispute_expired':
       // Treat as lost; keep access revoked
+      break;
+
+    case 'dispute_challenged':
+      // Evidence is under review; keep access revoked
       break;
   }
 }
@@ -274,7 +294,11 @@ async function reconcileRefund(refund) {
   const customer = payment.customer;
 
   // Revoke access for non-refundable products
-  if (isNonRefundable(payment.product_id)) {
+  const includesNonRefundableProduct = payment.product_cart?.some(({ product_id }) =>
+    isNonRefundable(product_id),
+  );
+
+  if (includesNonRefundableProduct) {
     await revokeCustomerAccess(customer.customer_id);
   }
 

--- a/dodo-payments/refunds-and-disputes/SKILL.md
+++ b/dodo-payments/refunds-and-disputes/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: refunds-and-disputes
+description: Guide for issuing refunds, handling disputes and chargebacks, and reconciling customer access with Dodo Payments
+---
+
+# Refunds and Disputes
+
+This skill covers issuing refunds (full and partial), handling the dispute lifecycle, and managing customer access during payment reversals. Disputes are inbound-only; Dodo handles the card-network process as Merchant of Record while you control application access and evidence gathering.
+
+## When to use this skill
+
+- You need to issue a refund (full or partial) for a payment
+- A customer disputes a charge and you need to respond with evidence
+- You're building access-revocation logic tied to refund or dispute status
+- You need to reconcile customer entitlements after a payment reversal
+- You're handling refund or dispute webhooks in production
+
+## Core concepts
+
+**Refunds** are initiated by you via the API. Each refund has a status that tells you whether the money has actually left your account. Partial refunds target specific line items in the original payment.
+
+**Disputes** are initiated by the customer's card network. You cannot create them; you only list and retrieve them. The dispute lifecycle spans seven events, each requiring different application actions.
+
+**Amounts** are always in the smallest currency unit (cents for USD, paise for INR, etc.).
+
+**Access revocation** means removing the customer's ability to use the product or service. On a dispute, you typically revoke access while it's open, then restore it if you win or keep it revoked if you lose.
+
+## Refunds
+
+### Create a refund
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+
+// Full refund
+const refund = await client.refunds.create({
+  payment_id: 'pay_abc123',
+});
+
+console.log(refund.refund_id);
+console.log(refund.status); // 'pending', 'succeeded', 'review', or 'failed'
+```
+
+### Partial refund by item
+
+To refund only specific items from a payment, pass the `items` array with the item IDs and quantities you want to refund:
+
+```typescript
+const partialRefund = await client.refunds.create({
+  payment_id: 'pay_abc123',
+  items: [
+    { item_id: 'item_1', quantity: 1 },
+    { item_id: 'item_2', quantity: 2 },
+  ],
+});
+```
+
+### Refund statuses
+
+Each refund has one of four statuses:
+
+| Status | Meaning | Your action |
+|---|---|---|
+| `pending` | Refund is processing; money hasn't left your account yet | Wait for a webhook or poll the refund status |
+| `succeeded` | Money has been returned to the customer | Revoke access if the product is non-refundable; update your records |
+| `review` | Refund is under review (rare) | Contact support; do not assume it will succeed |
+| `failed` | Refund failed; money remains in your account | Investigate the failure; consider retrying or contacting the customer |
+
+### List and retrieve refunds
+
+```typescript
+// List all refunds
+const refunds = await client.refunds.list({
+  payment_id: 'pay_abc123',
+});
+
+// Retrieve a specific refund
+const refund = await client.refunds.retrieve('ref_xyz789');
+console.log(refund.status);
+```
+
+### Handle refund webhooks
+
+Webhook signature verification is covered in the `webhook-integration` skill. Always verify the signature before processing.
+
+```typescript
+import DodoPayments from 'dodopayments';
+import express from 'express';
+
+const app = express();
+app.use(express.raw({ type: 'application/json' }));
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+});
+
+app.post('/webhook', async (req, res) => {
+  try {
+    const event = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
+
+    if (event.type === 'refund.succeeded') {
+      const refund = event.data;
+      // Refund succeeded; revoke access if needed
+      await revokeCustomerAccess(refund.customer_id);
+      await updateRefundRecord(refund.refund_id, 'succeeded');
+    }
+
+    if (event.type === 'refund.failed') {
+      const refund = event.data;
+      // Refund failed; keep access active, alert support
+      await logRefundFailure(refund.refund_id, refund.failure_reason);
+    }
+
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
+  }
+});
+```
+
+## Disputes
+
+### Retrieve disputes
+
+Disputes are inbound-only. You cannot create them; you can only list and retrieve them.
+
+```typescript
+// List all disputes
+const disputes = await client.disputes.list();
+
+// Retrieve a specific dispute
+const dispute = await client.disputes.retrieve('dis_abc123');
+console.log(dispute.status);
+console.log(dispute.amount); // in smallest currency unit
+```
+
+### Dispute lifecycle
+
+A dispute moves through seven events. Each event requires a different action from your application:
+
+| Event | Meaning | Your action |
+|---|---|---|
+| `dispute.opened` | Customer initiated a chargeback | Record the dispute; consider revoking access immediately; gather evidence from your logs |
+| `dispute.challenged` | You submitted evidence | Wait for the card network to review |
+| `dispute.accepted` | Card network accepted your evidence | Restore access; mark dispute as won in your records |
+| `dispute.cancelled` | Customer withdrew the dispute | Restore access only if the original payment succeeded; check payment status first |
+| `dispute.expired` | Dispute window closed without resolution | Treat as lost; keep access revoked |
+| `dispute.won` | You won the dispute | Funds are retained; restore access; update customer records |
+| `dispute.lost` | You lost the dispute | Funds returned to cardholder; keep access revoked; reconcile your records |
+
+### Handle dispute webhooks
+
+```typescript
+app.post('/webhook', async (req, res) => {
+  try {
+    const event = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
+
+    if (event.type === 'dispute.opened') {
+      const dispute = event.data;
+      // Record the dispute and revoke access
+      await recordDispute(dispute.dispute_id, dispute.payment_id, dispute.amount);
+      await revokeCustomerAccess(dispute.customer_id);
+      // Gather evidence from your system and submit via dashboard
+      // (no evidence-submission API exists; use the Dodo dashboard)
+    }
+
+    if (event.type === 'dispute.won') {
+      const dispute = event.data;
+      // Funds retained; restore normal state
+      await markDisputeResolved(dispute.dispute_id, 'won');
+      await restoreCustomerAccess(dispute.customer_id);
+    }
+
+    if (event.type === 'dispute.lost') {
+      const dispute = event.data;
+      // Funds returned to cardholder; keep access revoked
+      await markDisputeResolved(dispute.dispute_id, 'lost');
+      // Do NOT restore access
+    }
+
+    if (event.type === 'dispute.cancelled') {
+      const dispute = event.data;
+      // Customer withdrew the dispute
+      // Only restore access if the original payment succeeded
+      const payment = await client.payments.retrieve(dispute.payment_id);
+      if (payment.status === 'succeeded') {
+        await restoreCustomerAccess(dispute.customer_id);
+      }
+      await markDisputeResolved(dispute.dispute_id, 'cancelled');
+    }
+
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
+  }
+});
+```
+
+### Evidence submission
+
+Dodo handles the card-network dispute process as Merchant of Record. You submit evidence through the Dodo dashboard, not via API. No evidence-submission API exists.
+
+When a dispute opens, gather your evidence (order confirmation, delivery proof, customer communication, etc.) and upload it to the dashboard within the dispute window (typically 4 days). The card network reviews your evidence and makes a final decision.
+
+## Access revocation pattern
+
+A common pattern for managing access during disputes:
+
+```typescript
+async function handleDisputeLifecycle(dispute) {
+  switch (dispute.status) {
+    case 'opened':
+      // Revoke access immediately
+      await revokeCustomerAccess(dispute.customer_id);
+      break;
+
+    case 'won':
+      // You won; restore access
+      await restoreCustomerAccess(dispute.customer_id);
+      break;
+
+    case 'lost':
+      // You lost; keep access revoked
+      // (do nothing)
+      break;
+
+    case 'cancelled':
+      // Check the original payment status before restoring
+      const payment = await client.payments.retrieve(dispute.payment_id);
+      if (payment.status === 'succeeded') {
+        await restoreCustomerAccess(dispute.customer_id);
+      }
+      break;
+
+    case 'expired':
+      // Treat as lost; keep access revoked
+      break;
+  }
+}
+```
+
+## Reconciling entitlements after refund
+
+When a refund succeeds, you must reconcile the customer's access. If the product is non-refundable (e.g., a digital download or subscription already used), revoke access. If it's refundable (e.g., a subscription not yet started), you may restore access or leave it revoked depending on your policy.
+
+```typescript
+async function reconcileRefund(refund) {
+  if (refund.status !== 'succeeded') {
+    return; // Not yet final
+  }
+
+  const payment = await client.payments.retrieve(refund.payment_id);
+  const customer = payment.customer;
+
+  // Revoke access for non-refundable products
+  if (isNonRefundable(payment.product_id)) {
+    await revokeCustomerAccess(customer.customer_id);
+  }
+
+  // Update your entitlement records
+  await updateEntitlementRecord(customer.customer_id, {
+    refund_id: refund.refund_id,
+    refund_amount: refund.amount,
+    refund_date: new Date(),
+  });
+}
+```
+
+## Common mistakes
+
+**Auto-refunding without revoking access.** A refund webhook means money is leaving your account. If the product is non-refundable, revoke access immediately. Don't wait for the customer to ask.
+
+**Treating `dispute.opened` as final.** A dispute is not lost until the card network says so. Keep access revoked while it's open, but don't delete customer data or close their account.
+
+**Ignoring partial refunds when computing entitlements.** If a customer refunds only one item from a multi-item purchase, their entitlement to the other items remains valid. Track refunds by item, not just by payment.
+
+**Granting access again on `dispute.cancelled` without checking payment status.** A cancelled dispute doesn't mean the original payment succeeded. Always verify the payment status before restoring access.
+
+**Submitting evidence after the dispute window closes.** The card network typically gives you 4 days to respond. Set a calendar reminder and gather evidence immediately when a dispute opens.
+
+**Assuming Dodo will handle access revocation.** Dodo handles the card-network process; you handle application access. Dodo won't revoke your customer's subscription or file access automatically.
+
+## Resources
+
+- [Refunds API](https://docs.dodopayments.com/api-reference/refunds/post-refunds)
+- [Refunds feature guide](https://docs.dodopayments.com/features/transactions/refunds)
+- [Dispute webhooks](https://docs.dodopayments.com/developer-resources/webhooks/intents/dispute)
+- [Webhook integration skill](./webhook-integration) for signature verification

--- a/dodo-payments/refunds-and-disputes/SKILL.md
+++ b/dodo-payments/refunds-and-disputes/SKILL.md
@@ -23,7 +23,7 @@ This skill covers issuing refunds (full and partial), handling the dispute lifec
 
 **Amounts** are always in the smallest currency unit (cents for USD, paise for INR, etc.).
 
-**Access revocation** means removing the customer's ability to use the product or service. On a dispute, you typically revoke access while it's open, then restore it if you win or keep it revoked if you lose.
+**Access revocation** means removing the customer's ability to use the product or service. On a dispute, you typically revoke access while it's open. Restore it only on `dispute.won`; all other outcomes keep access revoked until you reconcile them separately.
 
 ## Refunds
 
@@ -155,8 +155,8 @@ A dispute moves through seven events. Each event requires a different action fro
 |---|---|---|
 | `dispute.opened` | Customer initiated a chargeback | Record the dispute; consider revoking access immediately; gather evidence from your logs |
 | `dispute.challenged` | You submitted evidence | Wait for the card network to review |
-| `dispute.accepted` | Card network accepted your evidence | Restore access; mark dispute as won in your records |
-| `dispute.cancelled` | Customer withdrew the dispute | Restore access only if the original payment succeeded; check payment status first |
+| `dispute.accepted` | You accepted (conceded) the dispute; funds go to the cardholder | Keep access revoked; mark the dispute as accepted in your records |
+| `dispute.cancelled` | Customer or system cancelled the dispute | Keep access revoked; reconcile the payment separately |
 | `dispute.expired` | Dispute window closed without resolution | Treat as lost; keep access revoked |
 | `dispute.won` | You won the dispute | Funds are retained; restore access; update customer records |
 | `dispute.lost` | You lost the dispute | Funds returned to cardholder; keep access revoked; reconcile your records |
@@ -197,14 +197,16 @@ app.post('/webhook', async (req, res) => {
       // Do NOT restore access
     }
 
+    if (event.type === 'dispute.accepted') {
+      const dispute = event.data;
+      // Merchant conceded; funds go to the cardholder and access stays revoked
+      await markDisputeResolved(dispute.dispute_id, 'accepted');
+      // Do NOT restore access
+    }
+
     if (event.type === 'dispute.cancelled') {
       const dispute = event.data;
-      // Customer withdrew the dispute
-      // Only restore access if the original payment succeeded
-      const payment = await client.payments.retrieve(dispute.payment_id);
-      if (payment.status === 'succeeded') {
-        await restoreCustomerAccess(dispute.customer_id);
-      }
+      // Cancellation is not a win; keep access revoked and reconcile separately
       await markDisputeResolved(dispute.dispute_id, 'cancelled');
     }
 
@@ -243,12 +245,12 @@ async function handleDisputeLifecycle(dispute) {
       // (do nothing)
       break;
 
+    case 'accepted':
+      // You conceded; funds go to the cardholder and access stays revoked
+      break;
+
     case 'cancelled':
-      // Check the original payment status before restoring
-      const payment = await client.payments.retrieve(dispute.payment_id);
-      if (payment.status === 'succeeded') {
-        await restoreCustomerAccess(dispute.customer_id);
-      }
+      // Cancellation is not a win; reconcile separately and keep access revoked
       break;
 
     case 'expired':
@@ -293,7 +295,7 @@ async function reconcileRefund(refund) {
 
 **Ignoring partial refunds when computing entitlements.** If a customer refunds only one item from a multi-item purchase, their entitlement to the other items remains valid. Track refunds by item, not just by payment.
 
-**Granting access again on `dispute.cancelled` without checking payment status.** A cancelled dispute doesn't mean the original payment succeeded. Always verify the payment status before restoring access.
+**Restoring access on any outcome except `dispute.won`.** `dispute.accepted` means you conceded and the cardholder receives the funds. A cancelled dispute is also not a win. Keep access revoked and reconcile separately unless you receive `dispute.won`.
 
 **Submitting evidence after the dispute window closes.** The card network typically gives you 4 days to respond. Set a calendar reminder and gather evidence immediately when a dispute opens.
 
@@ -304,4 +306,4 @@ async function reconcileRefund(refund) {
 - [Refunds API](https://docs.dodopayments.com/api-reference/refunds/post-refunds)
 - [Refunds feature guide](https://docs.dodopayments.com/features/transactions/refunds)
 - [Dispute webhooks](https://docs.dodopayments.com/developer-resources/webhooks/intents/dispute)
-- [Webhook integration skill](./webhook-integration) for signature verification
+- [Webhook integration skill](../webhook-integration/) for signature verification

--- a/dodo-payments/subscription-integration/SKILL.md
+++ b/dodo-payments/subscription-integration/SKILL.md
@@ -272,7 +272,7 @@ When a renewal or plan-change charge fails, the subscription moves to `on_hold`.
 // Listen for subscription.on_hold webhook
 case 'subscription.on_hold':
   // Notify customer, offer payment method update
-  await sendPaymentFailedEmail(data.customer_id);
+  await sendPaymentFailedEmail(data.customer.customer_id);
   break;
 ```
 
@@ -331,6 +331,8 @@ Webhook signature verification, raw-body handling, durable processing, and idemp
 ### Example Handler
 
 ```typescript
+import { NextRequest, NextResponse } from 'next/server';
+
 export async function POST(req: NextRequest) {
   const raw = await req.text();
   const headers = Object.fromEntries(req.headers.entries());
@@ -348,24 +350,22 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true });
   }
 
-  const data = event.data;
-
   switch (event.type) {
     case 'subscription.active':
-      await grantAccess(data.customer_id, data.product_id);
+      await grantAccess(event.data.customer.customer_id, event.data.product_id);
       break;
     case 'subscription.on_hold':
-      await notifyPaymentFailed(data.customer_id);
+      await notifyPaymentFailed(event.data.customer.customer_id);
       break;
     case 'subscription.cancelled':
-      if (data.cancel_at_next_billing_date) {
-        await scheduleAccessRevocation(data.subscription_id, new Date(data.next_billing_date));
+      if (event.data.cancel_at_next_billing_date) {
+        await scheduleAccessRevocation(event.data.subscription_id, new Date(event.data.next_billing_date));
       } else {
-        await revokeAccessImmediately(data.subscription_id);
+        await revokeAccessImmediately(event.data.subscription_id);
       }
       break;
     case 'subscription.expired':
-      await revokeAccess(data.customer_id);
+      await revokeAccess(event.data.customer.customer_id);
       break;
   }
 
@@ -415,7 +415,7 @@ The `return_url` is hit before the subscription is fully created. Dodo may still
 ```typescript
 // In webhook handler
 case 'subscription.active':
-  await grantAccess(data.customer_id);
+  await grantAccess(data.customer.customer_id);
   break;
 ```
 
@@ -446,6 +446,8 @@ const session = await client.checkoutSessions.create({
 
 ### 4. Forgetting Proration Mode
 
+**Wrong:**
+
 ```typescript
 // Missing proration_billing_mode
 await client.subscriptions.changePlan('sub_xxxxx', {
@@ -465,7 +467,7 @@ This will fail. Always specify a proration mode.
 
 ```typescript
 // Wrong: revoke immediately
-await revokeAccess(data.customer_id);
+await revokeAccess(data.customer.customer_id);
 
 // Right: check the flag
 if (data.cancel_at_next_billing_date) {

--- a/dodo-payments/subscription-integration/SKILL.md
+++ b/dodo-payments/subscription-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subscription-integration
-description: Guide for implementing subscription billing with Dodo Payments - trials, upgrades, downgrades, and on-demand charging.
+description: Guide for managing recurring subscriptions after checkout, including trials, lifecycle states, plan changes, cancellation, failed-payment recovery, proration, mandates, and on-demand charges.
 ---
 
 # Dodo Payments Subscription Integration
@@ -19,7 +19,7 @@ Implement recurring billing with trials, plan changes, and on-demand charging. S
 
 ## Core Concepts
 
-**Subscription lifecycle:** A subscription moves through states: `pending` → `active` (or `trial` if configured) → `renewed` on each billing cycle. Failed payments move it to `on_hold` (recoverable) or `failed` (terminal). Cancellation sets it to `cancelled` or schedules it for `expired` at period end.
+**Subscription lifecycle:** The six subscription statuses are `pending`, `active`, `on_hold`, `cancelled`, `failed`, and `expired`. A trialing subscription reports `active`; `subscription.renewed` is an event, not a status. Failed payments can move a subscription to `on_hold` (recoverable) or `failed` (terminal). Cancellation sets it to `cancelled` or schedules it to become `expired` at period end.
 
 **Checkout Sessions:** The recommended path for creating subscriptions. A single-use hosted checkout that collects payment and customer data, then creates the subscription server-side.
 
@@ -114,7 +114,10 @@ When a subscription is `on_hold` due to failed payment, the customer can update 
 
 ```typescript
 await client.subscriptions.updatePaymentMethod('sub_xxxxx', {
-  payment_method_id: 'pm_new_method',
+  payment_method: {
+    type: 'existing',
+    payment_method_id: 'pm_new_method',
+  },
 });
 ```
 
@@ -124,7 +127,8 @@ Success emits `payment.succeeded` followed by `subscription.active`.
 
 ```typescript
 const history = await client.subscriptions.retrieveUsageHistory('sub_xxxxx', {
-  limit: 50,
+  page_size: 50,
+  page_number: 0,
 });
 ```
 
@@ -132,7 +136,11 @@ const history = await client.subscriptions.retrieveUsageHistory('sub_xxxxx', {
 
 ```typescript
 const creditUsage = await client.subscriptions.retrieveCreditUsage('sub_xxxxx');
-console.log(creditUsage.balance_after, creditUsage.deducted);
+console.log('Subscription:', creditUsage.subscription_id);
+
+for (const item of creditUsage.items) {
+  console.log(item.credit_entitlement_name, item.balance); // balance is a string
+}
 ```
 
 ---
@@ -175,8 +183,10 @@ const preview = await client.subscriptions.previewChangePlan('sub_xxxxx', {
   proration_billing_mode: 'prorated_immediately',
 });
 
-console.log('Charge:', preview.charge_amount, preview.charge_currency);
-console.log('Credit:', preview.credit_amount);
+console.log('Effective at:', preview.immediate_charge.effective_at);
+console.log('Line items:', preview.immediate_charge.line_items);
+console.log('Summary:', preview.immediate_charge.summary);
+console.log('New plan:', preview.new_plan);
 ```
 
 ### Cancel a Scheduled Plan Change
@@ -308,7 +318,7 @@ For full customer management (creating, updating, listing), see the `customer-ma
 
 | Event | When | Action |
 |-------|------|--------|
-| `subscription.active` | Subscription starts or trial ends | Grant access |
+| `subscription.active` | Subscription becomes active, including a trial start or recovery | Grant access |
 | `subscription.renewed` | Successful renewal | Log renewal, send receipt |
 | `subscription.on_hold` | Renewal/plan-change payment failed | Notify customer, offer recovery |
 | `subscription.plan_changed` | Plan upgraded/downgraded or add-ons changed | Update entitlements |
@@ -316,13 +326,28 @@ For full customer management (creating, updating, listing), see the `customer-ma
 | `subscription.failed` | Initial mandate/payment failed | Notify customer, offer retry or new subscription |
 | `subscription.expired` | Subscription term ended | Revoke access |
 
-For webhook signature verification, see the `webhook-integration` skill.
+Webhook signature verification, raw-body handling, durable processing, and idempotency are covered in the `webhook-integration` skill.
 
 ### Example Handler
 
 ```typescript
 export async function POST(req: NextRequest) {
-  const event = await req.json();
+  const raw = await req.text();
+  const headers = Object.fromEntries(req.headers.entries());
+  const event = await client.webhooks.unwrap(raw, { headers });
+  const webhookId = req.headers.get('webhook-id');
+
+  if (!webhookId) {
+    return NextResponse.json({ error: 'Missing webhook-id' }, { status: 400 });
+  }
+
+  // Implement this as an atomic insert backed by a UNIQUE constraint.
+  // Keep the claim and entitlement changes in the same database transaction.
+  const claimed = await claimWebhookId(webhookId);
+  if (!claimed) {
+    return NextResponse.json({ received: true });
+  }
+
   const data = event.data;
 
   switch (event.type) {

--- a/dodo-payments/subscription-integration/SKILL.md
+++ b/dodo-payments/subscription-integration/SKILL.md
@@ -1,39 +1,52 @@
 ---
 name: subscription-integration
-description: Guide for implementing subscription billing with Dodo Payments - trials, upgrades, downgrades, and on-demand billing.
+description: Guide for implementing subscription billing with Dodo Payments - trials, upgrades, downgrades, and on-demand charging.
 ---
 
 # Dodo Payments Subscription Integration
 
-**Reference: [docs.dodopayments.com/developer-resources/subscription-integration-guide](https://docs.dodopayments.com/developer-resources/subscription-integration-guide)**
+Implement recurring billing with trials, plan changes, and on-demand charging. Subscriptions are created through Checkout Sessions, managed via the subscriptions API, and monitored through webhooks.
 
-Implement recurring billing with trials, plan changes, and usage-based pricing.
+## When to use this skill
+
+- Building a subscription product with recurring billing and trials
+- Handling plan upgrades, downgrades, and migrations mid-cycle
+- Implementing on-demand/off-session charging with mandates
+- Managing failed payments and dunning recovery
+- Building a customer self-service portal for subscription management
 
 ---
 
-## Quick Start
+## Core Concepts
 
-### 1. Create Subscription Product
-In the dashboard (Products → Create Product):
-- Select "Subscription" type
-- Set billing interval (monthly, yearly, etc.)
-- Configure pricing
+**Subscription lifecycle:** A subscription moves through states: `pending` → `active` (or `trial` if configured) → `renewed` on each billing cycle. Failed payments move it to `on_hold` (recoverable) or `failed` (terminal). Cancellation sets it to `cancelled` or schedules it for `expired` at period end.
 
-### 2. Create Checkout Session
+**Checkout Sessions:** The recommended path for creating subscriptions. A single-use hosted checkout that collects payment and customer data, then creates the subscription server-side.
+
+**Proration:** When a customer changes plans mid-cycle, Dodo calculates credits or charges based on the time remaining. Proration mode controls whether the customer is billed immediately, credited, or neither.
+
+**Mandates:** Authorization to charge a customer's payment method repeatedly (for subscriptions) or on-demand (for usage-based billing). Created during Checkout, can be updated if payment fails.
+
+---
+
+## Creating a Subscription
+
+### Via Checkout Session (Recommended)
 
 ```typescript
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
 });
 
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_monthly_plan', quantity: 1 }
+    { product_id: 'pdt_monthly_plan', quantity: 1 }
   ],
   subscription_data: {
-    trial_period_days: 14, // Optional trial
+    trial_period_days: 14, // Optional
   },
   customer: {
     email: 'subscriber@example.com',
@@ -42,37 +55,252 @@ const session = await client.checkoutSessions.create({
   return_url: 'https://yoursite.com/success',
 });
 
-// Redirect to session.checkout_url
+// Redirect user to session.checkout_url
+console.log('Redirect to:', session.checkout_url);
 ```
 
-### 3. Handle Webhook Events
+The customer completes payment on the hosted checkout. On success, Dodo creates the subscription and fires the `subscription.active` webhook.
+
+### With Add-ons
+
 ```typescript
-// subscription.active - Grant access
-// subscription.cancelled - Schedule access revocation
-// subscription.renewed - Log renewal
-// payment.succeeded - Track payments
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    {
+      product_id: 'pdt_pro_monthly',
+      quantity: 1,
+      addons: [
+        { addon_id: 'adn_extra_seats', quantity: 3 }
+      ]
+    }
+  ],
+  subscription_data: {
+    trial_period_days: 7,
+  },
+  customer: { email: 'user@example.com' },
+  return_url: 'https://yoursite.com/success',
+});
 ```
 
 ---
 
-## Subscription Lifecycle
+## Subscription Lifecycle & Status
 
+| Status | Meaning | Transitions |
+|--------|---------|-----------|
+| `pending` | Creation in progress | → `active`, `failed` |
+| `active` | Actively renewing | → `on_hold`, `cancelled`, `expired` |
+| `on_hold` | Renewal/plan-change payment failed; recoverable | → `active` (payment method updated), `failed` (retries exhausted), `cancelled` |
+| `cancelled` | Will not renew | → `expired` (at period end) |
+| `failed` | Initial mandate/payment failed; terminal | (no recovery) |
+| `expired` | Subscription term ended | (terminal) |
+
+**Trial period:** If `trial_period_days` is set, the subscription enters `active` immediately but charges nothing until the trial ends. The first charge occurs on the trial end date.
+
+---
+
+## Subscription Methods
+
+### Retrieve
+
+```typescript
+const subscription = await client.subscriptions.retrieve('sub_xxxxx');
+console.log(subscription.status, subscription.next_billing_date);
 ```
-┌─────────────┐     ┌─────────┐     ┌────────┐
-│   Created   │ ──▶ │  Trial  │ ──▶ │ Active │
-└─────────────┘     └─────────┘     └────────┘
-                                         │
-                    ┌────────────────────┼────────────────────┐
-                    ▼                    ▼                    ▼
-              ┌──────────┐        ┌───────────┐        ┌───────────┐
-              │ On Hold  │        │ Cancelled │        │  Renewed  │
-              └──────────┘        └───────────┘        └───────────┘
-                    │                    │
-                    ▼                    ▼
-              ┌──────────┐        ┌───────────┐
-              │  Failed  │        │  Expired  │
-              └──────────┘        └───────────┘
+
+### Update Payment Method
+
+When a subscription is `on_hold` due to failed payment, the customer can update their payment method. This automatically charges any outstanding dues.
+
+```typescript
+await client.subscriptions.updatePaymentMethod('sub_xxxxx', {
+  payment_method_id: 'pm_new_method',
+});
 ```
+
+Success emits `payment.succeeded` followed by `subscription.active`.
+
+### List Usage History (Metered Subscriptions)
+
+```typescript
+const history = await client.subscriptions.retrieveUsageHistory('sub_xxxxx', {
+  limit: 50,
+});
+```
+
+### Retrieve Credit Usage
+
+```typescript
+const creditUsage = await client.subscriptions.retrieveCreditUsage('sub_xxxxx');
+console.log(creditUsage.balance_after, creditUsage.deducted);
+```
+
+---
+
+## Plan Changes (Upgrades & Downgrades)
+
+### Change Plan
+
+```typescript
+await client.subscriptions.changePlan('sub_xxxxx', {
+  product_id: 'pdt_higher_tier',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+  on_payment_failure: 'prevent_change',
+});
+```
+
+**Proration modes:**
+
+| Mode | Upgrade | Downgrade | Billing date |
+|------|---------|-----------|--------------|
+| `prorated_immediately` | Time-prorated charge | Time-prorated credit | Resets to change date |
+| `difference_immediately` | Full new-plan charge | Difference becomes credit | Resets |
+| `full_immediately` | Full new-plan charge | Full new-plan charge, no credit | Resets |
+| `do_not_bill` | No charge | No credit | Preserved |
+
+**Payment failure handling:**
+
+- `prevent_change`: Keep the old plan if the charge fails.
+- `apply_change`: Apply the new plan even if payment fails (subscription may become `on_hold`).
+
+### Preview Plan Change
+
+Show the customer a quote before committing:
+
+```typescript
+const preview = await client.subscriptions.previewChangePlan('sub_xxxxx', {
+  product_id: 'pdt_new_plan',
+  quantity: 1,
+  proration_billing_mode: 'prorated_immediately',
+});
+
+console.log('Charge:', preview.charge_amount, preview.charge_currency);
+console.log('Credit:', preview.credit_amount);
+```
+
+### Cancel a Scheduled Plan Change
+
+```typescript
+await client.subscriptions.cancelChangePlan('sub_xxxxx');
+```
+
+---
+
+## Cancellation
+
+### Immediate Cancellation
+
+```typescript
+await client.subscriptions.update('sub_xxxxx', {
+  status: 'cancelled',
+});
+```
+
+Access is revoked immediately.
+
+### Cancel at Period End
+
+```typescript
+await client.subscriptions.update('sub_xxxxx', {
+  cancel_at_next_billing_date: true,
+});
+```
+
+The subscription remains `active` until the next billing date, then transitions to `expired`. The `subscription.cancelled` webhook includes `cancel_at_next_billing_date: true` and `next_billing_date` so you know when to revoke access.
+
+---
+
+## On-Demand (Off-Session) Charging
+
+For usage-based or metered subscriptions, charge the customer on-demand without a scheduled renewal.
+
+### Create Subscription with Mandate
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'pdt_usage_based', quantity: 1 }
+  ],
+  subscription_data: {
+    on_demand: {
+      mandate_only: true,
+    }
+  },
+  customer: { email: 'user@example.com' },
+  return_url: 'https://yoursite.com/success',
+});
+```
+
+This creates a subscription with a mandate but no automatic renewal. You control when to charge.
+
+### Charge On-Demand
+
+```typescript
+const charge = await client.subscriptions.charge('sub_xxxxx', {
+  product_price: 2500, // $25.00 in cents
+  product_currency: 'USD',
+  product_description: 'API calls for January 2025',
+});
+
+console.log('Payment ID:', charge.payment_id);
+```
+
+Amounts are in the smallest currency unit (cents for USD, paise for INR, etc.).
+
+**Dodo does not automatically retry on-demand charges.** You own retry logic and decline filtering. Monitor `payment.failed` webhooks and implement your own retry strategy.
+
+---
+
+## Failed Payments & Recovery
+
+### On-Hold Subscriptions
+
+When a renewal or plan-change charge fails, the subscription moves to `on_hold`. This is recoverable.
+
+```typescript
+// Listen for subscription.on_hold webhook
+case 'subscription.on_hold':
+  // Notify customer, offer payment method update
+  await sendPaymentFailedEmail(data.customer_id);
+  break;
+```
+
+### Recovery Options
+
+1. **Payment Retries:** Opt-in under Settings → Recovery. Dodo retries failed renewals up to 8 times over a configurable 1–30 day window (default 13 days). Only for soft declines.
+
+2. **Customer Portal:** Customer updates payment method → automatic charge for outstanding dues → `subscription.active`.
+
+3. **Manual Charge:** You update the payment method server-side, then call `updatePaymentMethod()`.
+
+### Dunning
+
+Dunning sends up to four configurable emails for `on_hold` renewals and customer-portal cancellations. Exhausted dunning does not change the subscription state; you must handle the final outcome.
+
+---
+
+## Customer Portal
+
+Allow customers to self-serve: view subscriptions, update payment methods, cancel, and upgrade/downgrade.
+
+```typescript
+const portalSession = await client.customers.customerPortal.create(
+  'cus_xxxxx',
+  { return_url: 'https://yoursite.com/account' }
+);
+
+// Redirect to portalSession.link
+```
+
+Portal links expire after 24 hours. Customers can:
+- View subscription details and renewal dates
+- Cancel immediately or at period end
+- Upgrade/downgrade within enabled Product Collections
+- Update payment methods and reactivate `on_hold` subscriptions
+- View billing history and download invoices
+
+For full customer management (creating, updating, listing), see the `customer-management` skill.
 
 ---
 
@@ -80,492 +308,156 @@ const session = await client.checkoutSessions.create({
 
 | Event | When | Action |
 |-------|------|--------|
-| `subscription.active` | Subscription starts | Grant access |
-| `subscription.updated` | Any field changes | Sync state |
-| `subscription.on_hold` | Payment fails | Notify user, retry |
-| `subscription.renewed` | Successful renewal | Log, send receipt |
-| `subscription.plan_changed` | Upgrade/downgrade | Update entitlements |
-| `subscription.cancelled` | User cancels | Schedule end of access |
-| `subscription.failed` | Mandate creation fails | Notify, retry options |
-| `subscription.expired` | Term ends | Revoke access |
+| `subscription.active` | Subscription starts or trial ends | Grant access |
+| `subscription.renewed` | Successful renewal | Log renewal, send receipt |
+| `subscription.on_hold` | Renewal/plan-change payment failed | Notify customer, offer recovery |
+| `subscription.plan_changed` | Plan upgraded/downgraded or add-ons changed | Update entitlements |
+| `subscription.cancelled` | Customer cancels | Schedule access revocation per `cancel_at_next_billing_date` |
+| `subscription.failed` | Initial mandate/payment failed | Notify customer, offer retry or new subscription |
+| `subscription.expired` | Subscription term ended | Revoke access |
 
----
+For webhook signature verification, see the `webhook-integration` skill.
 
-## Implementation Examples
-
-### Full Subscription Handler
+### Example Handler
 
 ```typescript
-// app/api/webhooks/subscription/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma';
-
 export async function POST(req: NextRequest) {
   const event = await req.json();
   const data = event.data;
 
   switch (event.type) {
     case 'subscription.active':
-      await handleSubscriptionActive(data);
-      break;
-    case 'subscription.cancelled':
-      await handleSubscriptionCancelled(data);
+      await grantAccess(data.customer_id, data.product_id);
       break;
     case 'subscription.on_hold':
-      await handleSubscriptionOnHold(data);
+      await notifyPaymentFailed(data.customer_id);
       break;
-    case 'subscription.renewed':
-      await handleSubscriptionRenewed(data);
-      break;
-    case 'subscription.plan_changed':
-      await handlePlanChanged(data);
+    case 'subscription.cancelled':
+      if (data.cancel_at_next_billing_date) {
+        await scheduleAccessRevocation(data.subscription_id, new Date(data.next_billing_date));
+      } else {
+        await revokeAccessImmediately(data.subscription_id);
+      }
       break;
     case 'subscription.expired':
-      await handleSubscriptionExpired(data);
+      await revokeAccess(data.customer_id);
       break;
   }
 
   return NextResponse.json({ received: true });
 }
-
-async function handleSubscriptionActive(data: any) {
-  const {
-    subscription_id,
-    customer,
-    product_id,
-    next_billing_date,
-    recurring_pre_tax_amount,
-    payment_frequency_interval,
-  } = data;
-
-  // Create or update user subscription
-  await prisma.subscription.upsert({
-    where: { externalId: subscription_id },
-    create: {
-      externalId: subscription_id,
-      userId: customer.customer_id,
-      email: customer.email,
-      productId: product_id,
-      status: 'active',
-      currentPeriodEnd: new Date(next_billing_date),
-      amount: recurring_pre_tax_amount,
-      interval: payment_frequency_interval,
-    },
-    update: {
-      status: 'active',
-      currentPeriodEnd: new Date(next_billing_date),
-    },
-  });
-
-  // Grant access
-  await prisma.user.update({
-    where: { id: customer.customer_id },
-    data: { 
-      subscriptionStatus: 'active',
-      plan: product_id,
-    },
-  });
-
-  // Send welcome email
-  await sendWelcomeEmail(customer.email, product_id);
-}
-
-async function handleSubscriptionCancelled(data: any) {
-  const { subscription_id, customer, cancelled_at, cancel_at_next_billing_date } = data;
-
-  await prisma.subscription.update({
-    where: { externalId: subscription_id },
-    data: {
-      status: 'cancelled',
-      cancelledAt: new Date(cancelled_at),
-      // Keep access until end of billing period if cancel_at_next_billing_date
-      accessEndsAt: cancel_at_next_billing_date 
-        ? new Date(data.next_billing_date) 
-        : new Date(),
-    },
-  });
-
-  // Send cancellation email
-  await sendCancellationEmail(customer.email, cancel_at_next_billing_date);
-}
-
-async function handleSubscriptionOnHold(data: any) {
-  const { subscription_id, customer } = data;
-
-  await prisma.subscription.update({
-    where: { externalId: subscription_id },
-    data: { status: 'on_hold' },
-  });
-
-  // Notify user about payment issue
-  await sendPaymentFailedEmail(customer.email);
-}
-
-async function handleSubscriptionRenewed(data: any) {
-  const { subscription_id, next_billing_date } = data;
-
-  await prisma.subscription.update({
-    where: { externalId: subscription_id },
-    data: {
-      status: 'active',
-      currentPeriodEnd: new Date(next_billing_date),
-    },
-  });
-}
-
-async function handlePlanChanged(data: any) {
-  const { subscription_id, product_id, recurring_pre_tax_amount } = data;
-
-  await prisma.subscription.update({
-    where: { externalId: subscription_id },
-    data: {
-      productId: product_id,
-      amount: recurring_pre_tax_amount,
-    },
-  });
-
-  // Update user entitlements based on new plan
-  await updateUserEntitlements(subscription_id, product_id);
-}
-
-async function handleSubscriptionExpired(data: any) {
-  const { subscription_id, customer } = data;
-
-  await prisma.subscription.update({
-    where: { externalId: subscription_id },
-    data: { status: 'expired' },
-  });
-
-  // Revoke access
-  await prisma.user.update({
-    where: { id: customer.customer_id },
-    data: { 
-      subscriptionStatus: 'expired',
-      plan: null,
-    },
-  });
-}
 ```
 
-### Subscription with Trial
+---
+
+## Credit Entitlements
+
+Attach credit entitlements to subscription products to grant credits each billing cycle. For full credit management, see the `credit-based-billing` skill.
+
+Quick example:
 
 ```typescript
+// Product has credit entitlement attached (e.g., 10,000 tokens/month)
 const session = await client.checkoutSessions.create({
   product_cart: [
-    { product_id: 'prod_pro_monthly', quantity: 1 }
+    { product_id: 'pdt_pro_with_credits', quantity: 1 }
   ],
   subscription_data: {
     trial_period_days: 14,
   },
-  customer: {
-    email: 'user@example.com',
-    name: 'John Doe',
-  },
-  return_url: 'https://yoursite.com/welcome',
-});
-```
-
-### Customer Portal for Self-Service
-
-Allow customers to manage their subscription:
-
-```typescript
-// Create portal session
-const portal = await client.customers.createPortalSession({
-  customer_id: 'cust_xxxxx',
-  return_url: 'https://yoursite.com/account',
-});
-
-// Redirect to portal.url
-```
-
-Portal features:
-- View subscription details
-- Update payment method
-- Cancel subscription
-- View billing history
-
----
-
-## On-Demand (Usage-Based) Subscriptions
-
-For metered/usage-based billing:
-
-### Create Subscription with Mandate
-
-```typescript
-const session = await client.checkoutSessions.create({
-  product_cart: [
-    { product_id: 'prod_usage_based', quantity: 1 }
-  ],
   customer: { email: 'user@example.com' },
   return_url: 'https://yoursite.com/success',
 });
 ```
 
-### Charge for Usage
-
-```typescript
-// When usage occurs, create a charge
-const charge = await client.subscriptions.charge({
-  subscription_id: 'sub_xxxxx',
-  amount: 1500, // $15.00 in cents
-  description: 'API calls for January 2025',
-});
-```
-
-### Track Usage Events
-
-```typescript
-// payment.succeeded - Charge succeeded
-// payment.failed - Charge failed, implement retry logic
-```
+On each renewal, credits are issued. Monitor `credit.added` and `credit.deducted` webhooks to sync your ledger.
 
 ---
 
-## Subscriptions with Credit Entitlements
+## Common Mistakes
 
-Attach credit entitlements to subscription products to grant credits each billing cycle:
+### 1. Granting Access on `return_url` Instead of Webhook
 
-### Setup
-
-1. Create a credit entitlement (Dashboard → Products → Credits)
-2. Create/edit a subscription product
-3. In **Entitlements** section, click **Attach** next to Credits
-4. Configure: credits per cycle, trial credits, proration, low balance threshold
-
-### Checkout with Credits
-
+**Wrong:**
 ```typescript
-// Product has credit entitlement attached (e.g., 10,000 AI tokens/month)
+// On return_url redirect
+await grantAccess(user.id);
+```
+
+The `return_url` is hit before the subscription is fully created. Dodo may still be processing the mandate or payment. Always wait for `subscription.active` webhook.
+
+**Right:**
+```typescript
+// In webhook handler
+case 'subscription.active':
+  await grantAccess(data.customer_id);
+  break;
+```
+
+### 2. Using Deprecated `subscriptions.create`
+
+**Wrong:**
+```typescript
+const sub = await client.subscriptions.create({
+  product_id: 'pdt_monthly',
+  customer_id: 'cus_xxxxx',
+});
+```
+
+This endpoint is deprecated. Use Checkout Sessions.
+
+**Right:**
+```typescript
 const session = await client.checkoutSessions.create({
-  product_cart: [
-    { product_id: 'prod_pro_with_credits', quantity: 1 }
-  ],
-  subscription_data: {
-    trial_period_days: 14, // Trial credits can differ from regular amount
-  },
-  customer: { email: 'user@example.com' },
+  product_cart: [{ product_id: 'pdt_monthly', quantity: 1 }],
+  customer: { customer_id: 'cus_xxxxx' },
   return_url: 'https://yoursite.com/success',
 });
 ```
 
-### Credit Lifecycle per Cycle
+### 3. Misinterpreting `subscription.plan_changed`
 
-Each billing cycle:
-1. **New credits issued** — `credit.added` webhook fires
-2. **Usage deducts credits** — Automatically via meters or manually via API
-3. **Cycle ends** — Unused credits expire or roll over based on settings
-4. **Overage handled** — Forgiven, billed, or carried as deficit
+`subscription.plan_changed` fires for upgrades, downgrades, add-on changes, AND when `cancel_at_next_billing_date` is toggled. Don't assume every `plan_changed` event means a paid upgrade succeeded. Inspect the payload and check the subscription's current `product_id`.
 
-### Handle Credit Webhooks in Subscription Context
+### 4. Forgetting Proration Mode
 
 ```typescript
-case 'credit.added':
-  // Credits issued with subscription renewal
-  await syncCreditBalance(data.customer_id, data.credit_entitlement_id, data.balance_after);
-  break;
-case 'credit.balance_low':
-  // Notify customer or suggest upgrade
-  await sendLowBalanceAlert(data.customer_id, data.credit_entitlement_name, data.available_balance);
-  break;
-case 'credit.deducted':
-  // Track consumption for analytics
-  await logCreditUsage(data.customer_id, data.amount);
-  break;
-```
-
-### Plan Changes with Credits
-
-When customers upgrade/downgrade, credit proration can be enabled:
-- **Proration enabled**: Remaining credits are prorated based on time left in cycle
-- **Proration disabled**: Credits continue as-is until next cycle
-
-## Plan Changes
-
-### Upgrade/Downgrade Flow
-
-```typescript
-// Get available plans
-const plans = await client.products.list({
-  type: 'subscription',
-});
-
-// Change plan
-await client.subscriptions.update({
-  subscription_id: 'sub_xxxxx',
-  product_id: 'prod_new_plan',
-  proration_behavior: 'create_prorations', // or 'none'
+// Missing proration_billing_mode
+await client.subscriptions.changePlan('sub_xxxxx', {
+  product_id: 'pdt_new',
+  quantity: 1,
+  // proration_billing_mode: 'prorated_immediately', // REQUIRED
 });
 ```
 
-### Handling `subscription.plan_changed`
+This will fail. Always specify a proration mode.
+
+### 5. Confusing `on_hold` with Pause
+
+`on_hold` means payment failed, not that the customer paused. There is no general pause/resume operation. `on_hold` is recoverable only by updating the payment method or waiting for retry.
+
+### 6. Not Handling `cancel_at_next_billing_date`
 
 ```typescript
-async function handlePlanChanged(data: any) {
-  const { subscription_id, product_id, customer } = data;
-  
-  // Map product to features/limits
-  const planFeatures = getPlanFeatures(product_id);
-  
-  await prisma.user.update({
-    where: { externalId: customer.customer_id },
-    data: {
-      plan: product_id,
-      features: planFeatures,
-      apiLimit: planFeatures.apiLimit,
-      storageLimit: planFeatures.storageLimit,
-    },
-  });
-}
-```
+// Wrong: revoke immediately
+await revokeAccess(data.customer_id);
 
----
-
-## Access Control Pattern
-
-### Middleware Example (Next.js)
-
-```typescript
-// middleware.ts
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-
-export async function middleware(request: NextRequest) {
-  // Check subscription status
-  const session = await getSession(request);
-  
-  if (!session?.user) {
-    return NextResponse.redirect(new URL('/login', request.url));
-  }
-
-  const subscription = await getSubscription(session.user.id);
-
-  // Check if accessing premium feature
-  if (request.nextUrl.pathname.startsWith('/dashboard/pro')) {
-    if (!subscription || subscription.status !== 'active') {
-      return NextResponse.redirect(new URL('/pricing', request.url));
-    }
-    
-    // Check if plan includes this feature
-    if (!subscription.features.includes('pro')) {
-      return NextResponse.redirect(new URL('/upgrade', request.url));
-    }
-  }
-
-  return NextResponse.next();
-}
-```
-
-### React Hook for Subscription State
-
-```typescript
-// hooks/useSubscription.ts
-import useSWR from 'swr';
-
-export function useSubscription() {
-  const { data, error, mutate } = useSWR('/api/subscription', fetcher);
-
-  return {
-    subscription: data,
-    isLoading: !error && !data,
-    isError: error,
-    isActive: data?.status === 'active',
-    isPro: data?.plan?.includes('pro'),
-    refresh: mutate,
-  };
-}
-
-// Usage in component
-function PremiumFeature() {
-  const { isActive, isPro } = useSubscription();
-
-  if (!isActive) {
-    return <UpgradePrompt />;
-  }
-
-  if (!isPro) {
-    return <ProUpgradePrompt />;
-  }
-
-  return <ActualFeature />;
-}
-```
-
----
-
-## Common Patterns
-
-### Grace Period for Failed Payments
-
-```typescript
-async function handleSubscriptionOnHold(data: any) {
-  const gracePeriodDays = 7;
-  
-  await prisma.subscription.update({
-    where: { externalId: data.subscription_id },
-    data: {
-      status: 'on_hold',
-      gracePeriodEnds: new Date(Date.now() + gracePeriodDays * 24 * 60 * 60 * 1000),
-    },
-  });
-
-  // Schedule job to revoke access after grace period
-  await scheduleAccessRevocation(data.subscription_id, gracePeriodDays);
-}
-```
-
-### Prorated Upgrades
-
-When upgrading mid-cycle:
-```typescript
-// Dodo handles proration automatically
-// Customer pays difference for remaining days
-await client.subscriptions.update({
-  subscription_id: 'sub_xxxxx',
-  product_id: 'prod_higher_plan',
-  proration_behavior: 'create_prorations',
-});
-```
-
-### Cancellation with End-of-Period Access
-
-```typescript
-// subscription.cancelled event includes:
-// - cancel_at_next_billing_date: boolean
-// - next_billing_date: string (when access should end)
-
+// Right: check the flag
 if (data.cancel_at_next_billing_date) {
-  // Keep access until next_billing_date
-  await scheduleAccessRevocation(
-    data.subscription_id, 
-    new Date(data.next_billing_date)
-  );
+  await scheduleAccessRevocation(data.subscription_id, new Date(data.next_billing_date));
+} else {
+  await revokeAccessImmediately(data.subscription_id);
 }
 ```
-
----
-
-## Testing
-
-### Test Scenarios
-1. New subscription → `subscription.active`
-2. Renewal success → `subscription.renewed` + `payment.succeeded`
-3. Renewal failure → `subscription.on_hold` + `payment.failed`
-4. Plan upgrade → `subscription.plan_changed`
-5. Cancellation → `subscription.cancelled`
-6. Expiration → `subscription.expired`
-
-### Test in Dashboard
-Use test mode and trigger events manually from the webhook settings.
 
 ---
 
 ## Resources
 
-- [Subscription Guide](https://docs.dodopayments.com/developer-resources/subscription-integration-guide)
+- [Subscription Integration Guide](https://docs.dodopayments.com/developer-resources/subscription-integration-guide)
+- [Upgrade & Downgrade Guide](https://docs.dodopayments.com/developer-resources/subscription-upgrade-downgrade)
 - [On-Demand Subscriptions](https://docs.dodopayments.com/developer-resources/ondemand-subscriptions)
-- [Webhook Events](https://docs.dodopayments.com/developer-resources/webhooks/intents/subscription)
-- [Customer Portal](https://docs.dodopayments.com/developer-resources/customer-portal)
-- [Credit-Based Billing](https://docs.dodopayments.com/features/credit-based-billing)
-- [Credit Webhook Events](https://docs.dodopayments.com/developer-resources/webhooks/intents/credit)
+- [Subscription Webhooks](https://docs.dodopayments.com/developer-resources/webhooks/intents/subscription)
+- [Customer Portal](https://docs.dodopayments.com/features/customer-portal)
+- [Subscription Payment Retries](https://docs.dodopayments.com/features/recovery/payment-retries)
+- [Subscription Dunning](https://docs.dodopayments.com/features/recovery/subscription-dunning)

--- a/dodo-payments/testing-and-go-live/SKILL.md
+++ b/dodo-payments/testing-and-go-live/SKILL.md
@@ -117,8 +117,10 @@ client.subscriptions.update(
 ```
 
 ```go
+// NextBillingDate is param.Field[time.Time], not a string. Passing a string
+// literal compiles to param.Field[string] and will not type-check.
 client.Subscriptions.Update(ctx, "sub_123", dodopayments.SubscriptionUpdateParams{
-    NextBillingDate: dodopayments.F("2026-05-03T00:00:00Z"),
+    NextBillingDate: dodopayments.F(time.Date(2026, time.May, 3, 0, 0, 0, 0, time.UTC)),
 })
 ```
 

--- a/dodo-payments/testing-and-go-live/SKILL.md
+++ b/dodo-payments/testing-and-go-live/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-and-go-live
-description: Guide for testing payment flows, webhook verification, and launching to production with Dodo Payments
+description: Guide for test-mode payment scenarios, renewal simulation, local webhook delivery tests, test and live catalog migration, and production launch checks.
 ---
 
 # Testing and Go-Live
@@ -122,7 +122,7 @@ client.Subscriptions.Update(ctx, "sub_123", dodopayments.SubscriptionUpdateParam
 })
 ```
 
-This immediately schedules the renewal. If you used the subscription-renewal-failure card, the renewal will fail and trigger a `subscription.renewal_failed` webhook.
+This immediately schedules the renewal. If you used the subscription-renewal-failure card, the failed charge emits `payment.failed` and the affected subscription enters `on_hold`, which emits `subscription.on_hold`.
 
 ---
 

--- a/dodo-payments/testing-and-go-live/SKILL.md
+++ b/dodo-payments/testing-and-go-live/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: testing-and-go-live
+description: Guide for testing payment flows, webhook verification, and launching to production with Dodo Payments
+---
+
+# Testing and Go-Live
+
+This skill covers test mode, test payment methods, webhook testing, and the production launch checklist. Use it when building payment flows that need verification before going live, or when preparing to switch from test to production.
+
+## When to use this skill
+
+- You need to test card success/decline scenarios, subscription renewals, or regional payment methods.
+- You're setting up webhook testing locally or in a staging environment.
+- You're preparing to launch to production and need a go-live checklist.
+- You want to verify that test and live environments are properly isolated.
+- You're copying products from test to production.
+
+## Core concepts
+
+**Test vs. live mode:** Dodo Payments maintains two completely separate environments. Each has its own base URL, API keys, webhooks, products, customers, and transactions. Data does not carry over between them.
+
+- **Test mode:** `https://test.dodopayments.com`
+- **Live mode:** `https://live.dodopayments.com`
+
+Each environment requires separate API keys issued from the dashboard. The SDK defaults to `live_mode` if you don't specify `environment`, which is a real footgun in development.
+
+**Test payment methods:** Dodo documents specific card numbers, VPAs, and payment method scenarios for testing. These only work in test mode.
+
+**Webhook testing:** The CLI provides commands to listen for webhooks locally and trigger test events without making real payments.
+
+---
+
+## Setting up test mode
+
+Always explicitly set `environment: 'test_mode'` during development. The default is `live_mode`.
+
+```typescript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode', // REQUIRED — defaults to 'live_mode'
+});
+```
+
+```python
+from dodopayments import DodoPayments
+
+client = DodoPayments(
+    bearer_token=os.environ.get("DODO_PAYMENTS_API_KEY"),
+    environment="test_mode",  # defaults to "live_mode"
+)
+```
+
+```go
+client := dodopayments.NewClient(
+    option.WithBearerToken("dodo_test_..."),
+    option.WithEnvironmentTestMode(), // defaults to WithEnvironmentLiveMode()
+)
+```
+
+Get your test API key from the Dodo dashboard. Test keys are prefixed `dodo_test_`.
+
+---
+
+## Test payment methods
+
+### Card success and decline scenarios
+
+Use these card numbers in test mode. The expiry can be any future date; the CVC can be any three digits.
+
+| Scenario | Card Number | Result |
+|---|---|---|
+| Success | `4242 4242 4242 4242` | Payment succeeds |
+| Decline | `4000 0000 0000 0002` | Payment declined |
+| Decline (insufficient funds) | `4000 0000 0000 9995` | Insufficient funds error |
+| Decline (lost card) | `4000 0000 0000 9987` | Lost card error |
+
+### Subscription renewal failure
+
+To test subscription renewal failures, use this card:
+
+| Card Number | Behavior |
+|---|---|
+| `4000 0000 0000 0069` | Renewal fails on next billing date |
+
+### UPI (India)
+
+Test UPI success and failure with these VPAs:
+
+| VPA | Result |
+|---|---|
+| `success@okhdfcbank` | Payment succeeds |
+| `failure@okhdfcbank` | Payment fails |
+
+### BNPL, wallets, and regional methods
+
+BNPL, Apple Pay, Google Pay, and European payment methods (Giropay, iDEAL, Bancontact) are available in test mode. Exact test scenarios vary by method. Refer to the [Testing Process](https://docs.dodopayments.com/miscellaneous/testing-process) documentation for the current test matrix.
+
+---
+
+## Testing subscription renewals
+
+To force a subscription to renew on a specific date without waiting, update the `next_billing_date`:
+
+```typescript
+await client.subscriptions.update('sub_123', {
+  next_billing_date: '2026-05-03T00:00:00Z',
+});
+```
+
+```python
+client.subscriptions.update(
+    'sub_123',
+    next_billing_date='2026-05-03T00:00:00Z'
+)
+```
+
+```go
+client.Subscriptions.Update(ctx, "sub_123", dodopayments.SubscriptionUpdateParams{
+    NextBillingDate: dodopayments.F("2026-05-03T00:00:00Z"),
+})
+```
+
+This immediately schedules the renewal. If you used the subscription-renewal-failure card, the renewal will fail and trigger a `subscription.renewal_failed` webhook.
+
+---
+
+## Webhook testing
+
+### Listen for webhooks locally
+
+The Dodo CLI provides a tunnel to receive webhooks on your local machine:
+
+```bash
+dodo wh listen
+```
+
+This starts a local server and prints a webhook URL. Use that URL in your dashboard webhook configuration during development.
+
+### Trigger test webhook events
+
+Send a test webhook event without making a real payment:
+
+```bash
+dodo wh trigger
+```
+
+This prompts you to select an event type and sends it to your configured webhook endpoint. Useful for testing your webhook handler before going live.
+
+### Webhook signature verification
+
+Webhook signature verification is covered in the `webhook-integration` skill. Always verify signatures in production, even in test mode.
+
+---
+
+## Copying products from test to live
+
+Products are environment-specific. You cannot reuse a test product ID in production. Instead, recreate the product in live mode or use the dashboard to export and reimport.
+
+**Manual approach:**
+
+1. Note the product details (name, price, tax category, etc.) from test mode.
+2. Create a new product in live mode with the same configuration.
+3. Update your code to use the new live product ID.
+
+**Programmatic approach:**
+
+Fetch the product from test mode, extract its configuration, and create it in live mode:
+
+```typescript
+// In test mode
+const testClient = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+const testProduct = await testClient.products.retrieve('pdt_test_123');
+
+// In live mode
+const liveClient = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'live_mode',
+});
+const liveProduct = await liveClient.products.create({
+  name: testProduct.name,
+  price: testProduct.price,
+  tax_category: testProduct.tax_category,
+  // ... other fields
+});
+```
+
+---
+
+## Go-live checklist
+
+Before switching to production, verify each item:
+
+### Business and compliance
+
+- [ ] KYC (Know Your Customer) verification is complete in the Dodo dashboard.
+- [ ] Business verification is approved.
+- [ ] Your business details are correct in the dashboard.
+
+### API and keys
+
+- [ ] You have live API keys from the dashboard (prefixed `dodo_live_`).
+- [ ] You've rotated or revoked any test keys that were accidentally committed.
+- [ ] Your code uses `environment: 'live_mode'` (or omits it, since live is the default).
+
+### Webhooks
+
+- [ ] Your webhook endpoint is publicly accessible over HTTPS.
+- [ ] You've updated the webhook URL in the dashboard to your production domain.
+- [ ] You've updated the webhook secret in your environment variables.
+- [ ] Your webhook handler verifies signatures using `client.webhooks.unwrap()` or the `standardwebhooks` package.
+- [ ] You've tested the webhook flow end-to-end in production (or a staging environment with live keys).
+
+### Products and checkout
+
+- [ ] All products are created in live mode (not copied from test).
+- [ ] Your checkout code uses live product IDs.
+- [ ] Return URLs point to your production domain.
+- [ ] Tax categories are correct for your products.
+
+### Monitoring and support
+
+- [ ] You have monitoring in place for payment failures, webhook delivery, and API errors.
+- [ ] You know how to access the Dodo dashboard to view transactions and disputes.
+- [ ] You have a plan for handling refunds and chargebacks.
+
+---
+
+## Common mistakes
+
+### Leaving `environment` unset
+
+The SDK defaults to `live_mode`. If you forget to set `environment: 'test_mode'` during development, your test code will hit production and create real charges.
+
+```typescript
+// WRONG — this hits live mode
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+});
+
+// CORRECT
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
+});
+```
+
+### Reusing test product IDs in production
+
+Test and live environments are completely separate. A product ID from test mode does not exist in live mode. Always create new products in live mode or use the dashboard to migrate them.
+
+```typescript
+// WRONG — pdt_test_123 does not exist in live mode
+const session = await liveClient.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_test_123', quantity: 1 }],
+});
+
+// CORRECT — use a live product ID
+const session = await liveClient.checkoutSessions.create({
+  product_cart: [{ product_id: 'pdt_live_456', quantity: 1 }],
+});
+```
+
+### Forgetting to reconfigure webhooks for production
+
+Test and live modes have separate webhook endpoints and secrets. If you copy your test webhook configuration to production without updating the URL and secret, webhooks will fail or go to the wrong place.
+
+- [ ] Update `DODO_PAYMENTS_WEBHOOK_KEY` in production environment variables.
+- [ ] Update the webhook URL in the dashboard to your production domain.
+- [ ] Test webhook delivery in production.
+
+### Not verifying webhook signatures in production
+
+Always verify webhook signatures using `client.webhooks.unwrap()` or the `standardwebhooks` package. Never trust a webhook without verification, even if it came from Dodo.
+
+```typescript
+// WRONG — no verification
+app.post('/webhook', (req, res) => {
+  const event = req.body;
+  handleEvent(event);
+  res.json({ received: true });
+});
+
+// CORRECT
+app.post('/webhook', async (req, res) => {
+  try {
+    const unwrapped = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
+    handleEvent(unwrapped);
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
+  }
+});
+```
+
+### Mixing test and live keys
+
+Test keys (prefixed `dodo_test_`) only work with `https://test.dodopayments.com`. Live keys are issued per mode from the dashboard. Using a test key with live mode will fail with an authentication error.
+
+---
+
+## Resources
+
+- [Testing Process](https://docs.dodopayments.com/miscellaneous/testing-process)
+- [Test vs. Live Mode](https://docs.dodopayments.com/miscellaneous/test-mode-vs-live-mode)
+- [Webhook Integration](https://docs.dodopayments.com/developer-resources/webhooks/intents/introduction)
+- [Dodo CLI](https://docs.dodopayments.com/developer-resources/cli)

--- a/dodo-payments/testing-and-go-live/SKILL.md
+++ b/dodo-payments/testing-and-go-live/SKILL.md
@@ -130,29 +130,45 @@ This immediately schedules the renewal. If you used the subscription-renewal-fai
 
 ## Webhook testing
 
+The CLI ships separately from the SDKs:
+
+```bash
+npm install -g dodopayments-cli
+dodo login
+```
+
+`dodo login` opens the API Keys page, accepts a pasted key, and asks whether it is Test Mode or Live Mode. One key of each can stay authenticated at the same time.
+
 ### Listen for webhooks locally
 
-The Dodo CLI provides a tunnel to receive webhooks on your local machine:
-
 ```bash
-dodo wh listen
+dodo wh listen http://localhost:3000/webhook
 ```
 
-This starts a local server and prints a webhook URL. Use that URL in your dashboard webhook configuration during development.
+This forwards real test-mode events to your local URL over an outbound relay. It is **not** a tunnel: nothing listens publicly and no URL is printed for you to paste into the dashboard. If you need a registerable HTTPS URL, use ngrok instead — that flow is described in the `webhook-integration` skill.
 
-### Trigger test webhook events
+Two constraints to know before running it:
 
-Send a test webhook event without making a real payment:
+- **A Test Mode key is required.** Live Mode keys are not supported by the listen flow.
+- **The URL argument is required in direct mode.** Bare `dodo wh listen` only works inside the interactive TUI as `/wh listen`, which opens a wizard.
+
+Events arriving this way carry valid signatures, so verify them normally with `webhooks.unwrap()`.
+
+### Trigger mock webhook events
 
 ```bash
-dodo wh trigger
+dodo wh trigger payment.success http://localhost:3000/webhook
 ```
 
-This prompts you to select an event type and sends it to your configured webhook endpoint. Useful for testing your webhook handler before going live.
+Sends a realistic mock payload for a chosen event. It runs offline and works even while logged out — which is the tell for the part that matters: **these payloads are unsigned.** `unwrap()` rejects them because there is no valid signature to verify.
+
+Use `unsafeUnwrap()` for triggered events only, and never on an endpoint that also receives real traffic. Event names are `<category>.<event>`, for example `payment.success`, `subscription.active`, or `dispute.opened`.
+
+As with `listen`, both arguments are required in direct mode; `/wh trigger` inside the TUI opens a wizard instead.
 
 ### Webhook signature verification
 
-Webhook signature verification is covered in the `webhook-integration` skill. Always verify signatures in production, even in test mode.
+Covered in the `webhook-integration` skill. Verify every webhook that arrives over the network, in test mode as well as live. The single exception is the unsigned payloads produced by `dodo wh trigger` above.
 
 ---
 

--- a/dodo-payments/usage-based-billing/SKILL.md
+++ b/dodo-payments/usage-based-billing/SKILL.md
@@ -357,10 +357,10 @@ await updateStorageUsage(
 ```typescript
 const usage = await client.subscriptions.retrieveUsageHistory(
   'sub_abc123',
-  { limit: 100 }
+  { page_size: 100 }
 );
 
-console.log(usage.meters); // Array of meter usage records
+console.log(usage.items); // Array of billing-period usage records
 ```
 
 This returns aggregated usage per meter for the subscription's current billing period.
@@ -503,22 +503,26 @@ Event names are case-sensitive and must match the meter's event name exactly.
 ```typescript
 // WRONG — meter expects "api.call", event sends "API.CALL"
 const meter = await client.meters.create({
+  name: 'API Requests',
   event_name: 'api.call',
-  ...
+  aggregation: { type: 'count' },
+  measurement_unit: 'calls',
 });
 
 await client.usageEvents.ingest({
   events: [{
+    event_id: 'api-call:req_123',
+    customer_id: 'cus_abc',
     event_name: 'API.CALL', // Won't match
-    ...
   }]
 });
 
 // CORRECT
 await client.usageEvents.ingest({
   events: [{
+    event_id: 'api-call:req_123',
+    customer_id: 'cus_abc',
     event_name: 'api.call', // Matches exactly
-    ...
   }]
 });
 ```

--- a/dodo-payments/usage-based-billing/SKILL.md
+++ b/dodo-payments/usage-based-billing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: usage-based-billing
-description: Guide for implementing usage-based billing with Dodo Payments - meters, events, pricing per unit, and metered subscriptions.
+description: Guide for charging directly per measured API call, token, storage unit, or other consumption using meters, stable usage events, aggregation, free thresholds, and metered subscriptions.
 ---
 
 # Dodo Payments Usage-Based Billing
@@ -129,19 +129,29 @@ await client.meters.unarchive('mtr_abc123');
 ### Send Events
 
 ```typescript
-await client.usageEvents.ingest({
-  events: [{
-    event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
-    customer_id: 'cus_abc123',
-    event_name: 'api.call',
-    timestamp: new Date().toISOString(),
-    metadata: {
-      endpoint: '/v1/users',
-      method: 'GET',
-    }
-  }]
-});
+async function recordApiCall(
+  customerId: string,
+  requestId: string,
+  occurredAt: string,
+): Promise<number> {
+  const response = await client.usageEvents.ingest({
+    events: [{
+      event_id: `api-call:${requestId}`,
+      customer_id: customerId,
+      event_name: 'api.call',
+      timestamp: occurredAt,
+      metadata: {
+        endpoint: '/v1/users',
+        method: 'GET',
+      },
+    }],
+  });
+
+  return response.ingested_count;
+}
 ```
+
+`requestId` must identify the underlying API operation and remain unchanged across retries. Do not generate it inside the ingestion attempt.
 
 ### Event Schema
 
@@ -155,7 +165,8 @@ await client.usageEvents.ingest({
 
 ### Idempotency and Deduplication
 
-- Each `event_id` is unique per customer per meter.
+- Each distinct operation gets one globally unique `event_id`.
+- Derive the ID from an immutable request, job, generation, or snapshot ID and reuse it on every retry.
 - Duplicate IDs in a single request reject the entire batch.
 - An ID already ingested in an earlier request is silently ignored, making retries safe.
 
@@ -166,17 +177,19 @@ Send up to 1,000 events per request:
 ```typescript
 async function trackBatchUsage(
   events: Array<{
+    operationId: string;
     customerId: string;
     eventName: string;
+    occurredAt: string;
     metadata: Record<string, string>;
   }>
 ) {
-  const formattedEvents = events.map((e, i) => ({
-    event_id: `batch_${Date.now()}_${i}_${crypto.randomUUID()}`,
-    customer_id: e.customerId,
-    event_name: e.eventName,
-    timestamp: new Date().toISOString(),
-    metadata: e.metadata,
+  const formattedEvents = events.map((event) => ({
+    event_id: `usage:${event.operationId}`,
+    customer_id: event.customerId,
+    event_name: event.eventName,
+    timestamp: event.occurredAt,
+    metadata: event.metadata,
   }));
 
   await client.usageEvents.ingest({ events: formattedEvents });
@@ -184,9 +197,9 @@ async function trackBatchUsage(
 
 // Batch track multiple API calls
 await trackBatchUsage([
-  { customerId: 'cus_abc', eventName: 'api.call', metadata: { endpoint: '/v1/users' } },
-  { customerId: 'cus_abc', eventName: 'api.call', metadata: { endpoint: '/v1/orders' } },
-  { customerId: 'cus_xyz', eventName: 'api.call', metadata: { endpoint: '/v1/products' } },
+  { operationId: 'req_101', customerId: 'cus_abc', eventName: 'api.call', occurredAt: '2026-08-01T10:00:00Z', metadata: { endpoint: '/v1/users' } },
+  { operationId: 'req_102', customerId: 'cus_abc', eventName: 'api.call', occurredAt: '2026-08-01T10:00:01Z', metadata: { endpoint: '/v1/orders' } },
+  { operationId: 'req_103', customerId: 'cus_xyz', eventName: 'api.call', occurredAt: '2026-08-01T10:00:02Z', metadata: { endpoint: '/v1/products' } },
 ]);
 ```
 
@@ -208,29 +221,13 @@ const event = await client.usageEvents.retrieve('evt_abc123');
 
 ### Per-Unit Pricing
 
-The only currently documented and operable pricing model. Configure a meter on a product price with:
+The only currently documented and operable pricing model. A meter attachment uses:
 - `price_per_unit`: decimal string (max 5 integer digits, 12 decimal places)
 - `free_threshold`: optional integer (usage below this is not charged)
 
 Charge formula: `(usage − threshold) × price_per_unit`
 
-```typescript
-// Create a product with per-unit pricing
-const product = await client.products.create({
-  name: 'API Service',
-  type: 'usage_based',
-  prices: [{
-    type: 'usage_based_price',
-    currency: 'usd',
-    billing_period: 'month',
-    meters: [{
-      meter_id: 'mtr_api_calls',
-      price_per_unit: '0.001',
-      free_threshold: 1000,
-    }]
-  }]
-});
-```
+The `product-catalog-management` skill is the canonical source for the complete product creation request. It defines the singular `price` object with `type: 'usage_based_price'` and its nested `meters` array; do not define a parallel product schema here.
 
 **Note:** Tiered, graduated, volume, and staircase pricing models are not currently documented in the Dodo Payments API. Use per-unit pricing with free thresholds for now.
 
@@ -240,35 +237,58 @@ const product = await client.products.create({
 
 ### Track API Calls
 
-Place the ingest call in a non-blocking context to avoid slowing down user requests:
+Persist the event before reporting the operation as complete, then ingest it from a retrying worker. The outbox or queue implementation must durably store the payload before `persist` resolves.
 
 ```typescript
-// Express middleware (non-blocking)
-app.use(async (req, res, next) => {
-  res.on('finish', async () => {
-    // Fire-and-forget after response is sent
-    client.usageEvents.ingest({
-      events: [{
-        event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
-        customer_id: req.user.id,
-        event_name: 'api.call',
-        timestamp: new Date().toISOString(),
-        metadata: {
-          endpoint: req.path,
-          method: req.method,
-          status: res.statusCode,
-        }
-      }]
-    }).catch(err => console.error('Failed to ingest event:', err));
+type PersistedUsageEvent = {
+  event_id: string;
+  customer_id: string;
+  event_name: string;
+  timestamp: string;
+  metadata: Record<string, string | number | boolean>;
+};
+
+interface UsageOutbox {
+  persist(event: PersistedUsageEvent): Promise<void>;
+  nextBatch(limit: number): Promise<PersistedUsageEvent[]>;
+  markIngested(eventIds: string[]): Promise<void>;
+}
+
+async function completeApiOperation(
+  outbox: UsageOutbox,
+  operationId: string,
+  customerId: string,
+  occurredAt: string,
+): Promise<void> {
+  await outbox.persist({
+    event_id: `api-call:${operationId}`,
+    customer_id: customerId,
+    event_name: 'api.call',
+    timestamp: occurredAt,
+    metadata: { endpoint: '/v1/users', method: 'GET', status: 200 },
   });
-  next();
-});
+}
+
+async function ingestUsageOutbox(outbox: UsageOutbox): Promise<void> {
+  const events = await outbox.nextBatch(1000);
+  if (events.length === 0) return;
+
+  await client.usageEvents.ingest({ events });
+  await outbox.markIngested(events.map((event) => event.event_id));
+}
 ```
+
+If the worker crashes after Dodo accepts the batch but before `markIngested`, retry the same persisted events with the same IDs. Dodo ignores the already-ingested IDs.
 
 ### Track AI Token Usage
 
 ```typescript
-async function callAI(customerId: string, prompt: string) {
+async function callAI(
+  customerId: string,
+  generationId: string,
+  prompt: string,
+  completedAt: string,
+) {
   const response = await openai.chat.completions.create({
     model: 'gpt-4',
     messages: [{ role: 'user', content: prompt }],
@@ -277,10 +297,10 @@ async function callAI(customerId: string, prompt: string) {
   // Track tokens after completion
   await client.usageEvents.ingest({
     events: [{
-      event_id: `ai_${Date.now()}_${crypto.randomUUID()}`,
+      event_id: `generation:${generationId}`,
       customer_id: customerId,
       event_name: 'ai.tokens',
-      timestamp: new Date().toISOString(),
+      timestamp: completedAt,
       metadata: {
         tokens: response.usage.total_tokens.toString(),
         prompt_tokens: response.usage.prompt_tokens.toString(),
@@ -299,13 +319,18 @@ async function callAI(customerId: string, prompt: string) {
 For snapshot-based metrics (current state), use the `last` aggregation:
 
 ```typescript
-async function updateStorageUsage(customerId: string, bytesUsed: number) {
+async function updateStorageUsage(
+  customerId: string,
+  snapshotId: string,
+  bytesUsed: number,
+  capturedAt: string,
+) {
   await client.usageEvents.ingest({
     events: [{
-      event_id: `storage_${Date.now()}_${customerId}`,
+      event_id: `storage-snapshot:${snapshotId}`,
       customer_id: customerId,
       event_name: 'storage.snapshot',
-      timestamp: new Date().toISOString(),
+      timestamp: capturedAt,
       metadata: {
         bytes: bytesUsed.toString(),
         gb: (bytesUsed / 1024 / 1024 / 1024).toFixed(2),
@@ -315,7 +340,12 @@ async function updateStorageUsage(customerId: string, bytesUsed: number) {
 }
 
 // Call periodically or after storage changes
-await updateStorageUsage('cus_abc', 5368709120); // 5GB
+await updateStorageUsage(
+  'cus_abc',
+  'snapshot_01K1M4D2K9',
+  5368709120,
+  '2026-08-01T10:30:00Z',
+); // 5GB
 ```
 
 ---
@@ -360,50 +390,53 @@ Usage events trigger webhooks for monitoring and reconciliation. See the `webhoo
 
 ## Common Mistakes
 
-### 1. Reusing Event IDs Across Distinct Events
+### 1. Using Unstable or Reused Event IDs
 
-Each event must have a unique ID. Reusing an ID causes the second event to be silently ignored.
+Generate one ID from the immutable business operation. Reusing an ID for a different operation drops usage, while generating a timestamp or random ID on every retry can bill the same operation twice.
 
 ```typescript
-// WRONG
+// WRONG — a retry creates a new billable event
 await client.usageEvents.ingest({
-  events: [
-    { event_id: 'evt_1', customer_id: 'cus_abc', event_name: 'api.call', ... },
-    { event_id: 'evt_1', customer_id: 'cus_abc', event_name: 'api.call', ... }, // Ignored
-  ]
+  events: [{
+    event_id: `api-call:${Date.now()}:${crypto.randomUUID()}`,
+    customer_id: 'cus_abc',
+    event_name: 'api.call',
+  }],
 });
 
-// CORRECT
+// CORRECT — retry request req_123 with this same ID
 await client.usageEvents.ingest({
-  events: [
-    { event_id: `api_${Date.now()}_1`, customer_id: 'cus_abc', event_name: 'api.call', ... },
-    { event_id: `api_${Date.now()}_2`, customer_id: 'cus_abc', event_name: 'api.call', ... },
-  ]
+  events: [{
+    event_id: 'api-call:req_123',
+    customer_id: 'cus_abc',
+    event_name: 'api.call',
+  }],
 });
 ```
 
-### 2. Blocking User Requests on Event Ingestion
+Do not reuse `api-call:req_123` for a distinct request. This matches credit ledger guidance: a timeout is not permission to generate a fresh idempotency key.
 
-Ingest events asynchronously after the response is sent. Never wait for the ingest call to complete before returning to the user.
+### 2. Using Fire-and-Forget Ingestion
+
+Do not start ingestion after responding without first persisting the event. The process can crash after the user receives success but before usage reaches Dodo.
 
 ```typescript
-// WRONG — blocks the user
+// WRONG — an acknowledged operation can lose its usage event
 app.post('/api/generate', async (req, res) => {
   const result = await generateAI(req.body);
-  await client.usageEvents.ingest({ events: [...] }); // Blocks response
   res.json(result);
+  void client.usageEvents.ingest({ events: [result.usageEvent] });
 });
 
-// CORRECT — fire-and-forget
+// CORRECT — durable persistence completes before success is returned
 app.post('/api/generate', async (req, res) => {
   const result = await generateAI(req.body);
+  await usageOutbox.persist(result.usageEvent);
   res.json(result);
-  
-  // Ingest after response is sent
-  client.usageEvents.ingest({ events: [...] })
-    .catch(err => console.error('Ingest failed:', err));
 });
 ```
+
+A retrying worker ingests the persisted payload with its original `event_id`, as shown in **Track API Calls**. If persistence fails, return an error so the operation can be retried rather than silently underbilling.
 
 ### 3. Clock Skew in Timestamps
 
@@ -451,21 +484,15 @@ const trackUsage = async (eventName: string) => {
   });
 };
 
-// CORRECT — backend route
-app.post('/api/track-usage', async (req, res) => {
-  const { customerId, eventName, metadata } = req.body;
-  
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `${eventName}_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: eventName,
-      timestamp: new Date().toISOString(),
-      metadata,
-    }]
-  });
-  
-  res.json({ success: true });
+// CORRECT — send the event from a backend worker using its persisted payload
+await client.usageEvents.ingest({
+  events: [{
+    event_id: 'api-call:req_123',
+    customer_id: 'cus_abc',
+    event_name: 'api.call',
+    timestamp: '2026-08-01T10:30:00Z',
+    metadata: { endpoint: '/v1/users' },
+  }],
 });
 ```
 

--- a/dodo-payments/usage-based-billing/SKILL.md
+++ b/dodo-payments/usage-based-billing/SKILL.md
@@ -11,20 +11,21 @@ Charge customers for what they actually use—API calls, storage, AI tokens, or 
 
 ---
 
-## Overview
+## When to use this skill
 
-Usage-based billing is perfect for:
-- **APIs**: Charge per request or operation
-- **AI Services**: Bill per token, generation, or inference
-- **Infrastructure**: Charge for compute, storage, bandwidth
-- **SaaS**: Metered features alongside subscriptions
+- You need to bill customers based on consumption (API calls, tokens, storage, bandwidth).
+- You want to combine usage charges with subscriptions or one-time purchases.
+- You need to track and aggregate events into billable quantities.
+- You're building an AI service, SaaS platform, or infrastructure product with metered features.
 
 ---
 
 ## Core Concepts
 
 ### Events
-Usage actions sent from your application:
+
+Usage records sent from your application to Dodo. Each event is attributed to a customer and matched to a meter by its `event_name`.
+
 ```json
 {
   "event_id": "evt_unique_123",
@@ -36,56 +37,101 @@ Usage actions sent from your application:
 ```
 
 ### Meters
-Aggregate events into billable quantities:
-| Aggregation | Use Case | Example |
-|-------------|----------|---------|
+
+Filters and aggregates events into billable quantities. A meter specifies:
+- **Event name**: which events to match (case-sensitive)
+- **Aggregation type**: how to combine events (count, sum, max, last)
+- **Measurement unit**: the billing unit (calls, tokens, GB, etc.)
+- **Optional filters**: conditions events must meet to be counted
+
+### Aggregation Types
+
+| Type | Use Case | Example |
+|------|----------|---------|
 | **Count** | Total events | API calls, image generations |
-| **Sum** | Add values | Tokens used, bytes transferred |
-| **Max** | Highest value | Peak concurrent users |
-| **Last** | Most recent | Current storage used |
+| **Sum** | Add values from a property | Tokens used, bytes transferred |
+| **Max** | Highest value in a period | Peak concurrent users |
+| **Last** | Most recent value | Current storage used |
 
-### Products with Usage Pricing
-- Price per unit (e.g., $0.001 per API call)
-- Free threshold (e.g., 1,000 free calls)
-- Automatic billing each cycle
+For `sum`, `max`, and `last`, you specify which metadata property to aggregate.
 
-**Billing Example**: 2,500 calls - 1,000 free = 1,500 × $0.02 = $30.00
+### Pricing
+
+Attach a meter to a product price to charge per unit:
+- **Price per unit**: e.g., $0.001 per API call
+- **Free threshold**: e.g., 1,000 free calls per month
+- **Charge formula**: `(usage − threshold) × price_per_unit`
+
+**Example**: 2,500 calls − 1,000 free = 1,500 × $0.02 = $30.00
 
 ---
 
-## Quick Start
+## Meter Lifecycle
 
-### 1. Create a Meter
-
-In Dashboard → Meters → Create Meter:
-
-1. **Name**: "API Requests"
-2. **Event Name**: `api.call` (exact match, case-sensitive)
-3. **Aggregation**: Count
-4. **Unit**: "calls"
-
-### 2. Create Usage-Based Product
-
-In Dashboard → Products → Create Product:
-
-1. Select **Usage-Based** type
-2. Connect your meter
-3. Set pricing:
-   - **Price Per Unit**: $0.001
-   - **Free Threshold**: 1000
-
-### 3. Send Events
+### Create a Meter
 
 ```typescript
 import DodoPayments from 'dodopayments';
 
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: 'test_mode',
 });
 
+const meter = await client.meters.create({
+  name: 'API Requests',
+  event_name: 'api.call',
+  aggregation: { type: 'count' },
+  measurement_unit: 'calls',
+  description: 'Track API calls per customer',
+});
+
+console.log(meter.id); // mtr_...
+```
+
+For a sum aggregation, specify the property to aggregate:
+
+```typescript
+const meter = await client.meters.create({
+  name: 'Token Usage',
+  event_name: 'ai.tokens',
+  aggregation: { type: 'sum', key: 'tokens' },
+  measurement_unit: 'tokens',
+});
+```
+
+### List and Retrieve Meters
+
+```typescript
+// List all meters
+const meters = await client.meters.list();
+
+// Retrieve a specific meter
+const meter = await client.meters.retrieve('mtr_abc123');
+```
+
+### Archive and Unarchive
+
+Meters are archived, not deleted. Archived meters stop accepting new events but retain historical data.
+
+```typescript
+// Archive a meter
+await client.meters.archive('mtr_abc123');
+
+// Unarchive to resume
+await client.meters.unarchive('mtr_abc123');
+```
+
+---
+
+## Event Ingestion
+
+### Send Events
+
+```typescript
 await client.usageEvents.ingest({
   events: [{
-    event_id: `api_${Date.now()}_${Math.random()}`,
+    event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
     customer_id: 'cus_abc123',
     event_name: 'api.call',
     timestamp: new Date().toISOString(),
@@ -97,52 +143,25 @@ await client.usageEvents.ingest({
 });
 ```
 
----
+### Event Schema
 
-## Implementation Examples
+| Field | Required | Notes |
+|-------|----------|-------|
+| `event_id` | Yes | Unique identifier for idempotency. Duplicate IDs in the same request reject the entire request. |
+| `customer_id` | Yes | Dodo Payments customer ID. |
+| `event_name` | Yes | Must match a meter's event name exactly (case-sensitive). |
+| `timestamp` | No | ISO-8601 datetime. Defaults to current UTC time. Must be within one hour in the past or five minutes in the future. |
+| `metadata` | No | Object with string, integer, number, or boolean values. Max 50 pairs; key length 100, value length 500. No nested objects or arrays. |
 
-### TypeScript/Node.js
+### Idempotency and Deduplication
 
-```typescript
-import DodoPayments from 'dodopayments';
+- Each `event_id` is unique per customer per meter.
+- Duplicate IDs in a single request reject the entire batch.
+- An ID already ingested in an earlier request is silently ignored, making retries safe.
 
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
-});
+### Batch Ingestion
 
-// Track single event
-async function trackUsage(
-  customerId: string,
-  eventName: string,
-  metadata: Record<string, string>
-) {
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `${eventName}_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: eventName,
-      timestamp: new Date().toISOString(),
-      metadata,
-    }]
-  });
-}
-
-// Track API call
-await trackUsage('cus_abc123', 'api.call', {
-  endpoint: '/v1/generate',
-  method: 'POST',
-});
-
-// Track token usage (for Sum aggregation)
-await trackUsage('cus_abc123', 'token.usage', {
-  tokens: '1500',
-  model: 'gpt-4',
-});
-```
-
-### Batch Event Ingestion
-
-Send multiple events efficiently (max 1000 per request):
+Send up to 1,000 events per request:
 
 ```typescript
 async function trackBatchUsage(
@@ -150,14 +169,13 @@ async function trackBatchUsage(
     customerId: string;
     eventName: string;
     metadata: Record<string, string>;
-    timestamp?: string;
   }>
 ) {
   const formattedEvents = events.map((e, i) => ({
     event_id: `batch_${Date.now()}_${i}_${crypto.randomUUID()}`,
     customer_id: e.customerId,
     event_name: e.eventName,
-    timestamp: e.timestamp || new Date().toISOString(),
+    timestamp: new Date().toISOString(),
     metadata: e.metadata,
   }));
 
@@ -172,162 +190,91 @@ await trackBatchUsage([
 ]);
 ```
 
-### Python
+### Query Events
 
-```python
-from dodopayments import DodoPayments
-import uuid
-from datetime import datetime
+```typescript
+// List events for a customer
+const events = await client.usageEvents.list({
+  customer_id: 'cus_abc123',
+});
 
-client = DodoPayments(bearer_token=os.environ["DODO_PAYMENTS_API_KEY"])
-
-def track_usage(customer_id: str, event_name: str, metadata: dict):
-    client.usage_events.ingest(events=[{
-        "event_id": f"{event_name}_{datetime.now().timestamp()}_{uuid.uuid4()}",
-        "customer_id": customer_id,
-        "event_name": event_name,
-        "timestamp": datetime.now().isoformat(),
-        "metadata": metadata
-    }])
-
-# Track AI token usage
-track_usage("cus_abc123", "ai.tokens", {
-    "tokens": "2500",
-    "model": "claude-3",
-    "operation": "completion"
-})
-
-# Track image generation
-track_usage("cus_abc123", "image.generated", {
-    "size": "1024x1024",
-    "model": "dall-e-3"
-})
-```
-
-### Go
-
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "os"
-    "time"
-
-    "github.com/dodopayments/dodopayments-go"
-    "github.com/google/uuid"
-)
-
-func main() {
-    client := dodopayments.NewClient(
-        option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
-    )
-
-    ctx := context.Background()
-
-    _, err := client.UsageEvents.Ingest(ctx, &dodopayments.UsageEventIngestParams{
-        Events: []dodopayments.UsageEvent{{
-            EventID:    fmt.Sprintf("api_%d_%s", time.Now().Unix(), uuid.New().String()),
-            CustomerID: "cus_abc123",
-            EventName:  "api.call",
-            Timestamp:  time.Now().Format(time.RFC3339),
-            Metadata: map[string]string{
-                "endpoint": "/v1/users",
-                "method":   "GET",
-            },
-        }},
-    })
-
-    if err != nil {
-        panic(err)
-    }
-}
+// Retrieve a specific event
+const event = await client.usageEvents.retrieve('evt_abc123');
 ```
 
 ---
 
-## Meter Configuration
+## Pricing Models
 
-### Aggregation Types
+### Per-Unit Pricing
 
-#### Count (API Calls, Requests)
-```
-Meter: API Requests
-Event Name: api.call
-Aggregation: Count
-Unit: calls
-```
+The only currently documented and operable pricing model. Configure a meter on a product price with:
+- `price_per_unit`: decimal string (max 5 integer digits, 12 decimal places)
+- `free_threshold`: optional integer (usage below this is not charged)
 
-#### Sum (Tokens, Bytes)
-```
-Meter: Token Usage
-Event Name: token.usage
-Aggregation: Sum
-Over Property: tokens
-Unit: tokens
-```
+Charge formula: `(usage − threshold) × price_per_unit`
 
-Events must include the property in metadata:
 ```typescript
-await client.usageEvents.ingest({
-  events: [{
-    event_id: 'token_123',
-    customer_id: 'cus_abc',
-    event_name: 'token.usage',
-    metadata: { tokens: '1500' } // This value gets summed
+// Create a product with per-unit pricing
+const product = await client.products.create({
+  name: 'API Service',
+  type: 'usage_based',
+  prices: [{
+    type: 'usage_based_price',
+    currency: 'usd',
+    billing_period: 'month',
+    meters: [{
+      meter_id: 'mtr_api_calls',
+      price_per_unit: '0.001',
+      free_threshold: 1000,
+    }]
   }]
 });
 ```
 
-#### Max (Peak Concurrent Users)
-```
-Meter: Peak Users
-Event Name: concurrent.users
-Aggregation: Max
-Over Property: count
-Unit: users
-```
-
-#### Last (Current Storage)
-```
-Meter: Storage Used
-Event Name: storage.snapshot
-Aggregation: Last
-Over Property: bytes
-Unit: GB
-```
-
-### Event Filtering
-
-Filter which events count toward the meter:
-
-```
-Filter Logic: AND
-Conditions:
-  - Property: tier, Equals: "premium"
-  - Property: status, Equals: "success"
-```
-
-Only events matching ALL conditions are counted.
+**Note:** Tiered, graduated, volume, and staircase pricing models are not currently documented in the Dodo Payments API. Use per-unit pricing with free thresholds for now.
 
 ---
 
-## Common Use Cases
+## Instrumenting Your Application
 
-### AI Token Billing
+### Track API Calls
+
+Place the ingest call in a non-blocking context to avoid slowing down user requests:
 
 ```typescript
-// Meter: AI Tokens (Sum aggregation over "tokens" property)
+// Express middleware (non-blocking)
+app.use(async (req, res, next) => {
+  res.on('finish', async () => {
+    // Fire-and-forget after response is sent
+    client.usageEvents.ingest({
+      events: [{
+        event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
+        customer_id: req.user.id,
+        event_name: 'api.call',
+        timestamp: new Date().toISOString(),
+        metadata: {
+          endpoint: req.path,
+          method: req.method,
+          status: res.statusCode,
+        }
+      }]
+    }).catch(err => console.error('Failed to ingest event:', err));
+  });
+  next();
+});
+```
 
-async function trackAIUsage(
-  customerId: string,
-  promptTokens: number,
-  completionTokens: number,
-  model: string
-) {
-  const totalTokens = promptTokens + completionTokens;
+### Track AI Token Usage
 
+```typescript
+async function callAI(customerId: string, prompt: string) {
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  // Track tokens after completion
   await client.usageEvents.ingest({
     events: [{
       event_id: `ai_${Date.now()}_${crypto.randomUUID()}`,
@@ -335,74 +282,23 @@ async function trackAIUsage(
       event_name: 'ai.tokens',
       timestamp: new Date().toISOString(),
       metadata: {
-        tokens: totalTokens.toString(),
-        prompt_tokens: promptTokens.toString(),
-        completion_tokens: completionTokens.toString(),
-        model,
+        tokens: response.usage.total_tokens.toString(),
+        prompt_tokens: response.usage.prompt_tokens.toString(),
+        completion_tokens: response.usage.completion_tokens.toString(),
+        model: 'gpt-4',
       }
     }]
   });
-}
 
-// After AI completion
-await trackAIUsage('cus_abc', 500, 1200, 'gpt-4');
-```
-
-### Image Generation
-
-```typescript
-// Meter: Images Generated (Count aggregation)
-
-async function trackImageGeneration(
-  customerId: string,
-  imageSize: string,
-  model: string
-) {
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `img_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: 'image.generated',
-      timestamp: new Date().toISOString(),
-      metadata: {
-        size: imageSize,
-        model,
-      }
-    }]
-  });
+  return response;
 }
 ```
 
-### API Rate Tracking
+### Track Storage Usage
+
+For snapshot-based metrics (current state), use the `last` aggregation:
 
 ```typescript
-// Middleware for Express/Next.js
-
-async function trackAPIUsage(
-  req: Request,
-  customerId: string
-) {
-  await client.usageEvents.ingest({
-    events: [{
-      event_id: `api_${Date.now()}_${crypto.randomUUID()}`,
-      customer_id: customerId,
-      event_name: 'api.call',
-      timestamp: new Date().toISOString(),
-      metadata: {
-        endpoint: req.url,
-        method: req.method,
-        user_agent: req.headers['user-agent'] || 'unknown',
-      }
-    }]
-  });
-}
-```
-
-### Storage Billing
-
-```typescript
-// Meter: Storage (Last aggregation - snapshot of current usage)
-
 async function updateStorageUsage(customerId: string, bytesUsed: number) {
   await client.usageEvents.ingest({
     events: [{
@@ -424,248 +320,180 @@ await updateStorageUsage('cus_abc', 5368709120); // 5GB
 
 ---
 
-## Next.js Integration
+## Querying Usage for Display
 
-### API Route for Usage Tracking
-
-```typescript
-// app/api/track-usage/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import DodoPayments from 'dodopayments';
-
-const client = new DodoPayments({
-  bearerToken: process.env.DODO_PAYMENTS_API_KEY!,
-});
-
-export async function POST(req: NextRequest) {
-  const { customerId, eventName, metadata } = await req.json();
-
-  try {
-    await client.usageEvents.ingest({
-      events: [{
-        event_id: `${eventName}_${Date.now()}_${crypto.randomUUID()}`,
-        customer_id: customerId,
-        event_name: eventName,
-        timestamp: new Date().toISOString(),
-        metadata,
-      }]
-    });
-
-    return NextResponse.json({ success: true });
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message },
-      { status: 500 }
-    );
-  }
-}
-```
-
-### Usage Tracking Hook
+### Retrieve Usage History
 
 ```typescript
-// hooks/useUsageTracking.ts
-import { useCallback } from 'react';
+const usage = await client.subscriptions.retrieveUsageHistory(
+  'sub_abc123',
+  { limit: 100 }
+);
 
-export function useUsageTracking(customerId: string) {
-  const trackUsage = useCallback(async (
-    eventName: string,
-    metadata: Record<string, string>
-  ) => {
-    await fetch('/api/track-usage', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ customerId, eventName, metadata }),
-    });
-  }, [customerId]);
-
-  return { trackUsage };
-}
-
-// Usage in component
-function AIChat() {
-  const { trackUsage } = useUsageTracking('cus_abc123');
-
-  const handleGenerate = async () => {
-    const result = await generateAIResponse(prompt);
-    
-    // Track token usage
-    await trackUsage('ai.tokens', {
-      tokens: result.totalTokens.toString(),
-      model: 'gpt-4',
-    });
-  };
-}
+console.log(usage.meters); // Array of meter usage records
 ```
+
+This returns aggregated usage per meter for the subscription's current billing period.
 
 ---
 
-## Hybrid Billing
+## Credit-Based Billing Integration
 
-Combine usage-based with subscriptions:
+Usage events can deduct from a customer's credit balance instead of charging per-unit. See the `credit-based-billing` skill for full details on credit entitlements, balances, and ledger management.
 
-### Subscription + Usage Overage
+To link a meter to credits:
 
-```typescript
-// 1. Customer subscribes to plan with included usage
-// Product: Pro Plan - $49/month + $0.01/call after 10,000 free
+1. Create a credit entitlement (e.g., "AI Credits").
+2. Attach the credit entitlement to the same product.
+3. On the meter, enable **Bill usage in Credits**.
+4. Set `credit_entitlement_id` and `meter_units_per_credit` (e.g., 1,000 tokens = 1 credit).
 
-// 2. Track all usage events
-await trackUsage('cus_abc', 'api.call', { endpoint: '/v1/generate' });
+Usage under the free threshold is excluded. Approximately every minute, a background worker aggregates new usage, converts it using the meter-to-credit ratio, and consumes the oldest non-expired credit grants (FIFO). When credits run out, configured overage behavior applies.
 
-// 3. Dodo automatically:
-//    - Applies free threshold (10,000 calls)
-//    - Charges overage at $0.01/call
-//    - Combines with subscription fee
-```
+---
 
-### Multiple Meters per Product
+## Webhook Integration
 
-Attach up to 10 meters to a single product:
+Usage events trigger webhooks for monitoring and reconciliation. See the `webhook-integration` skill for webhook setup and verification.
 
-```
-Product: AI Platform
-├── Meter: API Calls ($0.001/call, 1000 free)
-├── Meter: Token Usage ($0.01/1000 tokens)
-├── Meter: Image Generations ($0.05/image, 10 free)
-└── Meter: Storage ($0.10/GB)
-```
+---
 
-### Credit-Based Meter Billing
+## Common Mistakes
 
-Link meters to credit entitlements so usage events deduct from a customer's credit balance instead of charging per-unit:
+### 1. Reusing Event IDs Across Distinct Events
 
-1. Create a credit entitlement (Dashboard → Products → Credits)
-2. Create a usage-based product with a meter
-3. On the meter, toggle **Bill usage in Credits**
-4. Select the credit entitlement and set **Meter units per credit**
+Each event must have a unique ID. Reusing an ID causes the second event to be silently ignored.
 
 ```typescript
-// Meter: AI Tokens (Sum aggregation over "tokens")
-// Credit: "AI Credits" with 10,000 credits/cycle
-// Meter units per credit: 1000 (1,000 tokens = 1 credit)
+// WRONG
+await client.usageEvents.ingest({
+  events: [
+    { event_id: 'evt_1', customer_id: 'cus_abc', event_name: 'api.call', ... },
+    { event_id: 'evt_1', customer_id: 'cus_abc', event_name: 'api.call', ... }, // Ignored
+  ]
+});
 
-// Usage events deduct credits automatically
+// CORRECT
+await client.usageEvents.ingest({
+  events: [
+    { event_id: `api_${Date.now()}_1`, customer_id: 'cus_abc', event_name: 'api.call', ... },
+    { event_id: `api_${Date.now()}_2`, customer_id: 'cus_abc', event_name: 'api.call', ... },
+  ]
+});
+```
+
+### 2. Blocking User Requests on Event Ingestion
+
+Ingest events asynchronously after the response is sent. Never wait for the ingest call to complete before returning to the user.
+
+```typescript
+// WRONG — blocks the user
+app.post('/api/generate', async (req, res) => {
+  const result = await generateAI(req.body);
+  await client.usageEvents.ingest({ events: [...] }); // Blocks response
+  res.json(result);
+});
+
+// CORRECT — fire-and-forget
+app.post('/api/generate', async (req, res) => {
+  const result = await generateAI(req.body);
+  res.json(result);
+  
+  // Ingest after response is sent
+  client.usageEvents.ingest({ events: [...] })
+    .catch(err => console.error('Ingest failed:', err));
+});
+```
+
+### 3. Clock Skew in Timestamps
+
+Timestamps must be within one hour in the past or five minutes in the future. Ensure your server clock is synchronized.
+
+```typescript
+// WRONG — timestamp is 2 hours old
+const oldTime = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
 await client.usageEvents.ingest({
   events: [{
-    event_id: `ai_${Date.now()}_${crypto.randomUUID()}`,
-    customer_id: 'cus_abc123',
-    event_name: 'ai.tokens',
-    timestamp: new Date().toISOString(),
-    metadata: { tokens: '1500', model: 'gpt-4' }
+    event_id: 'evt_123',
+    customer_id: 'cus_abc',
+    event_name: 'api.call',
+    timestamp: oldTime, // Rejected
+    metadata: {}
   }]
 });
 
-// Check remaining credit balance
-const balance = await client.creditEntitlements.balances.get(
-  'cent_ai_credits',
-  'cus_abc123'
-);
-console.log(`Credits remaining: ${balance.available_balance}`);
+// CORRECT — use current time
+await client.usageEvents.ingest({
+  events: [{
+    event_id: 'evt_123',
+    customer_id: 'cus_abc',
+    event_name: 'api.call',
+    timestamp: new Date().toISOString(),
+    metadata: {}
+  }]
+});
 ```
 
-Credit deduction runs via a background worker every minute using FIFO ordering (oldest grants consumed first). When credits run out:
-- **Overage disabled**: Usage is blocked
-- **Overage enabled**: Usage continues and overage is tracked per your configured behavior (forgive, bill, or carry deficit)
----
+### 4. Ingesting on the Client Side
 
-## Best Practices
+Never send events from client-side code. Always ingest from your backend to avoid exposing your API key.
 
-### 1. Unique Event IDs
-Always generate unique IDs for idempotency:
 ```typescript
-const eventId = `${eventName}_${Date.now()}_${crypto.randomUUID()}`;
+// WRONG — client-side
+const trackUsage = async (eventName: string) => {
+  await fetch('https://test.dodopayments.com/events/ingest', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.DODO_PAYMENTS_API_KEY}`, // Exposed!
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ events: [...] })
+  });
+};
+
+// CORRECT — backend route
+app.post('/api/track-usage', async (req, res) => {
+  const { customerId, eventName, metadata } = req.body;
+  
+  await client.usageEvents.ingest({
+    events: [{
+      event_id: `${eventName}_${Date.now()}_${crypto.randomUUID()}`,
+      customer_id: customerId,
+      event_name: eventName,
+      timestamp: new Date().toISOString(),
+      metadata,
+    }]
+  });
+  
+  res.json({ success: true });
+});
 ```
 
-### 2. Batch Events
-For high-volume, batch events (max 1000/request):
+### 5. Mismatched Event Names
+
+Event names are case-sensitive and must match the meter's event name exactly.
+
 ```typescript
-// Queue events and send in batches
-const eventQueue: Event[] = [];
+// WRONG — meter expects "api.call", event sends "API.CALL"
+const meter = await client.meters.create({
+  event_name: 'api.call',
+  ...
+});
 
-function queueEvent(event: Event) {
-  eventQueue.push(event);
-  if (eventQueue.length >= 100) {
-    flushEvents();
-  }
-}
+await client.usageEvents.ingest({
+  events: [{
+    event_name: 'API.CALL', // Won't match
+    ...
+  }]
+});
 
-async function flushEvents() {
-  if (eventQueue.length === 0) return;
-  const batch = eventQueue.splice(0, 1000);
-  await client.usageEvents.ingest({ events: batch });
-}
-
-// Flush periodically
-setInterval(flushEvents, 5000);
-```
-
-### 3. Handle Failures Gracefully
-Implement retry logic for event ingestion:
-```typescript
-async function trackWithRetry(event: Event, retries = 3) {
-  for (let i = 0; i < retries; i++) {
-    try {
-      await client.usageEvents.ingest({ events: [event] });
-      return;
-    } catch (error) {
-      if (i === retries - 1) throw error;
-      await sleep(1000 * Math.pow(2, i)); // Exponential backoff
-    }
-  }
-}
-```
-
-### 4. Include Relevant Metadata
-Add context for debugging and filtering:
-```typescript
-metadata: {
-  endpoint: '/v1/generate',
-  method: 'POST',
-  model: 'gpt-4',
-  user_id: 'internal_user_123',
-  request_id: requestId,
-}
-```
-
-### 5. Monitor in Dashboard
-Check Meters dashboard for:
-- Event volume and trends
-- Usage per customer
-- Aggregated quantities
-
----
-
-## Pricing Examples
-
-### API Service
-```
-Meter: API Calls (Count)
-Price: $0.001 per call
-Free Threshold: 1,000 calls/month
-
-Customer uses 15,000 calls:
-(15,000 - 1,000) × $0.001 = $14.00
-```
-
-### AI Token Service
-```
-Meter: Tokens (Sum over "tokens")
-Price: $0.00001 per token ($0.01 per 1,000)
-Free Threshold: 10,000 tokens
-
-Customer uses 50,000 tokens:
-(50,000 - 10,000) × $0.00001 = $0.40
-```
-
-### Image Generation
-```
-Meter: Images (Count)
-Price: $0.05 per image
-Free Threshold: 10 images
-
-Customer generates 100 images:
-(100 - 10) × $0.05 = $4.50
+// CORRECT
+await client.usageEvents.ingest({
+  events: [{
+    event_name: 'api.call', // Matches exactly
+    ...
+  }]
+});
 ```
 
 ---
@@ -674,7 +502,8 @@ Customer generates 100 images:
 
 - [Usage-Based Billing Guide](https://docs.dodopayments.com/features/usage-based-billing/introduction)
 - [Meters Documentation](https://docs.dodopayments.com/features/usage-based-billing/meters)
-- [Event Ingestion](https://docs.dodopayments.com/features/usage-based-billing/event-ingestion)
-- [AI Chat App Tutorial](https://docs.dodopayments.com/developer-resources/build-an-ai-chat-app-with-usage-based-billing)
-- [Hybrid Billing Models](https://docs.dodopayments.com/features/hybrid-billing)
+- [Event Ingestion API](https://docs.dodopayments.com/api-reference/usage-events/ingest-events)
+- [Create Meter API](https://docs.dodopayments.com/api-reference/meters/create-meter)
+- [Usage-Based Billing Integration Guide](https://docs.dodopayments.com/developer-resources/usage-based-billing-guide)
 - [Credit-Based Billing](https://docs.dodopayments.com/features/credit-based-billing)
+- [Webhook Integration](https://docs.dodopayments.com/developer-resources/webhooks)

--- a/dodo-payments/webhook-integration/SKILL.md
+++ b/dodo-payments/webhook-integration/SKILL.md
@@ -100,9 +100,14 @@ import express from 'express';
 const app = express();
 app.use(express.raw({ type: 'application/json' }));
 
+// `environment` is a narrow union, but env vars are `string | undefined`.
+// Narrow explicitly rather than casting, and default to test mode so a missing
+// variable can never accidentally hit live.
+const environment = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live_mode' : 'test_mode';
+
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment,
   webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
 });
 
@@ -331,19 +336,26 @@ These concern virtual credit entitlements, not monetary wallet balances.
 
 ## Production-Grade Handler Pattern
 
-Respond quickly after durably recording the event, process asynchronously, and use idempotency keys. If the durable write fails, return a non-`2xx` response so Dodo retries:
+Respond quickly after durably recording the event, process asynchronously, and use idempotency keys. In the worker, insert the idempotency claim and apply all durable business changes in one database transaction. If processing throws, the transaction rolls back the claim so the job can retry safely:
 
 ```typescript
 import DodoPayments from 'dodopayments';
 import express from 'express';
-import { Queue, Worker } from 'bullmq'; // or your async queue
+import { Queue, Worker } from 'bullmq';
+
+// BullMQ is illustrative; use your preferred durable async queue.
 
 const app = express();
 app.use(express.raw({ type: 'application/json' }));
 
+// `environment` is a narrow union, but env vars are `string | undefined`.
+// Narrow explicitly rather than casting, and default to test mode so a missing
+// variable can never accidentally hit live.
+const environment = process.env.DODO_PAYMENTS_ENVIRONMENT === 'live_mode' ? 'live_mode' : 'test_mode';
+
 const client = new DodoPayments({
   bearerToken: process.env.DODO_PAYMENTS_API_KEY,
-  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  environment,
   webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
 });
 
@@ -377,7 +389,11 @@ app.post('/webhook', async (req, res) => {
     await eventQueue.add(
       `process-${unwrapped.type}`,
       { event: unwrapped, webhookId },
-      { jobId: webhookId } // Prevents duplicate queue entries
+      {
+        jobId: webhookId, // Prevents duplicate queue entries
+        attempts: 8,
+        backoff: { type: 'exponential', delay: 1000 },
+      }
     );
     return res.json({ received: true });
   } catch (error) {
@@ -392,26 +408,29 @@ const worker = new Worker<WebhookJob>(
   async (job) => {
     const { event, webhookId } = job.data;
 
-    // Atomically claim the webhook before any side effects.
-    const claim = await db.webhookLog.createMany({
-      data: [{ webhookId, eventType: event.type }],
-      skipDuplicates: true,
-    });
-    if (claim.count === 0) return;
+    await db.$transaction(async (tx) => {
+      const claim = await tx.webhookLog.createMany({
+        data: [{ webhookId, eventType: event.type }],
+        skipDuplicates: true,
+      });
+      if (claim.count === 0) return;
 
-    switch (event.type) {
-      case 'payment.succeeded':
-        await handlePaymentSucceeded(event.data);
-        break;
-      case 'subscription.active':
-        await handleSubscriptionActive(event.data);
-        break;
-      // ... handle other events
-    }
+      switch (event.type) {
+        case 'payment.succeeded':
+          await handlePaymentSucceeded(event.data, tx);
+          break;
+        case 'subscription.active':
+          await handleSubscriptionActive(event.data, tx);
+          break;
+        // ... handle other events
+      }
+    });
   },
   { connection }
 );
 ```
+
+The handlers above must perform entitlement writes through `tx`. Queue emails or other external work through a transactional outbox; a database transaction cannot roll back an already-sent external request.
 
 ---
 
@@ -453,7 +472,7 @@ If you use a supported framework, use the official adaptor package for built-in 
 
 **Next.js example:**
 
-The adapter callback does not expose `webhook-id`, so this payment example atomically claims `payment_id` before side effects. Use a handler that exposes `webhook-id` for event types without a verified stable identifier.
+The adapter callback does not expose `webhook-id`, so this payment example uses `payment_id` as its stable key and commits the claim and durable fulfillment together. Use a handler that exposes `webhook-id` for event types without a verified stable identifier.
 
 ```typescript
 // app/api/webhook/dodo-payments/route.ts
@@ -467,22 +486,25 @@ export const POST = Webhooks({
 
     if (payload.type !== 'payment.succeeded') return;
 
-    // webhookLog.webhookId must have a unique constraint.
-    const claim = await db.webhookLog.createMany({
-      data: [{
-        webhookId: payload.data.payment_id,
-        eventType: payload.type,
-      }],
-      skipDuplicates: true,
-    });
-    if (claim.count === 0) return;
+    // webhookLog.webhookId must have a unique constraint. If fulfillment
+    // throws, the claim rolls back and Dodo's redelivery can retry it.
+    await db.$transaction(async (tx) => {
+      const claim = await tx.webhookLog.createMany({
+        data: [{
+          webhookId: payload.data.payment_id,
+          eventType: payload.type,
+        }],
+        skipDuplicates: true,
+      });
+      if (claim.count === 0) return;
 
-    await handlePaymentSucceeded(payload.data);
+      await handlePaymentSucceeded(payload.data, tx);
+    });
   },
 });
 ```
 
-Continue to handle `subscription.active` with `handleSubscriptionActive(payload.data)` only in a handler that can first atomically claim its `webhook-id`.
+Handle `subscription.active` only in a handler that exposes `webhook-id`, then commit that claim and the entitlement changes in the same transaction.
 
 ---
 
@@ -589,6 +611,8 @@ app.get('/checkout/return', (req, res) => {
 
 **Correct:** Grant access only after receiving and verifying a webhook:
 ```typescript
+const event = client.webhooks.unwrap(rawBody, { headers });
+
 if (event.type === 'payment.succeeded') {
   grantAccess(event.data.customer.customer_id);
 }
@@ -633,6 +657,40 @@ await queue.add('process-event', unwrapped); // A crash can lose an acknowledged
 ```
 
 **Correct:** Verify the signature, durably insert or enqueue the event, and only then return `2xx`. If persistence fails, return non-`2xx` so Dodo retries.
+
+### 8. Committing an idempotency claim before fulfillment
+
+**Wrong:**
+```typescript
+const claim = await db.webhookLog.createMany({
+  data: [{ webhookId }],
+  skipDuplicates: true,
+});
+if (claim.count === 0) return;
+
+await grantSubscriptionEntitlements(event.data); // A failure leaves the claim behind
+```
+
+The retry sees the existing claim and skips fulfillment, permanently dropping the event.
+
+**Correct:** Commit the claim and all durable fulfillment changes in one transaction. A failure rolls both back, so the retry can claim the event again:
+```typescript
+const event = client.webhooks.unwrap(rawBody, { headers });
+
+await db.$transaction(async (tx) => {
+  const claim = await tx.webhookLog.createMany({
+    data: [{ webhookId, eventType: event.type }],
+    skipDuplicates: true,
+  });
+  if (claim.count === 0) return;
+
+  if (event.type === 'subscription.active') {
+    await grantSubscriptionEntitlements(event.data, tx);
+  }
+});
+```
+
+Use a transactional outbox for email or other external effects that must follow the database commit.
 
 ---
 

--- a/dodo-payments/webhook-integration/SKILL.md
+++ b/dodo-payments/webhook-integration/SKILL.md
@@ -5,82 +5,62 @@ description: Complete guide for setting up and handling Dodo Payments webhooks f
 
 # Dodo Payments Webhook Integration
 
-**Reference: [docs.dodopayments.com/developer-resources/webhooks](https://docs.dodopayments.com/developer-resources/webhooks)**
+Webhooks deliver real-time notifications when payment events occur. Use them to automate workflows, update databases, send confirmations, and keep your systems in sync.
 
-Webhooks provide real-time notifications when payment events occur. Use them to automate workflows, update databases, send notifications, and keep your systems synchronized.
+## When to use this skill
+
+- Setting up a webhook endpoint to receive payment, subscription, or refund events
+- Implementing signature verification to ensure webhook authenticity
+- Handling specific event types (payment succeeded, subscription renewed, etc.)
+- Testing webhooks locally during development
+- Ensuring idempotent webhook processing to handle retries
 
 ---
 
-## Quick Setup
+## Core Concepts
 
-### 1. Configure Webhook in Dashboard
-1. Go to Dashboard → Developer → Webhooks
-2. Click "Create Webhook"
-3. Enter your endpoint URL
-4. Select events to subscribe to
-5. Copy the webhook secret
+**Webhook**: An HTTP POST request sent by Dodo to your endpoint when an event occurs.
 
-### 2. Environment Variables
+**Signature verification**: Cryptographic proof that a webhook came from Dodo, not an attacker. Required for production.
+
+**Idempotency**: Processing the same webhook multiple times produces the same result. Use the `webhook-id` header to detect and skip duplicates.
+
+**Raw body**: The exact bytes received from Dodo, before parsing. Required for signature verification.
+
+---
+
+## Setup: Creating a Webhook Endpoint
+
+### 1. Create the endpoint in the dashboard
+
+1. Go to **Developer → Webhooks**
+2. Click **Create Webhook**
+3. Enter your endpoint URL (must be HTTPS in production)
+4. Select the events you want to receive
+5. Copy the signing secret
+
+### 2. Store the signing secret
+
 ```bash
-DODO_PAYMENTS_WEBHOOK_SECRET=your_webhook_secret_here
+export DODO_PAYMENTS_WEBHOOK_KEY=whsec_...
 ```
+
+The SDK reads this automatically. You can also pass it explicitly when initializing the client.
 
 ---
 
-## Webhook Events
+## Webhook Headers and Payload
 
-### Payment Events
-| Event | Description |
-|-------|-------------|
-| `payment.succeeded` | Payment completed successfully |
-| `payment.failed` | Payment attempt failed |
-| `payment.processing` | Payment is being processed |
-| `payment.cancelled` | Payment was cancelled |
+Every webhook request includes three required headers (all lowercase, hyphenated):
 
-### Subscription Events
-| Event | Description |
-|-------|-------------|
-| `subscription.active` | Subscription is now active |
-| `subscription.updated` | Subscription details changed |
-| `subscription.on_hold` | Subscription on hold (failed renewal) |
-| `subscription.renewed` | Subscription renewed successfully |
-| `subscription.plan_changed` | Plan upgraded/downgraded |
-| `subscription.cancelled` | Subscription cancelled |
-| `subscription.failed` | Subscription creation failed |
-| `subscription.expired` | Subscription term ended |
+| Header | Example | Purpose |
+|--------|---------|---------|
+| `webhook-id` | `evt_abc123` | Unique identifier for this webhook delivery |
+| `webhook-signature` | `v1,base64_signature_here` | HMAC-SHA256 signature for verification |
+| `webhook-timestamp` | `1704067200` | Unix timestamp (seconds) when the event was sent |
 
-### Other Events
-| Event | Description |
-|-------|-------------|
-| `refund.succeeded` | Refund processed successfully |
-| `dispute.opened` | New dispute received |
-| `license_key.created` | License key generated |
+The request body is JSON:
 
-### Credit Events
-| Event | Description |
-|-------|-------------|
-| `credit.added` | Credits granted to a customer (subscription, one-time, or API) |
-| `credit.deducted` | Credits consumed through usage or manual debit |
-| `credit.expired` | Unused credits expired after configured period |
-| `credit.rolled_over` | Unused credits carried forward at cycle end |
-| `credit.rollover_forfeited` | Credits forfeited at max rollover count |
-| `credit.overage_charged` | Overage charges applied beyond zero balance |
-| `credit.manual_adjustment` | Manual credit/debit adjustment via dashboard or API |
-| `credit.balance_low` | Credit balance dropped below configured threshold |
----
-
-## Webhook Payload Structure
-
-### Request Headers
-```http
-POST /your-webhook-url
-Content-Type: application/json
-webhook-id: evt_xxxxx
-webhook-signature: v1,signature_here
-webhook-timestamp: 1234567890
-```
-
-### Payload Format
 ```json
 {
   "business_id": "bus_xxxxx",
@@ -89,441 +69,541 @@ webhook-timestamp: 1234567890
   "data": {
     "payload_type": "Payment",
     "payment_id": "pay_xxxxx",
+    "status": "succeeded",
     "total_amount": 2999,
     "currency": "USD",
     "customer": {
-      "customer_id": "cust_xxxxx",
+      "customer_id": "cus_xxxxx",
       "email": "customer@example.com",
       "name": "John Doe"
     }
-    // ... additional event-specific fields
   }
 }
 ```
 
 ---
 
-## Implementation Examples
+## Verification: The Centerpiece
 
-### Next.js (App Router)
+**Always verify the signature before processing.** Unverified webhooks can be spoofed.
+
+### Preferred: SDK helper
+
+The simplest and safest approach. The SDK handles all verification details.
+
+**TypeScript/Node:**
 
 ```typescript
-// app/api/webhooks/dodo/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
+import DodoPayments from 'dodopayments';
+import express from 'express';
 
-const WEBHOOK_SECRET = process.env.DODO_PAYMENTS_WEBHOOK_SECRET!;
+const app = express();
+app.use(express.raw({ type: 'application/json' }));
 
-function verifySignature(payload: string, signature: string, timestamp: string): boolean {
-  const signedPayload = `${timestamp}.${payload}`;
-  const expectedSignature = crypto
-    .createHmac('sha256', WEBHOOK_SECRET)
-    .update(signedPayload)
-    .digest('base64');
-  
-  // Extract signature from "v1,signature" format
-  const providedSig = signature.split(',')[1];
-  
-  return crypto.timingSafeEqual(
-    Buffer.from(expectedSignature),
-    Buffer.from(providedSig || '')
-  );
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+});
+
+app.post('/webhook', async (req, res) => {
+  try {
+    const unwrapped = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
+    
+    // Signature verified. Process the event.
+    console.log(`Received ${unwrapped.type}`);
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: 'Invalid signature' });
+  }
+});
+```
+
+**Python:**
+
+```python
+from fastapi import FastAPI, Request, HTTPException
+from dodopayments import DodoPayments
+import os
+
+app = FastAPI()
+client = DodoPayments(
+    bearer_token=os.getenv("DODO_PAYMENTS_API_KEY"),
+    environment=os.getenv("DODO_PAYMENTS_ENVIRONMENT"),
+    webhook_key=os.getenv("DODO_PAYMENTS_WEBHOOK_KEY"),
+)
+
+@app.post("/webhook")
+async def handle_webhook(request: Request):
+    try:
+        unwrapped = client.webhooks.unwrap(
+            await request.body(),
+            headers={
+                "webhook-id": request.headers.get("webhook-id", ""),
+                "webhook-signature": request.headers.get("webhook-signature", ""),
+                "webhook-timestamp": request.headers.get("webhook-timestamp", ""),
+            },
+        )
+        # Signature verified. Process the event.
+        return {"received": True}
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid signature")
+```
+
+**Go:**
+
+```go
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"github.com/dodopayments/dodopayments-go"
+	"github.com/dodopayments/dodopayments-go/option"
+)
+
+func webhookHandler(w http.ResponseWriter, r *http.Request) {
+	client := dodopayments.NewClient(
+		option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
+		option.WithEnvironment(os.Getenv("DODO_PAYMENTS_ENVIRONMENT")),
+		option.WithWebhookKey(os.Getenv("DODO_PAYMENTS_WEBHOOK_KEY")),
+	)
+	
+	rawBody, _ := io.ReadAll(r.Body)
+	if _, err := client.Webhooks.Unwrap(context.Background(), rawBody, map[string]string{
+		"webhook-id":        r.Header.Get("webhook-id"),
+		"webhook-signature": r.Header.Get("webhook-signature"),
+		"webhook-timestamp": r.Header.Get("webhook-timestamp"),
+	}); err != nil {
+		http.Error(w, "Invalid signature", http.StatusUnauthorized)
+		return
+	}
+	
+	// Signature verified. Process the event.
+	w.WriteHeader(http.StatusOK)
 }
+```
 
-export async function POST(req: NextRequest) {
-  const body = await req.text();
-  const signature = req.headers.get('webhook-signature') || '';
-  const timestamp = req.headers.get('webhook-timestamp') || '';
-  const webhookId = req.headers.get('webhook-id');
+### Alternative: `standardwebhooks` package
 
-  // Verify signature
-  if (!verifySignature(body, signature, timestamp)) {
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+If you prefer manual verification or don't use the Dodo SDK:
+
+```typescript
+import { Webhook } from "standardwebhooks";
+import express from "express";
+
+const app = express();
+app.use(express.raw({ type: "application/json" }));
+
+const webhook = new Webhook(process.env.DODO_PAYMENTS_WEBHOOK_KEY);
+
+app.post("/webhooks/dodo", async (req, res) => {
+  try {
+    const payload = req.body.toString();
+    await webhook.verify(payload, req.headers);
+    
+    const event = JSON.parse(payload);
+    console.log(`Received ${event.type}`);
+    res.json({ received: true });
+  } catch (error) {
+    res.status(401).json({ error: "Invalid signature" });
   }
+});
+```
 
-  // Check timestamp to prevent replay attacks (5 minute tolerance)
-  const eventTime = parseInt(timestamp) * 1000;
-  if (Math.abs(Date.now() - eventTime) > 300000) {
-    return NextResponse.json({ error: 'Timestamp too old' }, { status: 401 });
+### `unwrap()` vs `unsafeUnwrap()`
+
+- `unwrap()` verifies the signature. Use this for all production webhooks.
+- `unsafeUnwrap()` skips verification. Use only for unsigned test payloads from `dodo wh trigger`.
+
+---
+
+## Raw Body Requirement
+
+Signature verification requires the exact bytes Dodo sent. If you parse the JSON first and then re-serialize it, the bytes change and verification fails.
+
+**Framework-specific setup:**
+
+| Framework | Raw body setup |
+|-----------|---|
+| **Express** | `app.use(express.raw({ type: 'application/json' }))` |
+| **Next.js** | `req.text()` in route handlers; no middleware needed |
+| **Fastify** | Custom content-type parser (see adaptor docs) |
+| **Hono** | Built-in; no special setup |
+| **FastAPI** | `await request.body()` returns bytes |
+| **Go** | `io.ReadAll(r.Body)` |
+
+---
+
+## Webhook Event Catalog
+
+Dodo sends 40+ event types across nine domains. Subscribe to only the events you need.
+
+### Payment events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `payment.succeeded` | Payment completed successfully | Grant access, send confirmation, update order status |
+| `payment.failed` | Payment attempt failed | Notify customer, suggest retry or alternative payment method |
+| `payment.processing` | Payment is still being processed | Acknowledge receipt, wait for `payment.succeeded` or `payment.failed` |
+| `payment.cancelled` | Payment was cancelled before completion | Update order status, notify customer if applicable |
+
+### Subscription events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `subscription.active` | Subscription becomes active; recurring charges are scheduled | Grant subscription access, send welcome email |
+| `subscription.updated` | Any field on the subscription changes | Sync changes to your database |
+| `subscription.on_hold` | Failed renewal temporarily pauses the subscription | Notify customer, prompt payment method update |
+| `subscription.renewed` | Subscription amount successfully deducted for a billing period | Log renewal, update next billing date |
+| `subscription.plan_changed` | Plan upgraded, downgraded, or modified | Update customer's access level or feature set |
+| `subscription.update_payment_method` | Payment method is updated | Sync the new payment method to your records |
+| `subscription.cancelled` | Merchant or customer cancels the subscription | Revoke access, send cancellation confirmation |
+| `subscription.failed` | Subscription creation fails (mandate creation failed) | Notify customer, suggest alternative payment method |
+| `subscription.expired` | Subscription reaches the end of its term | Revoke access, offer renewal or upgrade |
+
+### Refund events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `refund.succeeded` | Refund successfully processed | Update order status, revoke access if applicable |
+| `refund.failed` | Refund processing fails | Alert team, investigate reason |
+
+### Dispute events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `dispute.opened` | Customer initiates a dispute | Alert team, prepare evidence |
+| `dispute.expired` | Dispute expires without resolution | Log outcome |
+| `dispute.accepted` | Merchant accepts the dispute | Process refund if not already done |
+| `dispute.cancelled` | Customer or system cancels the dispute | Log outcome |
+| `dispute.challenged` | Merchant challenges the dispute | Prepare additional evidence |
+| `dispute.won` | Merchant wins the dispute | Log outcome, retain funds |
+| `dispute.lost` | Merchant loses the dispute | Process refund, log outcome |
+
+### License key events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `license_key.created` | License key is generated | Send key to customer (legacy; prefer `entitlement_grant.delivered`) |
+
+### Entitlement grant events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `entitlement_grant.created` | Grant row is created | Prepare for fulfillment |
+| `entitlement_grant.delivered` | Fulfillment completes; customer receives access | Grant platform, file, or license-key access |
+| `entitlement_grant.failed` | Delivery fails and is no longer retried | Alert team, inspect `error_code` and `error_message` |
+| `entitlement_grant.revoked` | Access is withdrawn | Revoke customer access, inspect `revocation_reason` |
+
+### Credit events
+
+These concern virtual credit entitlements, not monetary wallet balances.
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `credit.added` | Credits granted via subscription, purchase, add-on, or API | Update internal credit balance, log grant |
+| `credit.deducted` | Usage or manual debit consumes credits | Update internal credit balance |
+| `credit.expired` | Unused credits reach expiry | Log expiration, notify customer if applicable |
+| `credit.rolled_over` | Unused credits carried into a new grant | Update internal balance |
+| `credit.rollover_forfeited` | Credits forfeited at max rollover count | Log forfeiture |
+| `credit.overage_charged` | Overage charged after usage exceeds balance | Update internal balance, notify customer |
+| `credit.overage_reset` | Accumulated overage reset (e.g., new billing cycle) | Update internal balance |
+| `credit.manual_adjustment` | Manual credit or debit adjustment made | Update internal balance, log adjustment |
+| `credit.balance_low` | Balance falls below configured threshold | Notify customer, suggest purchase |
+
+### Recovery and dunning events
+
+| Event | When it fires | What to do |
+|-------|---|---|
+| `abandoned_checkout.detected` | Failed or incomplete checkout classified as abandoned (after 60 min) | Monitor recovery link usage |
+| `abandoned_checkout.recovered` | Customer pays through recovery link | Log recovery, update order status |
+| `dunning.started` | Dunning attempt begins after subscription enters `on_hold` | Monitor dunning progress |
+| `dunning.recovered` | Customer updates payment method and charge succeeds | Reactivate subscription, send confirmation |
+
+---
+
+## Production-Grade Handler Pattern
+
+Respond quickly, process asynchronously, and use idempotency keys:
+
+```typescript
+import DodoPayments from 'dodopayments';
+import express from 'express';
+import { Queue } from 'bullmq'; // or your async queue
+
+const app = express();
+app.use(express.raw({ type: 'application/json' }));
+
+const client = new DodoPayments({
+  bearerToken: process.env.DODO_PAYMENTS_API_KEY,
+  environment: process.env.DODO_PAYMENTS_ENVIRONMENT,
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+});
+
+const eventQueue = new Queue('webhook-events');
+
+app.post('/webhook', async (req, res) => {
+  let unwrapped;
+  
+  try {
+    unwrapped = client.webhooks.unwrap(req.body.toString(), {
+      headers: {
+        'webhook-id': req.headers['webhook-id'] as string,
+        'webhook-signature': req.headers['webhook-signature'] as string,
+        'webhook-timestamp': req.headers['webhook-timestamp'] as string,
+      },
+    });
+  } catch (error) {
+    return res.status(401).json({ error: 'Invalid signature' });
   }
+  
+  // Respond immediately with 200 OK
+  res.json({ received: true });
+  
+  // Queue for async processing, keyed by webhook-id for idempotency
+  const webhookId = req.headers['webhook-id'] as string;
+  await eventQueue.add(
+    `process-${unwrapped.type}`,
+    { event: unwrapped, webhookId },
+    { jobId: webhookId } // Prevents duplicate processing
+  );
+});
 
-  const event = JSON.parse(body);
-
-  // Handle events
+// Async worker
+eventQueue.process(async (job) => {
+  const { event, webhookId } = job.data;
+  
+  // Check if already processed
+  const processed = await db.webhookLog.findUnique({ where: { webhookId } });
+  if (processed) return; // Idempotent: skip
+  
+  // Process based on event type
   switch (event.type) {
     case 'payment.succeeded':
       await handlePaymentSucceeded(event.data);
       break;
-    case 'payment.failed':
-      await handlePaymentFailed(event.data);
-      break;
     case 'subscription.active':
       await handleSubscriptionActive(event.data);
       break;
-    case 'subscription.cancelled':
-      await handleSubscriptionCancelled(event.data);
-      break;
-    case 'refund.succeeded':
-      await handleRefundSucceeded(event.data);
-      break;
-    case 'dispute.opened':
-      await handleDisputeOpened(event.data);
-      break;
-    case 'license_key.created':
-      await handleLicenseKeyCreated(event.data);
-      break;
-    case 'credit.added':
-      await handleCreditAdded(event.data);
-      break;
-    case 'credit.deducted':
-      await handleCreditDeducted(event.data);
-      break;
-    case 'credit.balance_low':
-      await handleCreditBalanceLow(event.data);
-      break;
-    default:
-      console.log(`Unhandled event type: ${event.type}`);
+    // ... handle other events
   }
-
-  return NextResponse.json({ received: true });
-}
-
-async function handlePaymentSucceeded(data: any) {
-  const { payment_id, customer, total_amount, product_id, subscription_id } = data;
   
-  // Update database
-  // Send confirmation email
-  // Grant access to product
-  console.log(`Payment ${payment_id} succeeded for ${customer.email}`);
-}
-
-async function handlePaymentFailed(data: any) {
-  const { payment_id, customer, error_message } = data;
-  
-  // Log failure
-  // Notify customer
-  // Update UI state
-  console.log(`Payment ${payment_id} failed: ${error_message}`);
-}
-
-async function handleSubscriptionActive(data: any) {
-  const { subscription_id, customer, product_id, next_billing_date } = data;
-  
-  // Grant subscription access
-  // Update user record
-  // Send welcome email
-  console.log(`Subscription ${subscription_id} activated for ${customer.email}`);
-}
-
-async function handleSubscriptionCancelled(data: any) {
-  const { subscription_id, customer, cancelled_at, cancel_at_next_billing_date } = data;
-  
-  // Schedule access revocation
-  // Send cancellation confirmation
-  console.log(`Subscription ${subscription_id} cancelled`);
-}
-
-async function handleRefundSucceeded(data: any) {
-  const { refund_id, payment_id, amount } = data;
-  
-  // Update order status
-  // Revoke access if needed
-  console.log(`Refund ${refund_id} processed for payment ${payment_id}`);
-}
-
-async function handleDisputeOpened(data: any) {
-  const { dispute_id, payment_id, amount, dispute_status } = data;
-  
-  // Alert team
-  // Prepare evidence
-  console.log(`Dispute ${dispute_id} opened for payment ${payment_id}`);
-}
-
-async function handleLicenseKeyCreated(data: any) {
-  const { id, key, product_id, customer_id, expires_at } = data;
-  
-  // Store license key
-  // Send to customer
-  console.log(`License key created: ${key.substring(0, 8)}...`);
-}
-
-async function handleCreditAdded(data: any) {
-  const { customer_id, credit_entitlement_id, amount, balance_after } = data;
-  
-  // Update internal credit balance
-  // Log credit grant
-  console.log(`${amount} credits added for customer ${customer_id}, balance: ${balance_after}`);
-}
-
-async function handleCreditDeducted(data: any) {
-  const { customer_id, credit_entitlement_id, amount, balance_after } = data;
-  
-  // Update internal credit balance
-  // Check if balance is getting low
-  console.log(`${amount} credits deducted for customer ${customer_id}, balance: ${balance_after}`);
-}
-
-async function handleCreditBalanceLow(data: any) {
-  const { customer_id, credit_entitlement_name, available_balance, threshold_percent } = data;
-  
-  // Notify customer about low balance
-  // Suggest upgrading plan or purchasing more credits
-  console.log(`Low balance alert: ${available_balance} ${credit_entitlement_name} remaining for ${customer_id}`);
-}
-```
-
-### Express.js
-
-```typescript
-import express from 'express';
-import crypto from 'crypto';
-
-const app = express();
-const WEBHOOK_SECRET = process.env.DODO_PAYMENTS_WEBHOOK_SECRET!;
-
-// Use raw body for signature verification
-app.post('/webhooks/dodo', 
-  express.raw({ type: 'application/json' }),
-  async (req, res) => {
-    const signature = req.headers['webhook-signature'] as string;
-    const timestamp = req.headers['webhook-timestamp'] as string;
-    const payload = req.body.toString();
-
-    // Verify signature
-    const signedPayload = `${timestamp}.${payload}`;
-    const expectedSig = crypto
-      .createHmac('sha256', WEBHOOK_SECRET)
-      .update(signedPayload)
-      .digest('base64');
-    
-    const providedSig = signature?.split(',')[1];
-    
-    if (!providedSig || !crypto.timingSafeEqual(
-      Buffer.from(expectedSig),
-      Buffer.from(providedSig)
-    )) {
-      return res.status(401).json({ error: 'Invalid signature' });
-    }
-
-    const event = JSON.parse(payload);
-
-    // Process event
-    try {
-      switch (event.type) {
-        case 'payment.succeeded':
-          await processPayment(event.data);
-          break;
-        case 'subscription.active':
-          await activateSubscription(event.data);
-          break;
-        // ... handle other events
-      }
-      res.json({ received: true });
-    } catch (error) {
-      console.error('Webhook processing error:', error);
-      res.status(500).json({ error: 'Processing failed' });
-    }
-  }
-);
-```
-
-### Python (FastAPI)
-
-```python
-from fastapi import FastAPI, Request, HTTPException
-import hmac
-import hashlib
-import base64
-import time
-
-app = FastAPI()
-WEBHOOK_SECRET = os.environ["DODO_PAYMENTS_WEBHOOK_SECRET"]
-
-def verify_signature(payload: bytes, signature: str, timestamp: str) -> bool:
-    signed_payload = f"{timestamp}.{payload.decode()}"
-    expected_sig = base64.b64encode(
-        hmac.new(
-            WEBHOOK_SECRET.encode(),
-            signed_payload.encode(),
-            hashlib.sha256
-        ).digest()
-    ).decode()
-    
-    provided_sig = signature.split(',')[1] if ',' in signature else ''
-    return hmac.compare_digest(expected_sig, provided_sig)
-
-@app.post("/webhooks/dodo")
-async def handle_webhook(request: Request):
-    body = await request.body()
-    signature = request.headers.get("webhook-signature", "")
-    timestamp = request.headers.get("webhook-timestamp", "")
-    
-    if not verify_signature(body, signature, timestamp):
-        raise HTTPException(status_code=401, detail="Invalid signature")
-    
-    # Check timestamp freshness
-    event_time = int(timestamp)
-    if abs(time.time() - event_time) > 300:
-        raise HTTPException(status_code=401, detail="Timestamp too old")
-    
-    event = json.loads(body)
-    
-    if event["type"] == "payment.succeeded":
-        await handle_payment_succeeded(event["data"])
-    elif event["type"] == "subscription.active":
-        await handle_subscription_active(event["data"])
-    # ... handle other events
-    
-    return {"received": True}
-```
-
-### Go
-
-```go
-package main
-
-import (
-    "crypto/hmac"
-    "crypto/sha256"
-    "encoding/base64"
-    "encoding/json"
-    "io"
-    "net/http"
-    "os"
-    "strconv"
-    "strings"
-    "time"
-)
-
-var webhookSecret = os.Getenv("DODO_PAYMENTS_WEBHOOK_SECRET")
-
-func verifySignature(payload []byte, signature, timestamp string) bool {
-    signedPayload := timestamp + "." + string(payload)
-    
-    mac := hmac.New(sha256.New, []byte(webhookSecret))
-    mac.Write([]byte(signedPayload))
-    expectedSig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
-    
-    parts := strings.Split(signature, ",")
-    if len(parts) < 2 {
-        return false
-    }
-    
-    return hmac.Equal([]byte(expectedSig), []byte(parts[1]))
-}
-
-func webhookHandler(w http.ResponseWriter, r *http.Request) {
-    body, _ := io.ReadAll(r.Body)
-    signature := r.Header.Get("webhook-signature")
-    timestamp := r.Header.Get("webhook-timestamp")
-    
-    if !verifySignature(body, signature, timestamp) {
-        http.Error(w, "Invalid signature", http.StatusUnauthorized)
-        return
-    }
-    
-    // Check timestamp
-    ts, _ := strconv.ParseInt(timestamp, 10, 64)
-    if time.Since(time.Unix(ts, 0)) > 5*time.Minute {
-        http.Error(w, "Timestamp too old", http.StatusUnauthorized)
-        return
-    }
-    
-    var event map[string]interface{}
-    json.Unmarshal(body, &event)
-    
-    switch event["type"] {
-    case "payment.succeeded":
-        handlePaymentSucceeded(event["data"].(map[string]interface{}))
-    case "subscription.active":
-        handleSubscriptionActive(event["data"].(map[string]interface{}))
-    }
-    
-    w.Header().Set("Content-Type", "application/json")
-    json.NewEncoder(w).Encode(map[string]bool{"received": true})
-}
-```
-
----
-
-## Best Practices
-
-### 1. Always Verify Signatures
-Never process webhooks without signature verification to prevent spoofing.
-
-### 2. Implement Idempotency
-Use `webhook-id` header to prevent duplicate processing:
-```typescript
-const processedIds = new Set<string>();
-
-if (processedIds.has(webhookId)) {
-  return NextResponse.json({ received: true }); // Already processed
-}
-processedIds.add(webhookId);
-```
-
-### 3. Respond Quickly
-Return 200 immediately, process asynchronously if needed:
-```typescript
-// Queue for async processing
-await queue.add('process-webhook', event);
-return NextResponse.json({ received: true });
-```
-
-### 4. Handle Retries
-Dodo Payments retries failed webhooks. Design handlers to be idempotent.
-
-### 5. Log Everything
-Keep detailed logs for debugging:
-```typescript
-console.log(`[Webhook] ${event.type} - ${webhookId}`, {
-  timestamp: event.timestamp,
-  data: event.data
+  // Log as processed
+  await db.webhookLog.create({ webhookId, eventType: event.type });
 });
 ```
 
 ---
 
-## Local Development
+## Delivery Semantics
 
-### Using ngrok
-```bash
-# Start ngrok tunnel
-ngrok http 3000
+Understand how Dodo delivers webhooks:
 
-# Use the ngrok URL as your webhook endpoint
-# https://xxxx.ngrok.io/api/webhooks/dodo
-```
-
-### Testing Webhooks
-You can trigger test webhooks from the Dodo Payments dashboard:
-1. Go to Developer → Webhooks
-2. Select your webhook
-3. Click "Send Test Event"
+| Property | Behavior |
+|----------|----------|
+| **Timeout** | 15 seconds for connection and read |
+| **Success** | Any `2xx` response acknowledges delivery. Return `200` immediately. |
+| **Failure** | Any non-`2xx` response triggers a retry. |
+| **Retries** | Eight attempts: immediately, 5s, 5m, 30m, 2h, 5h, 10h, 10h |
+| **Idempotency** | Use `webhook-id` to detect and skip duplicates |
+| **Ordering** | No guarantee. Events can arrive out of order. |
+| **Payload freshness** | Delivery contains the latest resource state at delivery time |
+| **Transport** | Use HTTPS in production |
 
 ---
 
-## Troubleshooting
+## Framework Adaptor Shortcuts
 
-### Signature Verification Failing
-- Ensure you're using the raw request body
-- Check webhook secret is correct
-- Verify timestamp format (Unix seconds)
+If you use a supported framework, use the official adaptor package for built-in webhook handling:
 
-### Not Receiving Webhooks
-- Check endpoint is publicly accessible
-- Verify webhook is enabled in dashboard
-- Check server logs for errors
+| Framework | Package | Webhook handler |
+|-----------|---------|---|
+| Next.js | `@dodopayments/nextjs` | `Webhooks({ webhookKey, onPayload })` |
+| Nuxt | `@dodopayments/nuxt` | `Webhooks({ webhookKey, onPayload })` |
+| Express | `@dodopayments/express` | Middleware with raw-body parser |
+| Fastify | `@dodopayments/fastify` | `Webhooks({ webhookKey, onPayload })` |
+| Hono | `@dodopayments/hono` | `Webhooks({ webhookKey, onPayload })` |
+| Astro | `@dodopayments/astro` | `Webhooks({ webhookKey, onPayload })` |
+| SvelteKit | `@dodopayments/sveltekit` | `Webhooks({ webhookKey, onPayload })` |
+| Remix | `@dodopayments/remix` | `Webhooks({ webhookKey, onPayload })` |
+| TanStack Start | `@dodopayments/tanstack` | `Webhooks({ webhookKey, onPayload })` |
+| Bun | `@dodopayments/bun` | `Webhooks({ webhookKey, onPayload })` |
+| Better Auth | `@dodopayments/better-auth` | Plugin with `webhooks({ webhookKey, onPayload })` |
+| Convex | `@dodopayments/convex` | Component with verified HTTP handler |
 
-### Duplicate Events
-- Implement idempotency using webhook-id
-- Store processed event IDs in database
+**Next.js example:**
+
+```typescript
+// app/api/webhook/dodo-payments/route.ts
+import { Webhooks } from "@dodopayments/nextjs";
+
+export const POST = Webhooks({
+  webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
+  onPayload: async (payload) => {
+    // payload is already verified
+    console.log(`Received ${payload.type}`);
+    
+    switch (payload.type) {
+      case 'payment.succeeded':
+        await handlePaymentSucceeded(payload.data);
+        break;
+      case 'subscription.active':
+        await handleSubscriptionActive(payload.data);
+        break;
+    }
+  },
+});
+```
+
+---
+
+## Local Testing
+
+### Dashboard test tool
+
+1. Go to **Developer → Webhooks → [your endpoint] → Testing**
+2. Select an event type
+3. Click **Send Example**
+4. Verify your endpoint returns `200` and the signature verifies
+
+### CLI: Live forwarding
+
+Forward real test-mode events to localhost:
+
+```bash
+dodo wh listen
+```
+
+This creates a test webhook, opens a WebSocket relay, and forwards events with valid signatures to your local URL. Requires a test-mode API key.
+
+### CLI: Unsigned mock events
+
+Generate realistic unsigned payloads for testing without signature verification:
+
+```bash
+dodo wh trigger
+```
+
+Use `unsafeUnwrap()` only for these unsigned payloads.
+
+### Tunnel
+
+Expose localhost with ngrok and register the HTTPS URL in the dashboard:
+
+```bash
+ngrok http 3000
+# Register https://xxxx.ngrok.io/webhook in the dashboard
+```
+
+---
+
+## Common Mistakes
+
+### 1. Signing only the payload or `timestamp.payload`
+
+**Wrong:**
+```typescript
+const signed = crypto.createHmac('sha256', secret)
+  .update(payload)
+  .digest('base64');
+
+// or
+const signed = crypto.createHmac('sha256', secret)
+  .update(`${timestamp}.${payload}`)
+  .digest('base64');
+```
+
+**Correct:** The signed message is `webhook-id.webhook-timestamp.raw_body`, all three parts joined by periods. Use the SDK helper to avoid this entirely.
+
+### 2. Re-serializing the parsed body
+
+**Wrong:**
+```typescript
+const body = await req.json();
+const signed = JSON.stringify(body); // Reordered, reformatted, breaks signature
+```
+
+**Correct:** Always use the raw bytes:
+```typescript
+const body = await req.text(); // or req.body.toString() in Express
+// Pass body directly to unwrap() or webhook.verify()
+```
+
+### 3. Naive comma-splitting of the signature header
+
+**Wrong:**
+```typescript
+const sig = signature.split(',')[1]; // Assumes exactly one comma
+```
+
+The header is versioned and can contain multiple values. Use the SDK helper.
+
+### 4. `timingSafeEqual` throwing on length mismatch
+
+**Wrong:**
+```typescript
+crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(provided));
+// Throws if lengths differ; doesn't return false
+```
+
+**Correct:** Use the SDK helper, which handles this safely.
+
+### 5. Granting access from `return_url` instead of verified webhooks
+
+**Wrong:**
+```typescript
+// User visits return_url after checkout; you grant access
+app.get('/checkout/return', (req, res) => {
+  grantAccess(req.query.customer_id); // Unverified!
+});
+```
+
+**Correct:** Grant access only after receiving and verifying a webhook:
+```typescript
+if (event.type === 'payment.succeeded') {
+  grantAccess(event.data.customer.customer_id);
+}
+```
+
+### 6. Doing slow work before responding 2xx
+
+**Wrong:**
+```typescript
+app.post('/webhook', async (req, res) => {
+  const unwrapped = client.webhooks.unwrap(...);
+  
+  // Slow database writes, email sends, etc.
+  await db.payment.create(...);
+  await sendEmail(...);
+  
+  res.json({ received: true }); // Dodo times out after 15s
+});
+```
+
+**Correct:** Respond immediately, queue async work:
+```typescript
+app.post('/webhook', async (req, res) => {
+  const unwrapped = client.webhooks.unwrap(...);
+  res.json({ received: true }); // Return now
+  
+  // Queue for async processing
+  await queue.add('process-event', unwrapped);
+});
+```
 
 ---
 
 ## Resources
 
 - [Webhook Documentation](https://docs.dodopayments.com/developer-resources/webhooks)
-- [Event Reference](https://docs.dodopayments.com/developer-resources/webhooks/intents/webhook-events-guide)
+- [Event Catalog](https://docs.dodopayments.com/developer-resources/webhooks/intents/webhook-events-guide)
 - [Standard Webhooks Spec](https://standardwebhooks.com/)
-- [Credit Webhook Events](https://docs.dodopayments.com/developer-resources/webhooks/intents/credit)
+- [Framework Adaptors](https://docs.dodopayments.com/developer-resources/framework-adaptors)
+- [CLI Reference](https://docs.dodopayments.com/developer-resources/sdks/cli)

--- a/dodo-payments/webhook-integration/SKILL.md
+++ b/dodo-payments/webhook-integration/SKILL.md
@@ -331,12 +331,12 @@ These concern virtual credit entitlements, not monetary wallet balances.
 
 ## Production-Grade Handler Pattern
 
-Respond quickly, process asynchronously, and use idempotency keys:
+Respond quickly after durably recording the event, process asynchronously, and use idempotency keys. If the durable write fails, return a non-`2xx` response so Dodo retries:
 
 ```typescript
 import DodoPayments from 'dodopayments';
 import express from 'express';
-import { Queue } from 'bullmq'; // or your async queue
+import { Queue, Worker } from 'bullmq'; // or your async queue
 
 const app = express();
 app.use(express.raw({ type: 'application/json' }));
@@ -347,10 +347,17 @@ const client = new DodoPayments({
   webhookKey: process.env.DODO_PAYMENTS_WEBHOOK_KEY,
 });
 
-const eventQueue = new Queue('webhook-events');
+type WebhookEvent = ReturnType<typeof client.webhooks.unwrap>;
+type WebhookJob = { event: WebhookEvent; webhookId: string };
+
+const connection = {
+  host: process.env.REDIS_HOST ?? '127.0.0.1',
+  port: Number(process.env.REDIS_PORT ?? '6379'),
+};
+const eventQueue = new Queue<WebhookJob>('webhook-events', { connection });
 
 app.post('/webhook', async (req, res) => {
-  let unwrapped;
+  let unwrapped: WebhookEvent;
   
   try {
     unwrapped = client.webhooks.unwrap(req.body.toString(), {
@@ -364,40 +371,46 @@ app.post('/webhook', async (req, res) => {
     return res.status(401).json({ error: 'Invalid signature' });
   }
   
-  // Respond immediately with 200 OK
-  res.json({ received: true });
-  
-  // Queue for async processing, keyed by webhook-id for idempotency
+  // Durably enqueue before acknowledging, keyed by webhook-id for idempotency
   const webhookId = req.headers['webhook-id'] as string;
-  await eventQueue.add(
-    `process-${unwrapped.type}`,
-    { event: unwrapped, webhookId },
-    { jobId: webhookId } // Prevents duplicate processing
-  );
+  try {
+    await eventQueue.add(
+      `process-${unwrapped.type}`,
+      { event: unwrapped, webhookId },
+      { jobId: webhookId } // Prevents duplicate queue entries
+    );
+    return res.json({ received: true });
+  } catch (error) {
+    console.error('Failed to persist webhook', error);
+    return res.status(503).json({ error: 'Webhook persistence failed' });
+  }
 });
 
-// Async worker
-eventQueue.process(async (job) => {
-  const { event, webhookId } = job.data;
-  
-  // Check if already processed
-  const processed = await db.webhookLog.findUnique({ where: { webhookId } });
-  if (processed) return; // Idempotent: skip
-  
-  // Process based on event type
-  switch (event.type) {
-    case 'payment.succeeded':
-      await handlePaymentSucceeded(event.data);
-      break;
-    case 'subscription.active':
-      await handleSubscriptionActive(event.data);
-      break;
-    // ... handle other events
-  }
-  
-  // Log as processed
-  await db.webhookLog.create({ webhookId, eventType: event.type });
-});
+// Async worker. webhookLog.webhookId must have a unique constraint.
+const worker = new Worker<WebhookJob>(
+  'webhook-events',
+  async (job) => {
+    const { event, webhookId } = job.data;
+
+    // Atomically claim the webhook before any side effects.
+    const claim = await db.webhookLog.createMany({
+      data: [{ webhookId, eventType: event.type }],
+      skipDuplicates: true,
+    });
+    if (claim.count === 0) return;
+
+    switch (event.type) {
+      case 'payment.succeeded':
+        await handlePaymentSucceeded(event.data);
+        break;
+      case 'subscription.active':
+        await handleSubscriptionActive(event.data);
+        break;
+      // ... handle other events
+    }
+  },
+  { connection }
+);
 ```
 
 ---
@@ -409,7 +422,7 @@ Understand how Dodo delivers webhooks:
 | Property | Behavior |
 |----------|----------|
 | **Timeout** | 15 seconds for connection and read |
-| **Success** | Any `2xx` response acknowledges delivery. Return `200` immediately. |
+| **Success** | Any `2xx` response acknowledges delivery. Return `200` immediately after durably recording the event. |
 | **Failure** | Any non-`2xx` response triggers a retry. |
 | **Retries** | Eight attempts: immediately, 5s, 5m, 30m, 2h, 5h, 10h, 10h |
 | **Idempotency** | Use `webhook-id` to detect and skip duplicates |
@@ -440,6 +453,8 @@ If you use a supported framework, use the official adaptor package for built-in 
 
 **Next.js example:**
 
+The adapter callback does not expose `webhook-id`, so this payment example atomically claims `payment_id` before side effects. Use a handler that exposes `webhook-id` for event types without a verified stable identifier.
+
 ```typescript
 // app/api/webhook/dodo-payments/route.ts
 import { Webhooks } from "@dodopayments/nextjs";
@@ -449,18 +464,25 @@ export const POST = Webhooks({
   onPayload: async (payload) => {
     // payload is already verified
     console.log(`Received ${payload.type}`);
-    
-    switch (payload.type) {
-      case 'payment.succeeded':
-        await handlePaymentSucceeded(payload.data);
-        break;
-      case 'subscription.active':
-        await handleSubscriptionActive(payload.data);
-        break;
-    }
+
+    if (payload.type !== 'payment.succeeded') return;
+
+    // webhookLog.webhookId must have a unique constraint.
+    const claim = await db.webhookLog.createMany({
+      data: [{
+        webhookId: payload.data.payment_id,
+        eventType: payload.type,
+      }],
+      skipDuplicates: true,
+    });
+    if (claim.count === 0) return;
+
+    await handlePaymentSucceeded(payload.data);
   },
 });
 ```
+
+Continue to handle `subscription.active` with `handleSubscriptionActive(payload.data)` only in a handler that can first atomically claim its `webhook-id`.
 
 ---
 
@@ -587,16 +609,30 @@ app.post('/webhook', async (req, res) => {
 });
 ```
 
-**Correct:** Respond immediately, queue async work:
+**Correct:** Durably enqueue first, then respond immediately. Return non-`2xx` if persistence fails so Dodo retries:
 ```typescript
 app.post('/webhook', async (req, res) => {
   const unwrapped = client.webhooks.unwrap(...);
-  res.json({ received: true }); // Return now
-  
-  // Queue for async processing
-  await queue.add('process-event', unwrapped);
+
+  try {
+    await queue.add('process-event', unwrapped); // Durable write
+    return res.json({ received: true });
+  } catch (error) {
+    console.error('Failed to persist webhook', error);
+    return res.status(503).json({ error: 'Webhook persistence failed' });
+  }
 });
 ```
+
+### 7. Acknowledging before durable persistence
+
+**Wrong:**
+```typescript
+res.json({ received: true });
+await queue.add('process-event', unwrapped); // A crash can lose an acknowledged event
+```
+
+**Correct:** Verify the signature, durably insert or enqueue the event, and only then return `2xx`. If persistence fails, return non-`2xx` so Dodo retries.
 
 ---
 

--- a/dodo-payments/webhook-integration/SKILL.md
+++ b/dodo-payments/webhook-integration/SKILL.md
@@ -133,14 +133,24 @@ app.post('/webhook', async (req, res) => {
 **Python:**
 
 ```python
+from typing import Literal
 from fastapi import FastAPI, Request, HTTPException
 from dodopayments import DodoPayments
 import os
 
+# `environment` is Literal["live_mode", "test_mode"], not str. Passing the raw
+# variable through raises at construction: unset gives
+# `ValueError: Unknown environment: None`, and a typo like "test" gives
+# `Unknown environment: test`. Narrow it, defaulting to test mode so a
+# misconfigured variable can never select live.
+ENVIRONMENT: Literal["live_mode", "test_mode"] = (
+    "live_mode" if os.getenv("DODO_PAYMENTS_ENVIRONMENT") == "live_mode" else "test_mode"
+)
+
 app = FastAPI()
 client = DodoPayments(
     bearer_token=os.getenv("DODO_PAYMENTS_API_KEY"),
-    environment=os.getenv("DODO_PAYMENTS_ENVIRONMENT"),
+    environment=ENVIRONMENT,
     webhook_key=os.getenv("DODO_PAYMENTS_WEBHOOK_KEY"),
 )
 
@@ -165,31 +175,45 @@ async def handle_webhook(request: Request):
 
 ```go
 import (
-	"context"
 	"io"
 	"net/http"
 	"os"
+
 	"github.com/dodopayments/dodopayments-go"
 	"github.com/dodopayments/dodopayments-go/option"
 )
 
+// The Go SDK has no WithEnvironment(string). It exposes two explicit options,
+// so narrow here and default to test mode: an unset or misspelled variable must
+// never select live mode.
+func dodoEnvironment() option.RequestOption {
+	if os.Getenv("DODO_PAYMENTS_ENVIRONMENT") == "live_mode" {
+		return option.WithEnvironmentLiveMode()
+	}
+	return option.WithEnvironmentTestMode()
+}
+
 func webhookHandler(w http.ResponseWriter, r *http.Request) {
 	client := dodopayments.NewClient(
 		option.WithBearerToken(os.Getenv("DODO_PAYMENTS_API_KEY")),
-		option.WithEnvironment(os.Getenv("DODO_PAYMENTS_ENVIRONMENT")),
+		dodoEnvironment(),
 		option.WithWebhookKey(os.Getenv("DODO_PAYMENTS_WEBHOOK_KEY")),
 	)
-	
-	rawBody, _ := io.ReadAll(r.Body)
-	if _, err := client.Webhooks.Unwrap(context.Background(), rawBody, map[string]string{
-		"webhook-id":        r.Header.Get("webhook-id"),
-		"webhook-signature": r.Header.Get("webhook-signature"),
-		"webhook-timestamp": r.Header.Get("webhook-timestamp"),
-	}); err != nil {
+
+	rawBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Cannot read body", http.StatusBadRequest)
+		return
+	}
+
+	// Unwrap takes the raw body and the request headers directly. It is not
+	// context-aware and does not take a map: the signature is
+	// Unwrap(payload []byte, headers http.Header, opts ...option.RequestOption).
+	if _, err := client.Webhooks.Unwrap(rawBody, r.Header); err != nil {
 		http.Error(w, "Invalid signature", http.StatusUnauthorized)
 		return
 	}
-	
+
 	// Signature verified. Process the event.
 	w.WriteHeader(http.StatusOK)
 }

--- a/dodo-payments/webhook-integration/SKILL.md
+++ b/dodo-payments/webhook-integration/SKILL.md
@@ -546,20 +546,20 @@ Handle `subscription.active` only in a handler that exposes `webhook-id`, then c
 Forward real test-mode events to localhost:
 
 ```bash
-dodo wh listen
+dodo wh listen http://localhost:3000/webhook
 ```
 
-This creates a test webhook, opens a WebSocket relay, and forwards events with valid signatures to your local URL. Requires a test-mode API key.
+This creates a test webhook, opens a WebSocket relay, and forwards events with valid signatures to your local URL. Requires a test-mode API key. The URL argument is required in direct mode — bare `dodo wh listen` only works as `/wh listen` inside the TUI.
 
 ### CLI: Unsigned mock events
 
 Generate realistic unsigned payloads for testing without signature verification:
 
 ```bash
-dodo wh trigger
+dodo wh trigger payment.success http://localhost:3000/webhook
 ```
 
-Use `unsafeUnwrap()` only for these unsigned payloads.
+Use `unsafeUnwrap()` only for these unsigned payloads. Both arguments are required in direct mode.
 
 ### Tunnel
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,69 @@
+{
+    "name": "@dodopayments/skills",
+    "version": "2.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@dodopayments/skills",
+            "version": "2.0.0",
+            "license": "MIT",
+            "devDependencies": {
+                "dodopayments": "^2.44.0",
+                "typescript": "^5.6.0"
+            }
+        },
+        "node_modules/@stablelib/base64": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+            "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/dodopayments": {
+            "version": "2.44.0",
+            "resolved": "https://registry.npmjs.org/dodopayments/-/dodopayments-2.44.0.tgz",
+            "integrity": "sha512-IysdcP2H8q+50IPWwbY2g79lpiL6mg14EBAtzSVIbuyn4H8op1xdFOTlb8nMBNlbJzSab2SejYrG5pokXHkH/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "standardwebhooks": "^1.0.0"
+            },
+            "bin": {
+                "dodopayments": "bin/cli"
+            }
+        },
+        "node_modules/fast-sha256": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+            "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+            "dev": true,
+            "license": "Unlicense"
+        },
+        "node_modules/standardwebhooks": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+            "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@stablelib/base64": "^1.0.0",
+                "fast-sha256": "^1.3.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6148 @@
             "version": "2.0.0",
             "license": "MIT",
             "devDependencies": {
+                "@dodopayments/astro": "^0.2.9",
+                "@dodopayments/better-auth": "^1.6.4",
+                "@dodopayments/bun": "^0.1.3",
+                "@dodopayments/convex": "^0.2.13",
+                "@dodopayments/express": "^0.2.9",
+                "@dodopayments/fastify": "^0.2.8",
+                "@dodopayments/hono": "^0.2.8",
+                "@dodopayments/nextjs": "^0.3.7",
+                "@dodopayments/nuxt": "^0.2.8",
+                "@dodopayments/react-native-checkout": "^1.1.0",
+                "@dodopayments/remix": "^0.2.8",
+                "@dodopayments/sveltekit": "^0.2.8",
+                "@dodopayments/tanstack": "^0.2.8",
                 "dodopayments": "^2.44.0",
+                "standardwebhooks": "^1.0.0",
                 "typescript": "^5.6.0"
             }
+        },
+        "node_modules/@astrojs/compiler": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+            "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@astrojs/internal-helpers": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+            "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@astrojs/markdown-remark": {
+            "version": "6.3.11",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.11.tgz",
+            "integrity": "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@astrojs/internal-helpers": "0.7.6",
+                "@astrojs/prism": "3.3.0",
+                "github-slugger": "^2.0.0",
+                "hast-util-from-html": "^2.0.3",
+                "hast-util-to-text": "^4.0.2",
+                "import-meta-resolve": "^4.2.0",
+                "js-yaml": "^4.1.1",
+                "mdast-util-definitions": "^6.0.0",
+                "rehype-raw": "^7.0.0",
+                "rehype-stringify": "^10.0.1",
+                "remark-gfm": "^4.0.1",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.2",
+                "remark-smartypants": "^3.0.2",
+                "shiki": "^3.21.0",
+                "smol-toml": "^1.6.0",
+                "unified": "^11.0.5",
+                "unist-util-remove-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "unist-util-visit-parents": "^6.0.2",
+                "vfile": "^6.0.3"
+            }
+        },
+        "node_modules/@astrojs/prism": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+            "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prismjs": "^1.30.0"
+            },
+            "engines": {
+                "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+            }
+        },
+        "node_modules/@astrojs/telemetry": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+            "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ci-info": "^4.2.0",
+                "debug": "^4.4.0",
+                "dlv": "^1.1.3",
+                "dset": "^3.1.4",
+                "is-docker": "^3.0.0",
+                "is-wsl": "^3.1.0",
+                "which-pm-runs": "^1.1.0"
+            },
+            "engines": {
+                "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-annotate-as-pure": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-create-class-features-plugin": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+            "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-optimise-call-expression": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+            "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-replace-supers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+            "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+            "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.8"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+            "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-typescript": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+            "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-typescript": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+            "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-syntax-typescript": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@better-auth/core": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
+            "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.39.0",
+                "@standard-schema/spec": "^1.1.0",
+                "zod": "^4.3.6"
+            },
+            "peerDependencies": {
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1",
+                "@cloudflare/workers-types": ">=4",
+                "@opentelemetry/api": "^1.9.0",
+                "better-call": "1.3.7",
+                "jose": "^6.1.0",
+                "kysely": "^0.28.5 || ^0.29.0",
+                "nanostores": "^1.0.1"
+            },
+            "peerDependenciesMeta": {
+                "@cloudflare/workers-types": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@better-auth/drizzle-adapter": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
+            "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "drizzle-orm": "^0.45.2"
+            },
+            "peerDependenciesMeta": {
+                "drizzle-orm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@better-auth/kysely-adapter": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
+            "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "kysely": "^0.28.17 || ^0.29.0"
+            },
+            "peerDependenciesMeta": {
+                "kysely": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@better-auth/memory-adapter": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
+            "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2"
+            }
+        },
+        "node_modules/@better-auth/mongo-adapter": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
+            "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "mongodb": "^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "mongodb": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@better-auth/prisma-adapter": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
+            "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@prisma/client": {
+                    "optional": true
+                },
+                "prisma": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@better-auth/telemetry": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
+            "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@better-auth/core": "^1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1"
+            }
+        },
+        "node_modules/@better-auth/utils": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+            "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@noble/hashes": "^2.0.1"
+            }
+        },
+        "node_modules/@better-fetch/fetch": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+            "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@bomb.sh/tab": {
+            "version": "0.0.19",
+            "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.19.tgz",
+            "integrity": "sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "tab": "dist/bin/cli.mjs"
+            },
+            "peerDependencies": {
+                "cac": "^6.7.14",
+                "citty": "^0.1.6 || ^0.2.0",
+                "commander": "^13.1.0 || ^14.0.0 || ^15.0.0"
+            },
+            "peerDependenciesMeta": {
+                "cac": {
+                    "optional": true
+                },
+                "citty": {
+                    "optional": true
+                },
+                "commander": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@capsizecss/unpack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+            "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fontkitten": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@clack/core": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+            "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-wrap-ansi": "^0.2.0",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
+            }
+        },
+        "node_modules/@clack/prompts": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+            "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@clack/core": "1.4.3",
+                "fast-string-width": "^3.0.2",
+                "fast-wrap-ansi": "^0.2.0",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
+            }
+        },
+        "node_modules/@cloudflare/kv-asset-handler": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+            "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@colordx/core": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
+            "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@dodopayments/astro": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@dodopayments/astro/-/astro-0.2.9.tgz",
+            "integrity": "sha512-yGE0ePXLMPcBwh4rG567UAWcNKCOpsiziVokpA/5T+LDJvNugCIO5lpnCrLFjK7ynIX8U6bl0meIm+uje8L0AA==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "astro": "^4.0.0 || ^5.0.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/better-auth": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@dodopayments/better-auth/-/better-auth-1.6.4.tgz",
+            "integrity": "sha512-6tetpuxC8uFwNEZs2botuDl8NiWgtrWFdE4LZT3C7ekXteVBoo6mUt52IFQMuP0yKpBGe+DBSYVphhYUkqfCPQ==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "better-auth": "^1.4.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/bun": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@dodopayments/bun/-/bun-0.1.3.tgz",
+            "integrity": "sha512-ME26I+GOu9HzGQ4KN+fp3jfvWvD1gpigCwky1icrPNWtrxkQj5Fp9RCvL9PgzY4gfHJBkbOb1J8kYimsLn401Q==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/convex": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@dodopayments/convex/-/convex-0.2.13.tgz",
+            "integrity": "sha512-Ye1E0JGJobBKAhAHR+WQUdNIlz0d+19y98zkr5dSEwtXRKpxAlYulf8cF3hTjxU1uyDkaGYHLDpW0eEFduXZiQ==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "convex": "^1.26.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/core": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@dodopayments/core/-/core-0.3.13.tgz",
+            "integrity": "sha512-s7c3V5p0P31GCmmC1zyE/N7KK2FNB/PZdD/D6ZnMM8glGM3bdzZGFXjFzchMvwRyefeUz+FBRKSw9tbc/tXhVg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dodopayments": "^2.42.2",
+                "standardwebhooks": "^1.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/express": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@dodopayments/express/-/express-0.2.9.tgz",
+            "integrity": "sha512-Jk6bxSWcG1D+wjN/ugRUfPwWLTvTBBRxNiByImQN95EWmqRQXgQxG+3Xi2HbP5uD6/d01H2wFgvqxI9BkCdvew==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13",
+                "express": "^5.1.0"
+            }
+        },
+        "node_modules/@dodopayments/fastify": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/fastify/-/fastify-0.2.8.tgz",
+            "integrity": "sha512-oPb9s9+TMX6mVo+e2lKsG8lBmZTSNvqMwQygRSCjSrPRQo/ylNDTAvi2u2IdtnoNBxqpzQDhiYuQVUkaobCQcQ==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "fastify": "^5.4.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/hono": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/hono/-/hono-0.2.8.tgz",
+            "integrity": "sha512-ogjf3O5n4wKyYMZj3kxw53Pv6fHel6/xRXl0XhF4kWSKaqEyLRHdXJviWpRFBOItnsioUUVBGqiCKF5FrmtWdw==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "hono": "^4.8.9",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/nextjs": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/@dodopayments/nextjs/-/nextjs-0.3.7.tgz",
+            "integrity": "sha512-X3BDTeJh0/Oo8GbVg12OPNcKaVkclIpyjqO0pDzadCbC/7Isy/1Ytem03uv8ntqiQyg0hjycDQZXQ2H1H77svw==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/nuxt": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/nuxt/-/nuxt-0.2.8.tgz",
+            "integrity": "sha512-WUkIYhLWbaCqMNKfWp5VsXsCDa4L5BqBfUAk9em9VWziPT1SyvHesxY7kkdF3ORc3TPx6dnX8V0BS2nKgQdJ5w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13",
+                "@nuxt/module-builder": "^1.0.1"
+            },
+            "peerDependencies": {
+                "nuxt": "^3.13.1",
+                "vue": "^3.5.17",
+                "vue-router": "^4.5.1",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/react-native-checkout": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@dodopayments/react-native-checkout/-/react-native-checkout-1.1.0.tgz",
+            "integrity": "sha512-dy2Ufkp5sBrAXkHSbO5D2eYf9mYsOT5hgS1Wk4scvd7dKUVFbMs13JG1GVIRGoFlH0x9OoEKGJQknQk7m50wKA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react": "*",
+                "react-native": ">=0.77.0"
+            }
+        },
+        "node_modules/@dodopayments/remix": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/remix/-/remix-0.2.8.tgz",
+            "integrity": "sha512-vfvAI2FByGEK+FtIhx/yyH/733mR7XdRCuftd9YielZfRHDwHpjGGhkyOM3RNohNPKsT/Nr/e0hxSJoZ7xFgsw==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "remix": "^2.16.8",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/sveltekit": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/sveltekit/-/sveltekit-0.2.8.tgz",
+            "integrity": "sha512-nKYwIL8rD5JzDtTWqHi/KA28l8vMc1Ap1Md9TUcuONeWZNzWQVfm8VbxIoF1qrc+l/4mzCkyncHSIT7B2q1VfA==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13"
+            },
+            "peerDependencies": {
+                "@sveltejs/kit": "^2.20.3",
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dodopayments/tanstack": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@dodopayments/tanstack/-/tanstack-0.2.8.tgz",
+            "integrity": "sha512-7sN2NctiqQ9TtbF76eyeTxWnit8+F9bx5zF4abRMjPX8LyOmexSV/598TdOCu3lzEhu19mG/aebJkhugt8CaSQ==",
+            "dev": true,
+            "dependencies": {
+                "@dodopayments/core": "^0.3.13",
+                "@tanstack/react-start": "^1.129.8"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
+            }
+        },
+        "node_modules/@dxup/nuxt": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.5.tgz",
+            "integrity": "sha512-7GIUr0aD4klOyLjGMzLBNjsZiIbU6EPqO5de1Q1kTPdZXWMqamr5FqRCZycA/9n9lxsXRLFxENL7tcRAClMTrw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@dxup/unimport": "^0.1.2",
+                "@nuxt/kit": "^4.5.0",
+                "@vue/compiler-dom": "^3.5.40",
+                "chokidar": "^5.0.0",
+                "knitwork": "^1.3.0",
+                "magic-string": "^1.1.0",
+                "pathe": "^2.0.3",
+                "tinyglobby": "^0.2.17",
+                "unplugin": "^3.3.0"
+            }
+        },
+        "node_modules/@dxup/nuxt/node_modules/@nuxt/kit": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+            "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.1.0",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@dxup/nuxt/node_modules/magic-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+            "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/@dxup/nuxt/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@dxup/unimport": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@dxup/unimport/-/unimport-0.1.2.tgz",
+            "integrity": "sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@fastify/ajv-compiler": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+            "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ajv": "^8.12.0",
+                "ajv-formats": "^3.0.1",
+                "fast-uri": "^3.0.0"
+            }
+        },
+        "node_modules/@fastify/error": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+            "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@fastify/fast-json-stringify-compiler": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+            "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-json-stringify": "^7.0.0"
+            }
+        },
+        "node_modules/@fastify/forwarded": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.2.tgz",
+            "integrity": "sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@fastify/merge-json-schemas": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+            "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/@fastify/proxy-addr": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+            "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@fastify/forwarded": "^3.0.0",
+                "ipaddr.js": "^2.1.0"
+            }
+        },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.7.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@ioredis/commands": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+            "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@isaacs/ttlcache": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+            "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@jest/schemas": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/types": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/types/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@jest/types/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@jest/types/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.1.1"
+            }
+        },
+        "node_modules/@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@mapbox/node-pre-gyp": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+            "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "dependencies": {
+                "consola": "^3.2.3",
+                "detect-libc": "^2.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "node-fetch": "^2.6.7",
+                "nopt": "^8.0.0",
+                "semver": "^7.5.3",
+                "tar": "^7.4.0"
+            },
+            "bin": {
+                "node-pre-gyp": "bin/node-pre-gyp"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+            "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^22.20 || ^24.12 || >=25"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+            "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.3"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+                "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+            }
+        },
+        "node_modules/@next/env": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+            "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@next/swc-darwin-arm64": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+            "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-darwin-x64": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+            "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-gnu": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+            "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-musl": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+            "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-x64-gnu": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+            "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-x64-musl": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+            "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-arm64-msvc": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+            "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-x64-msvc": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+            "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@noble/ciphers": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+            "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nuxt/cli": {
+            "version": "3.37.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.37.0.tgz",
+            "integrity": "sha512-Zj9NwHjEBzVrgezsgMFjpMhNqwNgROk9DzNi/dyfk1mCbXIRigV11br2xOl0Satek30bmv7oZAfMtCnDe6Ip0Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@bomb.sh/tab": "^0.0.19",
+                "@clack/prompts": "^1.7.0",
+                "c12": "^3.3.4",
+                "citty": "^0.2.2",
+                "confbox": "^0.2.4",
+                "consola": "^3.4.2",
+                "debug": "^4.4.3",
+                "defu": "^6.1.7",
+                "exsolve": "^1.1.0",
+                "fuse.js": "^7.4.2",
+                "fzf": "^0.5.2",
+                "giget": "^3.3.0",
+                "jiti": "^2.7.0",
+                "listhen": "^1.10.0",
+                "nypm": "^0.6.8",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.1",
+                "scule": "^1.3.0",
+                "semver": "^7.8.5",
+                "srvx": "^0.11.22",
+                "std-env": "^4.2.0",
+                "tinyclip": "^0.1.15",
+                "tinyexec": "^1.2.4",
+                "ufo": "^1.6.4",
+                "youch": "^4.1.1"
+            },
+            "bin": {
+                "nuxi": "bin/nuxi.mjs",
+                "nuxi-ng": "bin/nuxi.mjs",
+                "nuxt": "bin/nuxi.mjs",
+                "nuxt-cli": "bin/nuxi.mjs"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@nuxt/schema": "^4.4.6"
+            },
+            "peerDependenciesMeta": {
+                "@nuxt/schema": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/devalue": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
+            "integrity": "sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@nuxt/devtools": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools/-/devtools-3.4.0.tgz",
+            "integrity": "sha512-hOOpXnNyGf03ac0TIqZQK5ErlX2zTB6nPcf6SxLBG9IW/oCECM5JQEgI4EyqDLE2VjkXaalOUdl0BwtL2XuEMw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nuxt/devtools-kit": "3.4.0",
+                "@nuxt/devtools-wizard": "3.4.0",
+                "@nuxt/kit": "^4.4.4",
+                "@vue/devtools-core": "^8.1.1",
+                "@vue/devtools-kit": "^8.1.1",
+                "birpc": "^4.0.0",
+                "consola": "^3.4.2",
+                "destr": "^2.0.5",
+                "error-stack-parser-es": "^1.0.5",
+                "execa": "^8.0.1",
+                "fast-npm-meta": "^1.5.0",
+                "get-port-please": "^3.2.0",
+                "hookable": "^6.1.1",
+                "image-meta": "^0.2.2",
+                "is-installed-globally": "^1.0.0",
+                "launch-editor": "^2.13.2",
+                "local-pkg": "^1.1.2",
+                "magicast": "^0.5.2",
+                "nypm": "^0.6.6",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.1",
+                "semver": "^7.7.4",
+                "simple-git": "^3.36.0",
+                "sirv": "^3.0.2",
+                "structured-clone-es": "^2.0.1",
+                "tinyglobby": "^0.2.16",
+                "unstorage": "^1.17.5",
+                "vite-plugin-inspect": "^11.3.3",
+                "vite-plugin-vue-tracer": "^1.3.0",
+                "which": "^6.0.1",
+                "ws": "^8.20.0"
+            },
+            "bin": {
+                "devtools": "cli.mjs"
+            },
+            "peerDependencies": {
+                "@vitejs/devtools": "*",
+                "vite": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vitejs/devtools": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/devtools-kit": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-3.4.0.tgz",
+            "integrity": "sha512-gkLbWT6xJ3QztuVuhDVZRWgZOhcbyhmyxEv92THTlgrmijJRWiRghw7a0fubPVwy5TZfinQaRH3hb1QDGTei1g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nuxt/kit": "^4.4.4",
+                "execa": "^8.0.1"
+            },
+            "peerDependencies": {
+                "vite": ">=6.0"
+            }
+        },
+        "node_modules/@nuxt/devtools-kit/node_modules/@nuxt/kit": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+            "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.1.0",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/devtools-kit/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/devtools-wizard": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.4.0.tgz",
+            "integrity": "sha512-BIaNM0Aig9j6lafF75+dHZ9sCdEbLv4ncwpVsVOF6N6z1ALvCesCCaTnhON+6MIf2hYDcSiC/zL/VhGjFkWV4A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@clack/prompts": "^1.3.0",
+                "consola": "^3.4.2",
+                "diff": "^8.0.4",
+                "execa": "^8.0.1",
+                "magicast": "^0.5.2",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "semver": "^7.7.4"
+            },
+            "bin": {
+                "devtools-wizard": "cli.mjs"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/@nuxt/kit": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
+            "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.1.0",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "mlly": "^1.8.2",
+                "nostics": "^1.2.0",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^3.0.0",
+                "untyped": "^2.0.0",
+                "verkit": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@nuxt/devtools/node_modules/unctx": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+            "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "magic-string": ">=0.30.21",
+                "oxc-parser": ">=0.140.0",
+                "rolldown": "^1.1.5",
+                "unplugin": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "magic-string": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/kit": {
+            "version": "3.21.10",
+            "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.10.tgz",
+            "integrity": "sha512-zs1+BZlRK1VlHo37TTzaMXQ+SemS1WeGRtcjWbW1ZoXpL3/ctn2VQu6nFpu6JqsJRd0QAPNS4GYmxGwLK8EHNw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "c12": "^3.3.4",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "errx": "^0.1.0",
+                "exsolve": "^1.1.0",
+                "ignore": "^7.0.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "knitwork": "^1.3.0",
+                "mlly": "^1.8.2",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rc9": "^3.0.1",
+                "scule": "^1.3.0",
+                "semver": "^7.8.5",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unctx": "^2.5.0",
+                "untyped": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/@nuxt/module-builder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@nuxt/module-builder/-/module-builder-1.0.3.tgz",
+            "integrity": "sha512-3VApg9j6MUc6G2p5hwUZmYCBHnFPg+18ye1uXpywDQGzS12HM9d1ktsCovBEImeLOLw2PlPOms/gMFkaqxRcuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.2.2",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "jiti": "^2.7.0",
+                "magic-regexp": "^0.11.0",
+                "mkdist": "^2.4.1",
+                "mlly": "^1.8.2",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "tsconfck": "^3.1.6",
+                "unbuild": "^3.6.1",
+                "vue-sfc-transformer": "^0.2.3"
+            },
+            "bin": {
+                "nuxt-build-module": "dist/cli.mjs",
+                "nuxt-module-build": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "@nuxt/cli": "^3.37.0",
+                "typescript": "^5.9.3"
+            }
+        },
+        "node_modules/@nuxt/nitro-server": {
+            "version": "3.21.10",
+            "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-3.21.10.tgz",
+            "integrity": "sha512-24hq6O1zv+ysuK2rufqib60tHUXM7zDn99bFM5o9FfWlQi+0NaT16YKd3mImhL9cvHBgAj2wvxMPz9+TJ+kxhA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nuxt/devalue": "^2.0.2",
+                "@nuxt/kit": "3.21.10",
+                "@unhead/vue": "^2.1.16",
+                "@vue/shared": "^3.5.40",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "devalue": "^5.8.2",
+                "errx": "^0.1.0",
+                "escape-string-regexp": "^5.0.0",
+                "exsolve": "^1.1.0",
+                "h3": "^1.15.11",
+                "impound": "^1.1.6",
+                "klona": "^2.0.6",
+                "mocked-exports": "^0.1.1",
+                "nitropack": "^2.13.4",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "rou3": "^0.9.1",
+                "std-env": "^4.2.0",
+                "ufo": "^1.6.4",
+                "unctx": "^2.5.0",
+                "unstorage": "^1.17.5",
+                "vue": "^3.5.40",
+                "vue-bundle-renderer": "^2.3.1",
+                "vue-devtools-stub": "^0.1.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "nuxt": "^3.21.10"
+            }
+        },
+        "node_modules/@nuxt/nitro-server/node_modules/rou3": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
+            "integrity": "sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@nuxt/telemetry": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.8.0.tgz",
+            "integrity": "sha512-zAwXY24KYvpLTmiV+osagd2EHkfs5IF+7oDZYTQoit5r0kPlwaCNlzHp5I/wUAWT4LBw6lG8gZ6bWidAdv/erQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "citty": "^0.2.1",
+                "consola": "^3.4.2",
+                "ofetch": "^2.0.0-alpha.3",
+                "rc9": "^3.0.0",
+                "std-env": "^4.0.0"
+            },
+            "bin": {
+                "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "@nuxt/kit": ">=3.0.0"
+            }
+        },
+        "node_modules/@nuxt/telemetry/node_modules/ofetch": {
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@nuxt/vite-builder": {
+            "version": "3.21.10",
+            "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.21.10.tgz",
+            "integrity": "sha512-360y1an7pFM4QgfspCXpJCmVrZXdxru6cUSyBKOI3B82xG6zfHMNf2eKu8NtZbVQ2c9LK144aCj5dOO19yNpcQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nuxt/kit": "3.21.10",
+                "@rollup/plugin-replace": "^6.0.3",
+                "@vitejs/plugin-vue": "^6.0.8",
+                "@vitejs/plugin-vue-jsx": "^5.1.6",
+                "autoprefixer": "^10.5.4",
+                "consola": "^3.4.2",
+                "cssnano": "^7.1.9",
+                "defu": "^6.1.7",
+                "escape-string-regexp": "^5.0.0",
+                "exsolve": "^1.1.0",
+                "externality": "^1.0.2",
+                "generic-names": "^4.0.0",
+                "get-port-please": "^3.2.0",
+                "jiti": "^2.7.0",
+                "knitwork": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.2",
+                "mocked-exports": "^0.1.1",
+                "nypm": "^0.6.8",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.1",
+                "postcss": "^8.5.22",
+                "seroval": "^1.5.6",
+                "std-env": "^4.2.0",
+                "ufo": "^1.6.4",
+                "unenv": "^2.0.0-rc.24",
+                "vite": "^7.3.6",
+                "vite-node": "^5.3.0",
+                "vite-plugin-checker": "^0.14.5",
+                "vue-bundle-renderer": "^2.3.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "nuxt": "3.21.10",
+                "rolldown": "^1.0.0-beta.38",
+                "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
+                "vue": "^3.3.4"
+            },
+            "peerDependenciesMeta": {
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup-plugin-visualizer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/vite": {
+            "version": "7.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@oozcitak/dom": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
+            "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oozcitak/infra": "^2.0.2",
+                "@oozcitak/url": "^3.0.0",
+                "@oozcitak/util": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@oozcitak/infra": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-2.0.2.tgz",
+            "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oozcitak/util": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@oozcitak/url": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-3.0.0.tgz",
+            "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oozcitak/infra": "^2.0.2",
+                "@oozcitak/util": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@oozcitak/util": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-10.0.0.tgz",
+            "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+            "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@oslojs/encoding": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+            "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@oxc-minify/binding-android-arm-eabi": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+            "integrity": "sha512-tt3ekadMhd/Q+9/mU1RaZWCUAJhOQgHsUD9tn0btFhEkZyeTg1rKt2+wzv+wjBE3QXlxVdV6sYMLKnbt8XdR+g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-android-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+            "integrity": "sha512-i7OGI2bFipaSlgwap/qiXcCmPbZMhlYdKAQvUtNziX8CJamNzhlqMNw4jz7wYdVNfcKuQ1eoyi7XMYCbNnKRtg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-darwin-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+            "integrity": "sha512-YOp5tcQRkLUbvII+EVwDss+Ww16b/V8XfrqNRDOTaLb/azGTb87iyS5drXfRosONv7Jp8/t8qRFC9K0aj1yYZA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-darwin-x64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+            "integrity": "sha512-9Z25dRX02krxcFXTIoZ3ym0+CF3gZ6RiU+bbckFT4l+d5LcQePfM1tR12zEW+GDTl0atCNG2TuEu61tT4L2LIQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-freebsd-x64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+            "integrity": "sha512-QtFX48viQb3Di8GkxhH9SPYZaafIwyEa51iFBALXz2x1WdYvZeAxgl33GjETq5/YXS7MiPYrZ7FNs3UHtPsTdg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+            "integrity": "sha512-HcgqdmJY+0qWnolOTxrvzilDTvs3q7RF2XcvO0q0iDld8SZBNARVqrWY9k5WwCMTZSJKCWfL/QqpUMBnyIHQAA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+            "integrity": "sha512-u8c4OPT8A6lx+mnFkMczIHCQQNqbqdEGwep2PlOoCgQhwsWR3auvs4cyD1JJW6huZQjeq0gJJ0dJtvJq3yLy+w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+            "integrity": "sha512-n+ljU1cOCpIqVDxYiYmNimXGKNYlPIkdWVrkC4hOQF3B7YqkSRtEWbHcvedinBqNCwUF+azynDWor5Bq3/BdDw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-arm64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+            "integrity": "sha512-Xkb5QCOywz/YbL+8LVQSzOxuz2jhRweBjr4BnQO7CQXAtQLLCNoll7v2qLg9OCzdqdhFw9uNgZ6aTBVADBhiPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+            "integrity": "sha512-IbVb+m0iL053WitFNnQbtmd8OjYGr4Xn5NTuAiYz8tJBtn82okEZFi0OgaeaHQE4aPZGOKPcSVlt1OMPtMoPCw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+            "integrity": "sha512-Sc/GAiyelxg8oXlBgmJI6OuKKHmg4rF0RvTLC8eL5V3qKDXrMdVWiJziwVBqN5oiFEog35ZM1/YNF63IZOdZjw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-riscv64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+            "integrity": "sha512-KHYS3oQJ5r1QBVAVubUy6UPRWYghqkjCOfNlGeH/sWlmfeM2OD74+Stc8eHmVm7QI2wDooOIlZfUso0Yz0jyRg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+            "integrity": "sha512-WyacIrs13ewOnGngxNmPF00xn0+aOYHTMSSMljNN3VShSbqB0A7ZEikR7q9fmmnBTf/jloQUO6bjzK85BFfl0w==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-x64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+            "integrity": "sha512-mP69bh2L/VVq10UEQ3wb0EsO0472TzOIZUfS/ADmxnr4gSxAzhRbO8w5QryL3BNyyyjSaXIlrAnAKO6G3srGwg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-linux-x64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+            "integrity": "sha512-B4w1uz+GPVD5iRNn9StLSG0ug5DNAy5YQVswjPy5fXNNO6JyADvmu4KZyE6tWCA6Kbz/84icD6RJ1TKVis2HSg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-openharmony-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+            "integrity": "sha512-p3nU1bo2t+QRvvqOPUqI8aEk8puhYdMq5cnjulovfKykWRi8cMcJJvuLp+RPkf45lUcTQdNG/YMFqR5eYGZfwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-wasm32-wasi": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+            "integrity": "sha512-Qb72fqFRs2Xu+KvAwisc1Fxn/rd/KROnFIdkFv77dTVmrKsq2HOCjWvxlPzjHcxNIgGUUJtpmNolrs7GYcopKg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+            "integrity": "sha512-C+lcoyJycCgq4MIgGe2K/xYZHKjaSfRMa+Bm88UoPK7U/mFHYoAnICbftkLh3IVnIuQAr9vGItp0w/m39VajgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-win32-ia32-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+            "integrity": "sha512-MAtLZpArekuD94sTmQYz7YAn3xDrq4wqT/71CUrv8ij2TSbYZGqDtA44ujP3977180ITcffPQYfHKXYX7arsgg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-win32-x64-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+            "integrity": "sha512-9B0SzKsstTUETz2SblLd2gZJ2H36GyBmZmwcZVwEaFOYW+luVm78yCSjZwja/xyl+PV6JsLhxQv+rgH46rpxQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
+            "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
+            "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
+            "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
+            "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
+            "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
+            "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
+            "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
+            "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
+            "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
+            "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
+            "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
+            "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
+            "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
+            "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
+            "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
+            "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
+            "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
+            "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
+            "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
+            "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+            "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@oxc-transform/binding-android-arm-eabi": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+            "integrity": "sha512-FOdseb5KpV3JtkM+7TN4u3sW3aQkUSRy0bWWiKgT/qrIGqZHqzKEUpwaMybutsfwEglWBXuJgnrT9loWisPkrw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-android-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+            "integrity": "sha512-jglqGwEnSuldt1nfFSpDBHQZ/RzjCjWQEMDatPOEOWIA0ZCCYFj/9ILUOTVllZz79FI9/c0p/bctVVlQqQxxYg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-darwin-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+            "integrity": "sha512-81jBeodJH0IRJ3/OnAgW2lBPm/kcoz603d8eGnnwgW2HbxAUs8rfw+YWaKLrWaKjT0oSIPOrGMJu9DeaKD68sQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-darwin-x64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+            "integrity": "sha512-o2jD9E7CyPxhb3CuYbaYsnFH0Mo1hKa2R+Hfo6xJxOlyfcM8U4R73W3YXb9w6lRPUc0PBFUbCmJjtGR/k5SIYA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-freebsd-x64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+            "integrity": "sha512-DNF+Of7nckfwqu9fZin4vR8bGmF/3sWPvtw9Jc4cjeQoRB9vUuC6w9C/GxW+0Vr+PCH+gk4tR4Ygvjfx3LYOzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+            "integrity": "sha512-nolqi5WqP68qVQJdnPFCF50JT5KzqlcpvwGFyIV+IRCLcv5Hh11gIu4InMs3Uswcf0BJnV/oLIjzb7Sycd3zJg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+            "integrity": "sha512-ytbO89DQl6KxjKCRlyCEtABgfs8njm623ambDkZZBer5J9dbTwbaV5hseZsPkVzZPxwXobu43/XS0jVZnrmCTA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+            "integrity": "sha512-Tjj3pobBAzbzUJE8ljbS61om6yfVnarSZzS8LaFCSn0rB+hs0IZRE3jC9IzpsVPHSoJl4uhbIGebuDY2G3B6gg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-arm64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+            "integrity": "sha512-aUUptri02E4nqkUvyA+2oYkmU20pYnHIpNLPZOgom0kAa0Fx9X6QFKqKm1MopyucWolQ9XTgCK2PrupSSBdCdQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+            "integrity": "sha512-d28AT+SfcAYFnulI2C8HJ5OeoUa5w+eMpwy0uMzbU/3zXJpFjjFOvJlEL8FNvx7HBEENj5IfgD+aXdNzEEn1Tg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+            "integrity": "sha512-P6XVhw+MJsjeliWJ6BBKdC0HU1VEiwMRHtqUADK+jK5wiqgzt3/JhIcMuRLzBPYfnOujLpe+fm63yEzKUIAcSA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+            "integrity": "sha512-6QUicErqoLpCVsXPYI+OEYJ95TjiV+trvX9VeCuyVcyL5p0Opi7DFQL2c1DcGHi1c9cqz1h09mUKCZ7Y52kxfw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+            "integrity": "sha512-r2Jk0vfcnHnkPOjLnWvpGVTFcYDirGICBJYraCkWeplhPZ2Sgg9GvDVgah9VFOHRZVtK6XQynELP9A8EB/Ne0Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-x64-gnu": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+            "integrity": "sha512-lIsdGq4LA1IlbrZlmrhP/p0pCo4+5jrAlLp9BMzIHaV4mILBSr+ZtuTDkML4117cLHdzoWOqw0s3Rb7igOWtxw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-linux-x64-musl": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+            "integrity": "sha512-y+9FbVRBhUtHBVn0xHiVcaNHkoRudIhlKhRk1+CclE1uGD6af3xznTjCOrKGB7HZ2SzlCWLZwQGm/KERpUjX1w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-openharmony-arm64": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+            "integrity": "sha512-Ul5Fu6zPL7kjTbtBU30HaRFHPL3bjjpdieHmAXJlJDuFukuOXqVD6dS70b314IjFy/rbqkD8OK4MQ4408eEjyg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-wasm32-wasi": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+            "integrity": "sha512-GaQJvcyFJyle5lll67+iYAgv+G21bQXvWPNhD6YIYoR/bV8kS0Qm8YSL22Y/YZC/8RwsneVFWpP2y6VZJfcM/g==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+            "integrity": "sha512-Fbi/hC64tNa56mXEitjaWsxQoMvtJDbOe2MxO+BA1v1Ev28L9n1yMJwhKyOCA+Rm8lYK91oOb5CRv3Ct5RuvJA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+            "integrity": "sha512-2HlslqwOXQ2nxAZjhqZIpvPxENhQGvA6b4cGwmiVD6Uh5x+dZAopOeEJRxRPpKcrr/W5KXfwwbttwx4OWbg9TA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-win32-x64-msvc": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+            "integrity": "sha512-JEgTv+y56FbwinH1/kqpNyD+bWRWDpbbPdSY7Ta7rCKFiRsYkUHZd1v+XWxda08cS8GAmlKS4WKcVwtrAbDUHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@parcel/watcher-wasm": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.6.0.tgz",
+            "integrity": "sha512-dtjbDxKSDPQ8AmA+pS4OFaHE1FKrjtGpLGBxw85uKFkRorjNbvDM/aFPgqosu40wprbp1xw2ZSxIKqghCUHe2w==",
+            "bundleDependencies": [
+                "napi-wasm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-glob": "^4.0.3",
+                "napi-wasm": "^1.1.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@pinojs/redact": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+            "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@poppinss/colors": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+            "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "kleur": "^4.1.5"
+            }
+        },
+        "node_modules/@poppinss/dumper": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.7.0.tgz",
+            "integrity": "sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@poppinss/colors": "^4.1.5",
+                "@sindresorhus/is": "^7.0.2",
+                "supports-color": "^10.0.0"
+            }
+        },
+        "node_modules/@poppinss/dumper/node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@poppinss/exception": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+            "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@react-native/assets-registry": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.2.tgz",
+            "integrity": "sha512-vcX/mBjWAVnWofu7KecotquI2unZ/tITwA7OGdq/mdY/zmGXIEvYhfEYyOQij/LRqi9WAL+iizInTBWnxDhK/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/codegen": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.2.tgz",
+            "integrity": "sha512-xKkudsahUJ1n//55g4fXk5BStVqqmZlz8HQveL45ZxcfDnwvhuYe2GymksQANFsSN+slvrarjrfq8kIxJzbceA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.25.2",
+                "@babel/parser": "^7.29.0",
+                "hermes-parser": "0.36.0",
+                "invariant": "^2.2.4",
+                "nullthrows": "^1.1.1",
+                "tinyglobby": "^0.2.15",
+                "yargs": "^17.6.2"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "*"
+            }
+        },
+        "node_modules/@react-native/community-cli-plugin": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.2.tgz",
+            "integrity": "sha512-YHXNKoM6Y/HjREySZ5arET2xgiHgg67r1MdwJB//MPJAJ0Xc5g0u6UHxY9VzsHO3Y07dre6s0BinYwjt1SEWvQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@react-native/dev-middleware": "0.86.2",
+                "debug": "^4.4.0",
+                "invariant": "^2.2.4",
+                "metro": "^0.84.3",
+                "metro-config": "^0.84.3",
+                "metro-core": "^0.84.3",
+                "semver": "^7.1.3"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            },
+            "peerDependencies": {
+                "@react-native-community/cli": "*",
+                "@react-native/metro-config": "0.86.2"
+            },
+            "peerDependenciesMeta": {
+                "@react-native-community/cli": {
+                    "optional": true
+                },
+                "@react-native/metro-config": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@react-native/debugger-frontend": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.2.tgz",
+            "integrity": "sha512-KGS1aV5F6cIqpnoIUhLBXyVzy1oAj8jBFGau6vX4Vy0HXRJN7p+68RU7x6NuyraHvQcR14ccMGT5TkFuNjQ4gA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/debugger-shell": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.2.tgz",
+            "integrity": "sha512-/TaVJ2+gGajZPJGrFaObUQmHmlaxAlfmOPZicl6pNKDUjzSgFMpcLkdTOExvb+USYTVdGX1XwxXyvjQdUO2bvg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.4.0",
+                "fb-dotslash": "0.5.8"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.2.tgz",
+            "integrity": "sha512-B7L0vKvg+IcEElT7Vpqh1xj5yJAqWUegjbP+bQRaorJMAYnv11GkliTnZV2AdTDfZQJWgOEx8i8LGkHkUg7bnA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@isaacs/ttlcache": "^1.4.1",
+                "@react-native/debugger-frontend": "0.86.2",
+                "@react-native/debugger-shell": "0.86.2",
+                "chrome-launcher": "^0.15.2",
+                "chromium-edge-launcher": "^0.3.0",
+                "connect": "^3.6.5",
+                "debug": "^4.4.0",
+                "invariant": "^2.2.4",
+                "nullthrows": "^1.1.1",
+                "open": "^7.0.3",
+                "serve-static": "^1.16.2",
+                "ws": "^7.5.10"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/send": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+            "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.1",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "~2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "~2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/serve-static": {
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+            "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "~0.19.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@react-native/gradle-plugin": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.2.tgz",
+            "integrity": "sha512-2F6x14NcHMpVmfTTFKfMkpV5dZedZrLiv6PE+c3vgnesV2bjleUBydr4U+NI8VkI7OwW71L0A5qQ76I9LCrfoQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/js-polyfills": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.2.tgz",
+            "integrity": "sha512-bIwNcGBaQ74shB5z1mRkxOpjikimuwsnOCEkZSzL67Z1FTyK1ObpENfyd2QvcvVW9Cjl+tHuw9ynpBnb2jPoJQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/normalize-colors": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.2.tgz",
+            "integrity": "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@react-native/virtualized-lists": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.2.tgz",
+            "integrity": "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "invariant": "^2.2.4",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^19.2.0",
+                "react": "*",
+                "react-native": "0.86.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+            "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+            "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+            "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+            "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+            "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+            "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+            "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+            "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+            "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+            "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+            "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+            "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+            "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "2.0.0-alpha.3",
+                "@emnapi/runtime": "2.0.0-alpha.3",
+                "@napi-rs/wasm-runtime": "^1.2.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "2.0.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+            "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+            "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+            "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@rollup/plugin-alias": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
+            "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "rollup": ">=4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "29.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+            "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "fdir": "^6.2.0",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-inject": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+            "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-json": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+            "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+            "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-terser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+            "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "serialize-javascript": "^7.0.3",
+                "smob": "^1.0.0",
+                "terser": "^5.17.4"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+            "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+            "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+            "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+            "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+            "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+            "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+            "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+            "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+            "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+            "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+            "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+            "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+            "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+            "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+            "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+            "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+            "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+            "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+            "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+            "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+            "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+            "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+            "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+            "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+            "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@shikijs/core": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+            "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/types": "3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4",
+                "hast-util-to-html": "^9.0.5"
+            }
+        },
+        "node_modules/@shikijs/engine-javascript": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+            "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/types": "3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "oniguruma-to-es": "^4.3.4"
+            }
+        },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+            "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/types": "3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@shikijs/langs": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+            "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/types": "3.23.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+            "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/types": "3.23.0"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+            "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@simple-git/args-pathspec": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+            "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@simple-git/argv-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+            "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@simple-git/args-pathspec": "^1.0.3"
+            }
+        },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@sindresorhus/is": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@speed-highlight/core": {
+            "version": "1.2.18",
+            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.18.tgz",
+            "integrity": "sha512-Q5USMGPOLp/dpVE0EA11QGuFyLAccJDKvsrmfqY/ZD540x/3kKlwtvuUxMqzNrOsGE/H4VtXe75EWma0dj/0jA==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/@stablelib/base64": {
             "version": "1.0.1",
@@ -19,6 +6158,5320 @@
             "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@sveltejs/acorn-typescript": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+            "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^8.9.0"
+            }
+        },
+        "node_modules/@sveltejs/kit": {
+            "version": "2.70.2",
+            "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+            "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@sveltejs/acorn-typescript": "^1.0.9",
+                "@types/cookie": "^0.6.0",
+                "acorn": "^8.16.0",
+                "cookie": "^0.6.0",
+                "devalue": "^5.8.1",
+                "esm-env": "^1.2.2",
+                "kleur": "^4.1.5",
+                "magic-string": "^0.30.5",
+                "mrmime": "^2.0.0",
+                "set-cookie-parser": "^3.0.0",
+                "sirv": "^3.0.0"
+            },
+            "bin": {
+                "svelte-kit": "svelte-kit.js"
+            },
+            "engines": {
+                "node": ">=18.13"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0",
+                "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
+                "svelte": "^4.0.0 || ^5.0.0-next.0",
+                "typescript": "^5.3.3 || ^6.0.0",
+                "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@sveltejs/vite-plugin-svelte": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.2.0.tgz",
+            "integrity": "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "deepmerge": "^4.3.1",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.0",
+                "vitefu": "^1.1.2"
+            },
+            "engines": {
+                "node": "^20.19 || ^22.12 || >=24"
+            },
+            "peerDependencies": {
+                "svelte": "^5.46.4",
+                "vite": "^8.0.0-beta.7 || ^8.0.0"
+            }
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
+        "node_modules/@tanstack/history": {
+            "version": "1.162.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.0.tgz",
+            "integrity": "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/react-router": {
+            "version": "1.170.18",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.18.tgz",
+            "integrity": "sha512-wpbGYZEp/fmz1q4bn7BD8VZ+/VZ7GBqSJv5V969pU+chP8y7dquWDmKTFMohvUegb9lg12m1uPVvD6kB2wORvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/history": "1.162.0",
+                "@tanstack/react-store": "^0.9.3",
+                "@tanstack/router-core": "1.171.15",
+                "isbot": "^5.1.22"
+            },
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=18.0.0 || >=19.0.0",
+                "react-dom": ">=18.0.0 || >=19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-start": {
+            "version": "1.168.34",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.168.34.tgz",
+            "integrity": "sha512-W5MDbD4QlDZHtEXlqN6bJUz7SdsPv6tbNPCih1i72FZqgQlhaxN1BoeoB8H+nN8M4tXRkfJD7VW75FCdQyaQDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-router": "1.170.18",
+                "@tanstack/react-start-client": "1.168.16",
+                "@tanstack/react-start-rsc": "0.1.33",
+                "@tanstack/react-start-server": "1.167.22",
+                "@tanstack/router-utils": "1.162.2",
+                "@tanstack/start-client-core": "1.170.14",
+                "@tanstack/start-plugin-core": "1.171.25",
+                "@tanstack/start-server-core": "1.169.17",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@rsbuild/core": "^2.0.0",
+                "react": ">=18.0.0 || >=19.0.0",
+                "react-dom": ">=18.0.0 || >=19.0.0",
+                "vite": ">=7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rsbuild/core": {
+                    "optional": true
+                },
+                "@vitejs/plugin-rsc": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/react-start-client": {
+            "version": "1.168.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-start-client/-/react-start-client-1.168.16.tgz",
+            "integrity": "sha512-1OfHgy0wpHwe2tlB3FxMeA+IMX6Il/QAMf+8UdXuimReIc2Lz3BkMLBL38k4GIxBguX9sI8EMLO5jlTZ4e1olw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-router": "1.170.18",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/start-client-core": "1.170.14"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=18.0.0 || >=19.0.0",
+                "react-dom": ">=18.0.0 || >=19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-start-rsc": {
+            "version": "0.1.33",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-start-rsc/-/react-start-rsc-0.1.33.tgz",
+            "integrity": "sha512-G4e1xwi/InoQmIGgNQSozcWASw68/o3NpbTz+exosdMGRZzLBeUDbj0swEAajxHm6jDEOQ/reSeIcDkcEfhMfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-router": "1.170.18",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/router-utils": "1.162.2",
+                "@tanstack/start-client-core": "1.170.14",
+                "@tanstack/start-fn-stubs": "1.162.0",
+                "@tanstack/start-plugin-core": "1.171.25",
+                "@tanstack/start-server-core": "1.169.17",
+                "@tanstack/start-storage-context": "1.167.17",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@rspack/core": ">=2.0.0-0",
+                "@vitejs/plugin-rsc": ">=0.5.30",
+                "react": ">=18.0.0 || >=19.0.0",
+                "react-dom": ">=18.0.0 || >=19.0.0",
+                "react-server-dom-rspack": ">=0.0.2"
+            },
+            "peerDependenciesMeta": {
+                "@rspack/core": {
+                    "optional": true
+                },
+                "@vitejs/plugin-rsc": {
+                    "optional": true
+                },
+                "react-server-dom-rspack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/react-start-server": {
+            "version": "1.167.22",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-start-server/-/react-start-server-1.167.22.tgz",
+            "integrity": "sha512-eH2PeHuLfL3R5YzE9+y2FfcE4Ld1LNV2ZfrCNVPJMMJFt+9nXDaRHg9BsEmc+JkTAGzz3FKLyQEoWwpbG6Ehqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-router": "1.170.18",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/start-server-core": "1.169.17"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=18.0.0 || >=19.0.0",
+                "react-dom": ">=18.0.0 || >=19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-store": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+            "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/store": "0.9.3",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/router-core": {
+            "version": "1.171.15",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.15.tgz",
+            "integrity": "sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/history": "1.162.0",
+                "cookie-es": "^3.0.0",
+                "seroval": "^1.5.4",
+                "seroval-plugins": "^1.5.4"
+            },
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/router-generator": {
+            "version": "1.167.21",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.167.21.tgz",
+            "integrity": "sha512-m3oXZyienj8owialdyoZ0txHQrnEx/Ra+D9kWtar5fC2cWZr5Pvxl86VY2mX5RRLC5QLKLeRGT1x4HV95wHVDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.5",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/router-utils": "1.162.2",
+                "@tanstack/virtual-file-routes": "1.162.0",
+                "jiti": "^2.7.0",
+                "magic-string": "^0.30.21",
+                "prettier": "^3.5.0",
+                "zod": "^4.4.3"
+            },
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/router-plugin": {
+            "version": "1.168.23",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.168.23.tgz",
+            "integrity": "sha512-0+PIcvnaAimFwjoEIeV3h7LKjzC8zNnp7pH2UamdKwQ9QlY99WU9V0Xl0zbM0i9hrUa/mKgWPDAzELmPUu5fMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.5",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.5",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/router-generator": "1.167.21",
+                "@tanstack/router-utils": "1.162.2",
+                "chokidar": "^5.0.0",
+                "unplugin": "^3.0.0",
+                "zod": "^4.4.3"
+            },
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@rsbuild/core": ">=1.0.2 || ^2.0.0",
+                "@tanstack/react-router": "^1.170.18",
+                "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
+                "vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
+                "webpack": ">=5.92.0"
+            },
+            "peerDependenciesMeta": {
+                "@rsbuild/core": {
+                    "optional": true
+                },
+                "@tanstack/react-router": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "vite-plugin-solid": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/router-utils": {
+            "version": "1.162.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-utils/-/router-utils-1.162.2.tgz",
+            "integrity": "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "^7.28.5",
+                "@babel/parser": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "ansis": "^4.1.0",
+                "babel-dead-code-elimination": "^1.0.12",
+                "diff": "^8.0.2",
+                "pathe": "^2.0.3",
+                "tinyglobby": "^0.2.15"
+            },
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/start-client-core": {
+            "version": "1.170.14",
+            "resolved": "https://registry.npmjs.org/@tanstack/start-client-core/-/start-client-core-1.170.14.tgz",
+            "integrity": "sha512-yasBgEIFSWysL4EiFIGwp638nCoXXKiTqkc48EP2oty4OyNsZPTC1yfJ82zjq2KGkTAYtIaeMl7otqqRl1n85Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/start-fn-stubs": "1.162.0",
+                "@tanstack/start-storage-context": "1.167.17",
+                "seroval": "^1.5.4"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/start-fn-stubs": {
+            "version": "1.162.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/start-fn-stubs/-/start-fn-stubs-1.162.0.tgz",
+            "integrity": "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/start-plugin-core": {
+            "version": "1.171.25",
+            "resolved": "https://registry.npmjs.org/@tanstack/start-plugin-core/-/start-plugin-core-1.171.25.tgz",
+            "integrity": "sha512-YmMye36vohfxau/MaVpltjkpJlf+wfUBoZp3S6Ue53mpAnsHr6El3XQDmcp1wS4kicZmyX1SNcobJpVZc+2dOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "7.27.1",
+                "@babel/core": "^7.28.5",
+                "@babel/types": "^7.28.5",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/router-generator": "1.167.21",
+                "@tanstack/router-plugin": "1.168.23",
+                "@tanstack/router-utils": "1.162.2",
+                "@tanstack/start-server-core": "1.169.17",
+                "exsolve": "^1.0.7",
+                "lightningcss": "^1.32.0",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "seroval": "^1.5.4",
+                "source-map": "^0.7.6",
+                "srvx": "^0.11.9",
+                "tinyglobby": "^0.2.15",
+                "ufo": "^1.5.4",
+                "vitefu": "^1.1.1",
+                "xmlbuilder2": "^4.0.3",
+                "zod": "^4.4.3"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "@rsbuild/core": "^2.0.0",
+                "vite": ">=7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rsbuild/core": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@tanstack/start-server-core": {
+            "version": "1.169.17",
+            "resolved": "https://registry.npmjs.org/@tanstack/start-server-core/-/start-server-core-1.169.17.tgz",
+            "integrity": "sha512-u0N+PHJhMHnzfnlXYI9F+A/qweDe3E2X0mfkORPGIEkNQgvS548RA9fjwvixR2en5b848CfpEqUzwFhm/tQ40Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/history": "1.162.0",
+                "@tanstack/router-core": "1.171.15",
+                "@tanstack/start-client-core": "1.170.14",
+                "@tanstack/start-storage-context": "1.167.17",
+                "fetchdts": "^0.1.6",
+                "h3-v2": "npm:h3@2.0.1-rc.20",
+                "seroval": "^1.5.4"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/start-storage-context": {
+            "version": "1.167.17",
+            "resolved": "https://registry.npmjs.org/@tanstack/start-storage-context/-/start-storage-context-1.167.17.tgz",
+            "integrity": "sha512-ntkDyGx0PE0opIlWNAMpkMb8qkjR4uyCUOfC0CiT0STM25+EcwPuwYNfDXXeVObMrTAPgsQ4yOj3xdY0Xr4ptw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/router-core": "1.171.15"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/store": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+            "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tanstack/virtual-file-routes": {
+            "version": "1.162.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.162.0.tgz",
+            "integrity": "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/istanbul-lib-report": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "node_modules/@types/istanbul-reports": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "node_modules/@types/mdast": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/nlcst": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+            "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/yargs": {
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+            "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/@unhead/vue": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.16.tgz",
+            "integrity": "sha512-t6QykImeMJcrUTbFB0Coy0cB/OZItHdQFRFLoH8GAVXKWmQORGPrwvueP9me7adOCuMH2uVvrv0nCkbi6zksaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hookable": "^6.0.1",
+                "unhead": "2.1.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "vue": ">=3.5.18"
+            }
+        },
+        "node_modules/@unhead/vue/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vercel/nft": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.2.tgz",
+            "integrity": "sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@mapbox/node-pre-gyp": "^2.0.0",
+                "@rollup/pluginutils": "^5.1.3",
+                "acorn": "^8.6.0",
+                "acorn-import-attributes": "^1.9.5",
+                "async-sema": "^3.1.1",
+                "bindings": "^1.4.0",
+                "estree-walker": "2.0.2",
+                "glob": "^13.0.0",
+                "graceful-fs": "^4.2.9",
+                "node-gyp-build": "^4.2.2",
+                "picomatch": "^4.0.2",
+                "resolve-from": "^5.0.0"
+            },
+            "bin": {
+                "nft": "out/cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+            "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@rolldown/pluginutils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vitejs/plugin-vue-jsx": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue-jsx/-/plugin-vue-jsx-5.1.6.tgz",
+            "integrity": "sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.29.0",
+                "@babel/plugin-syntax-typescript": "^7.29.7",
+                "@babel/plugin-transform-typescript": "^7.29.7",
+                "@rolldown/pluginutils": "^1.0.1",
+                "@vue/babel-plugin-jsx": "^2.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "vue": "^3.0.0"
+            }
+        },
+        "node_modules/@volar/language-core": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@volar/source-map": "2.4.28"
+            }
+        },
+        "node_modules/@volar/source-map": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue-macros/common": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.4.tgz",
+            "integrity": "sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-sfc": "^3.5.22",
+                "ast-kit": "^2.1.2",
+                "local-pkg": "^1.1.2",
+                "magic-string-ast": "^1.0.2",
+                "unplugin-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/vue-macros"
+            },
+            "peerDependencies": {
+                "vue": "^2.7.0 || ^3.2.25"
+            },
+            "peerDependenciesMeta": {
+                "vue": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vue/babel-helper-vue-transform-on": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-2.0.1.tgz",
+            "integrity": "sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue/babel-plugin-jsx": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-jsx/-/babel-plugin-jsx-2.0.1.tgz",
+            "integrity": "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@vue/babel-helper-vue-transform-on": "2.0.1",
+                "@vue/babel-plugin-resolve-type": "2.0.1",
+                "@vue/shared": "^3.5.22"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vue/babel-plugin-resolve-type": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-2.0.1.tgz",
+            "integrity": "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/parser": "^7.28.4",
+                "@vue/compiler-sfc": "^3.5.22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+            "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@vue/shared": "3.5.40",
+                "entities": "^7.0.1",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+            "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.5.40",
+                "@vue/shared": "3.5.40"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+            "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@vue/compiler-core": "3.5.40",
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/shared": "3.5.40",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.21",
+                "postcss": "^8.5.19",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+            "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
+            }
+        },
+        "node_modules/@vue/devtools-api": {
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+            "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue/devtools-core": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.2.1.tgz",
+            "integrity": "sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/devtools-kit": "^8.2.1",
+                "@vue/devtools-shared": "^8.2.1"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.0"
+            }
+        },
+        "node_modules/@vue/devtools-kit": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+            "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/devtools-shared": "^8.2.1",
+                "birpc": "^2.6.1",
+                "hookable": "^5.5.3",
+                "perfect-debounce": "^2.0.0"
+            }
+        },
+        "node_modules/@vue/devtools-kit/node_modules/birpc": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vue/devtools-shared": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+            "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@vue/language-core": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+            "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "@vue/compiler-dom": "^3.5.0",
+                "@vue/shared": "^3.5.0",
+                "alien-signals": "^3.2.1",
+                "muggle-string": "^0.4.1",
+                "path-browserify": "^1.0.1",
+                "picomatch": "^4.0.4"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+            "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/shared": "3.5.40"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+            "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.40",
+                "@vue/shared": "3.5.40"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+            "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.40",
+                "@vue/runtime-core": "3.5.40",
+                "@vue/shared": "3.5.40",
+                "csstype": "^3.2.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+            "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+            "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/abbrev": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
+        "node_modules/abstract-logging": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+            "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/alien-signals": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/anser": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+            "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ansis": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+            "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/anymatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/archiver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+            "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "archiver-utils": "^5.0.2",
+                "async": "^3.2.4",
+                "buffer-crc32": "^1.0.0",
+                "readable-stream": "^4.0.0",
+                "readdir-glob": "^1.1.2",
+                "tar-stream": "^3.0.0",
+                "zip-stream": "^6.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/archiver-utils": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+            "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "glob": "^10.0.0",
+                "graceful-fs": "^4.2.0",
+                "is-stream": "^2.0.1",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.17.15",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/archiver-utils/node_modules/brace-expansion": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/archiver-utils/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/archiver-utils/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/array-iterate": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+            "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/ast-kit": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+            "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.28.5",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/ast-walker-scope": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+            "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.28.4",
+                "ast-kit": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/astro": {
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.2.tgz",
+            "integrity": "sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@astrojs/compiler": "^2.13.0",
+                "@astrojs/internal-helpers": "0.7.6",
+                "@astrojs/markdown-remark": "6.3.11",
+                "@astrojs/telemetry": "3.3.0",
+                "@capsizecss/unpack": "^4.0.0",
+                "@oslojs/encoding": "^1.1.0",
+                "@rollup/pluginutils": "^5.3.0",
+                "acorn": "^8.15.0",
+                "aria-query": "^5.3.2",
+                "axobject-query": "^4.1.0",
+                "boxen": "8.0.1",
+                "ci-info": "^4.3.1",
+                "clsx": "^2.1.1",
+                "common-ancestor-path": "^1.0.1",
+                "cookie": "^1.1.1",
+                "cssesc": "^3.0.0",
+                "debug": "^4.4.3",
+                "deterministic-object-hash": "^2.0.2",
+                "devalue": "^5.6.2",
+                "diff": "^8.0.3",
+                "dlv": "^1.1.3",
+                "dset": "^3.1.4",
+                "es-module-lexer": "^1.7.0",
+                "esbuild": "^0.27.3",
+                "estree-walker": "^3.0.3",
+                "flattie": "^1.1.1",
+                "fontace": "~0.4.0",
+                "github-slugger": "^2.0.0",
+                "html-escaper": "3.0.3",
+                "http-cache-semantics": "^4.2.0",
+                "import-meta-resolve": "^4.2.0",
+                "js-yaml": "^4.1.1",
+                "magic-string": "^0.30.21",
+                "magicast": "^0.5.1",
+                "mrmime": "^2.0.1",
+                "neotraverse": "^0.6.18",
+                "p-limit": "^6.2.0",
+                "p-queue": "^8.1.1",
+                "package-manager-detector": "^1.6.0",
+                "piccolore": "^0.1.3",
+                "picomatch": "^4.0.3",
+                "prompts": "^2.4.2",
+                "rehype": "^13.0.2",
+                "semver": "^7.7.3",
+                "shiki": "^3.21.0",
+                "smol-toml": "^1.6.0",
+                "svgo": "^4.0.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tsconfck": "^3.1.6",
+                "ultrahtml": "^1.6.0",
+                "unifont": "~0.7.3",
+                "unist-util-visit": "^5.0.0",
+                "unstorage": "^1.17.4",
+                "vfile": "^6.0.3",
+                "vite": "^6.4.1",
+                "vitefu": "^1.1.1",
+                "xxhash-wasm": "^1.1.0",
+                "yargs-parser": "^21.1.1",
+                "yocto-spinner": "^0.2.3",
+                "zod": "^3.25.76",
+                "zod-to-json-schema": "^3.25.1",
+                "zod-to-ts": "^1.2.0"
+            },
+            "bin": {
+                "astro": "astro.js"
+            },
+            "engines": {
+                "node": "18.20.8 || ^20.3.0 || >=22.0.0",
+                "npm": ">=9.6.5",
+                "pnpm": ">=7.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/astrodotbuild"
+            },
+            "optionalDependencies": {
+                "sharp": "^0.34.0"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/astro/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/astro/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/astro/node_modules/vite": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "jiti": ">=1.21.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/astro/node_modules/vite/node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/astro/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/astro/node_modules/zod-to-ts": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
+            "integrity": "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "typescript": "^4.9.4 || ^5.0.2",
+                "zod": "^3"
+            }
+        },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/async-sema": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+            "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/autoprefixer": {
+            "version": "10.5.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.6",
+                "caniuse-lite": "^1.0.30001806",
+                "fraction.js": "^5.3.4",
+                "picocolors": "^1.1.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "bin": {
+                "autoprefixer": "bin/autoprefixer"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/avvio": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+            "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@fastify/error": "^4.0.0",
+                "fastq": "^1.17.1"
+            }
+        },
+        "node_modules/axobject-query": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/b4a": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/babel-dead-code-elimination": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz",
+            "integrity": "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.23.7",
+                "@babel/parser": "^7.23.6",
+                "@babel/traverse": "^7.23.7",
+                "@babel/types": "^7.23.6"
+            }
+        },
+        "node_modules/babel-plugin-syntax-hermes-parser": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
+            "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-parser": "0.36.0"
+            }
+        },
+        "node_modules/bail": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/bare-events": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+            "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-fs": {
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+            "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true
+        },
+        "node_modules/bare-stream": {
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+            "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "b4a": "^1.8.1",
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
+            },
+            "peerDependencies": {
+                "bare-abort-controller": "*",
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+            "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bare-path": "^3.0.0"
+            }
+        },
+        "node_modules/base-64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+            "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.11.9",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.9.tgz",
+            "integrity": "sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/better-auth": {
+            "version": "1.6.25",
+            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
+            "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@better-auth/core": "1.6.25",
+                "@better-auth/drizzle-adapter": "1.6.25",
+                "@better-auth/kysely-adapter": "1.6.25",
+                "@better-auth/memory-adapter": "1.6.25",
+                "@better-auth/mongo-adapter": "1.6.25",
+                "@better-auth/prisma-adapter": "1.6.25",
+                "@better-auth/telemetry": "1.6.25",
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1",
+                "@noble/ciphers": "^2.1.1",
+                "@noble/hashes": "^2.0.1",
+                "better-call": "1.3.7",
+                "defu": "^6.1.4",
+                "jose": "^6.1.3",
+                "kysely": "^0.28.17 || ^0.29.0",
+                "nanostores": "^1.1.1",
+                "zod": "^4.3.6"
+            },
+            "peerDependencies": {
+                "@lynx-js/react": "*",
+                "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "@sveltejs/kit": "^2.0.0",
+                "@tanstack/react-start": "^1.0.0",
+                "@tanstack/solid-start": "^1.0.0",
+                "better-sqlite3": "^12.0.0",
+                "drizzle-kit": ">=0.31.4",
+                "drizzle-orm": "^0.45.2",
+                "mongodb": "^6.0.0 || ^7.0.0",
+                "mysql2": "^3.0.0",
+                "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+                "pg": "^8.0.0",
+                "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0",
+                "solid-js": "^1.0.0",
+                "svelte": "^4.0.0 || ^5.0.0",
+                "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+                "vue": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@lynx-js/react": {
+                    "optional": true
+                },
+                "@prisma/client": {
+                    "optional": true
+                },
+                "@sveltejs/kit": {
+                    "optional": true
+                },
+                "@tanstack/react-start": {
+                    "optional": true
+                },
+                "@tanstack/solid-start": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "drizzle-kit": {
+                    "optional": true
+                },
+                "drizzle-orm": {
+                    "optional": true
+                },
+                "mongodb": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "next": {
+                    "optional": true
+                },
+                "pg": {
+                    "optional": true
+                },
+                "prisma": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "solid-js": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vitest": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/better-call": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+            "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@better-auth/utils": "^0.4.0",
+                "@better-fetch/fetch": "^1.1.21",
+                "rou3": "^0.7.12",
+                "set-cookie-parser": "^3.0.1"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "node_modules/birpc": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+            "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/boxen": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+            "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^8.0.0",
+                "chalk": "^5.3.0",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^7.2.0",
+                "type-fest": "^4.21.0",
+                "widest-line": "^5.0.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/buffer-crc32": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+            "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/c12": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+            "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "chokidar": "^5.0.0",
+                "confbox": "^0.2.4",
+                "defu": "^6.1.6",
+                "dotenv": "^17.3.1",
+                "exsolve": "^1.0.8",
+                "giget": "^3.2.0",
+                "jiti": "^2.6.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^3.0.1"
+            },
+            "peerDependencies": {
+                "magicast": "*"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+            "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/caniuse-api": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+            "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.0.0",
+                "caniuse-lite": "^1.0.0",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/ccount": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-html4": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/chrome-launcher": {
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+            "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "escape-string-regexp": "^4.0.0",
+                "is-wsl": "^2.2.0",
+                "lighthouse-logger": "^1.0.0"
+            },
+            "bin": {
+                "print-chrome-path": "bin/print-chrome-path.js"
+            },
+            "engines": {
+                "node": ">=12.13.0"
+            }
+        },
+        "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chrome-launcher/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chrome-launcher/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chromium-edge-launcher": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+            "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "escape-string-regexp": "^4.0.0",
+                "is-wsl": "^2.2.0",
+                "lighthouse-logger": "^1.0.0",
+                "mkdirp": "^1.0.4"
+            }
+        },
+        "node_modules/chromium-edge-launcher/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chromium-edge-launcher/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chromium-edge-launcher/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/client-only": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+            "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/common-ancestor-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+            "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/compatx": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/compatx/-/compatx-0.2.0.tgz",
+            "integrity": "sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/compress-commons": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+            "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "crc32-stream": "^6.0.0",
+                "is-stream": "^2.0.1",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/compress-commons/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/confbox": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/connect": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+            "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.2",
+                "parseurl": "~1.3.3",
+                "utils-merge": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/connect/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/connect/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/connect/node_modules/finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/connect/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/connect/node_modules/on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/connect/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/convex": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+            "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "esbuild": "0.27.0",
+                "prettier": "^3.0.0",
+                "ws": "8.21.0"
+            },
+            "bin": {
+                "convex": "bin/main.js"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=7.0.0"
+            },
+            "peerDependencies": {
+                "@auth0/auth0-react": "^2.0.1",
+                "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+                "@clerk/react": "^6.4.3",
+                "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@auth0/auth0-react": {
+                    "optional": true
+                },
+                "@clerk/clerk-react": {
+                    "optional": true
+                },
+                "@clerk/react": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+            "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/android-arm": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+            "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+            "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/android-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+            "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+            "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+            "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+            "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+            "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+            "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+            "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+            "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+            "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+            "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+            "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+            "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+            "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+            "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+            "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+            "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+            "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+            "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+            "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+            "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/convex/node_modules/esbuild": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+            "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.0",
+                "@esbuild/android-arm": "0.27.0",
+                "@esbuild/android-arm64": "0.27.0",
+                "@esbuild/android-x64": "0.27.0",
+                "@esbuild/darwin-arm64": "0.27.0",
+                "@esbuild/darwin-x64": "0.27.0",
+                "@esbuild/freebsd-arm64": "0.27.0",
+                "@esbuild/freebsd-x64": "0.27.0",
+                "@esbuild/linux-arm": "0.27.0",
+                "@esbuild/linux-arm64": "0.27.0",
+                "@esbuild/linux-ia32": "0.27.0",
+                "@esbuild/linux-loong64": "0.27.0",
+                "@esbuild/linux-mips64el": "0.27.0",
+                "@esbuild/linux-ppc64": "0.27.0",
+                "@esbuild/linux-riscv64": "0.27.0",
+                "@esbuild/linux-s390x": "0.27.0",
+                "@esbuild/linux-x64": "0.27.0",
+                "@esbuild/netbsd-arm64": "0.27.0",
+                "@esbuild/netbsd-x64": "0.27.0",
+                "@esbuild/openbsd-arm64": "0.27.0",
+                "@esbuild/openbsd-x64": "0.27.0",
+                "@esbuild/openharmony-arm64": "0.27.0",
+                "@esbuild/sunos-x64": "0.27.0",
+                "@esbuild/win32-arm64": "0.27.0",
+                "@esbuild/win32-ia32": "0.27.0",
+                "@esbuild/win32-x64": "0.27.0"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-es": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/crc-32": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "crc32": "bin/crc32.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/crc32-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+            "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/croner": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+            "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "other",
+                    "url": "https://paypal.me/hexagonpp"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/hexagon"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cross-spawn/node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/crossws": {
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+            "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "srvx": ">=0.11.5"
+            },
+            "peerDependenciesMeta": {
+                "srvx": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/css-declaration-sorter": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+            "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14 || ^16 || >=18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.9"
+            }
+        },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cssnano": {
+            "version": "7.1.9",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
+            "integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssnano-preset-default": "^7.0.17",
+                "lilconfig": "^3.1.3"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/cssnano"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/cssnano-preset-default": {
+            "version": "7.0.17",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
+            "integrity": "sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "css-declaration-sorter": "^7.2.0",
+                "cssnano-utils": "^5.0.3",
+                "postcss-calc": "^10.1.1",
+                "postcss-colormin": "^7.0.10",
+                "postcss-convert-values": "^7.0.12",
+                "postcss-discard-comments": "^7.0.8",
+                "postcss-discard-duplicates": "^7.0.4",
+                "postcss-discard-empty": "^7.0.3",
+                "postcss-discard-overridden": "^7.0.3",
+                "postcss-merge-longhand": "^7.0.7",
+                "postcss-merge-rules": "^7.0.11",
+                "postcss-minify-font-values": "^7.0.3",
+                "postcss-minify-gradients": "^7.0.5",
+                "postcss-minify-params": "^7.0.9",
+                "postcss-minify-selectors": "^7.1.2",
+                "postcss-normalize-charset": "^7.0.3",
+                "postcss-normalize-display-values": "^7.0.3",
+                "postcss-normalize-positions": "^7.0.4",
+                "postcss-normalize-repeat-style": "^7.0.4",
+                "postcss-normalize-string": "^7.0.3",
+                "postcss-normalize-timing-functions": "^7.0.3",
+                "postcss-normalize-unicode": "^7.0.9",
+                "postcss-normalize-url": "^7.0.3",
+                "postcss-normalize-whitespace": "^7.0.3",
+                "postcss-ordered-values": "^7.0.4",
+                "postcss-reduce-initial": "^7.0.9",
+                "postcss-reduce-transforms": "^7.0.3",
+                "postcss-svgo": "^7.1.3",
+                "postcss-unique-selectors": "^7.0.7"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/cssnano-utils": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.3.tgz",
+            "integrity": "sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "~2.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/db0": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+            "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@electric-sql/pglite": "*",
+                "@libsql/client": "*",
+                "better-sqlite3": "*",
+                "drizzle-orm": "*",
+                "mysql2": "*",
+                "sqlite3": "*"
+            },
+            "peerDependenciesMeta": {
+                "@electric-sql/pglite": {
+                    "optional": true
+                },
+                "@libsql/client": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "drizzle-orm": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defu": {
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+            "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/destr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/deterministic-object-hash": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+            "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "base-64": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/devalue": {
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+            "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/diff": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dlv": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dodopayments": {
             "version": "2.44.0",
@@ -33,12 +11486,9028 @@
                 "dodopayments": "bin/cli"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dot-prop": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.2.0.tgz",
+            "integrity": "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "type-fest": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dot-prop/node_modules/type-fest": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "peer": true,
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/dset": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+            "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.399",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+            "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/error-stack-parser": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+            "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "stackframe": "^1.3.4"
+            }
+        },
+        "node_modules/error-stack-parser-es": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+            "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/errx": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.2.tgz",
+            "integrity": "sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/esm-env": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+            "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/esrap": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+            "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/types": "^8.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/types": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bare-events": "^2.7.0"
+            }
+        },
+        "node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/exponential-backoff": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/exsolve": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/externality": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/externality/-/externality-1.0.2.tgz",
+            "integrity": "sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "enhanced-resolve": "^5.14.1",
+                "mlly": "^1.3.0",
+                "pathe": "^1.1.1",
+                "ufo": "^1.1.2"
+            }
+        },
+        "node_modules/externality/node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-json-stringify": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+            "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@fastify/merge-json-schemas": "^0.2.0",
+                "ajv": "^8.12.0",
+                "ajv-formats": "^3.0.1",
+                "fast-uri": "^4.0.0",
+                "json-schema-ref-resolver": "^3.0.0",
+                "rfdc": "^1.2.0"
+            }
+        },
+        "node_modules/fast-json-stringify/node_modules/fast-uri": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+            "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/fast-npm-meta": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/fast-npm-meta/-/fast-npm-meta-1.5.1.tgz",
+            "integrity": "sha512-tWhw7z4jFuQgZB9tbQyUh5BY9nNd/wimM+fBLfmmJjakkJDNvbJKm0nQ5ruPKC0us1HGg7L6iBk1fxpSzcgSaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "fast-npm-meta": "dist/cli.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/fast-querystring": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+            "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-decode-uri-component": "^1.0.1"
+            }
+        },
         "node_modules/fast-sha256": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
             "dev": true,
             "license": "Unlicense"
+        },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-string-truncated-width": "^3.0.2"
+            }
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/fast-wrap-ansi": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+            "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-string-width": "^3.0.2"
+            }
+        },
+        "node_modules/fastify": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.0.tgz",
+            "integrity": "sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@fastify/ajv-compiler": "^4.0.5",
+                "@fastify/error": "^4.0.0",
+                "@fastify/fast-json-stringify-compiler": "^5.0.0",
+                "@fastify/proxy-addr": "^5.0.0",
+                "abstract-logging": "^2.0.1",
+                "avvio": "^9.0.0",
+                "fast-json-stringify": "^7.0.0",
+                "find-my-way": "^9.6.0",
+                "light-my-request": "^6.0.0",
+                "pino": "^9.14.0 || ^10.1.0",
+                "process-warning": "^5.0.0",
+                "rfdc": "^1.3.1",
+                "secure-json-parse": "^4.0.0",
+                "semver": "^7.6.0",
+                "toad-cache": "^3.7.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fb-dotslash": {
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+            "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+            "dev": true,
+            "license": "(MIT OR Apache-2.0)",
+            "peer": true,
+            "bin": {
+                "dotslash": "bin/dotslash"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/fb-watchman": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "bser": "2.1.1"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fetchdts": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/fetchdts/-/fetchdts-0.1.7.tgz",
+            "integrity": "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/find-my-way": {
+            "version": "9.7.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+            "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-querystring": "^1.0.0",
+                "safe-regex2": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/fix-dts-default-cjs-exports": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+            "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.30.17",
+                "mlly": "^1.7.4",
+                "rollup": "^4.34.8"
+            }
+        },
+        "node_modules/flattie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+            "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/flow-enums-runtime": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+            "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fontace": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+            "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fontkitten": "^1.0.2"
+            }
+        },
+        "node_modules/fontkitten": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+            "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "tiny-inflate": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fraction.js": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/rawify"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/fuse.js": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+            "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/krisk"
+            }
+        },
+        "node_modules/fzf": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+            "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/generic-names": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
+            "integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "loader-utils": "^3.2.0"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-port-please": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+            "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/giget": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "giget": "dist/cli.mjs"
+            }
+        },
+        "node_modules/github-slugger": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+            "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/global-directory": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ini": "4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby": {
+            "version": "16.2.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+            "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "fast-glob": "^3.3.3",
+                "ignore": "^7.0.5",
+                "is-path-inside": "^4.0.0",
+                "slash": "^5.1.0",
+                "unicorn-magic": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/gzip-size": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-7.0.0.tgz",
+            "integrity": "sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/h3": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+            "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cookie-es": "^1.2.3",
+                "crossws": "^0.3.5",
+                "defu": "^6.1.6",
+                "destr": "^2.0.5",
+                "iron-webcrypto": "^1.2.1",
+                "node-mock-http": "^1.0.4",
+                "radix3": "^1.1.2",
+                "ufo": "^1.6.3",
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/h3-v2": {
+            "name": "h3",
+            "version": "2.0.1-rc.20",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz",
+            "integrity": "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rou3": "^0.8.1",
+                "srvx": "^0.11.13"
+            },
+            "bin": {
+                "h3": "bin/h3.mjs"
+            },
+            "engines": {
+                "node": ">=20.11.1"
+            },
+            "peerDependencies": {
+                "crossws": "^0.4.1"
+            },
+            "peerDependenciesMeta": {
+                "crossws": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/h3-v2/node_modules/rou3": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
+            "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/h3/node_modules/cookie-es": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+            "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/h3/node_modules/crossws": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hast-util-from-html": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+            "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "devlop": "^1.1.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "parse5": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
+                "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-raw": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "hast-util-to-parse5": "^8.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "parse5": "^7.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-html": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+            "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "stringify-entities": "^4.0.0",
+                "zwitch": "^2.0.4"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "web-namespaces": "^2.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-text": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+            "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-find-after": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-whitespace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hermes-compiler": {
+            "version": "250829098.0.16",
+            "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.16.tgz",
+            "integrity": "sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+            "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+            "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-estree": "0.36.0"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.12.33",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+            "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/hookable": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/html-void-elements": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/http-shutdown": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
+            "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/httpxy": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+            "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/image-meta": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.2.tgz",
+            "integrity": "sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/image-size": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+            "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "queue": "6.0.2"
+            },
+            "bin": {
+                "image-size": "bin/image-size.js"
+            },
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
+        "node_modules/import-meta-resolve": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/impound": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/impound/-/impound-1.1.6.tgz",
+            "integrity": "sha512-ugavDQkE74SGrBjagNIwNVHNBxX14mmfQnTm4jFGzOoWwYsgihqV698BNr5xwRY9quKK4rEg8bc6ECltllMr+w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "es-module-lexer": "^2.0.0",
+                "pathe": "^2.0.3",
+                "unplugin": "^3.0.0",
+                "unplugin-utils": "^0.3.1"
+            }
+        },
+        "node_modules/impound/node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/ini": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "node_modules/ioredis": {
+            "version": "5.11.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+            "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@ioredis/commands": "1.10.0",
+                "cluster-key-slot": "1.1.1",
+                "debug": "4.4.3",
+                "denque": "2.1.0",
+                "redis-errors": "1.2.0",
+                "redis-parser": "3.0.0",
+                "standard-as-callback": "2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/iron-webcrypto": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+            "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/brc-dd"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+            "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "global-directory": "^4.0.1",
+                "is-path-inside": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/isbot": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.2.1.tgz",
+            "integrity": "sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==",
+            "dev": true,
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jest-get-type": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-util": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "graceful-fs": "^4.2.9",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-util/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jest-util/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/jest-util/node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-util/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/jest-util/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-validate": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "camelcase": "^6.2.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "leven": "^3.1.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-validate/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-validate/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/jest-validate/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-worker": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jiti": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/jose": {
+            "version": "6.2.6",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.6.tgz",
+            "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsc-safe-url": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
+            "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+            "dev": true,
+            "license": "0BSD",
+            "peer": true
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json-schema-ref-resolver": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+            "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/klona": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/knitwork": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.3.0.tgz",
+            "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/kysely": {
+            "version": "0.29.4",
+            "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.4.tgz",
+            "integrity": "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/launch-editor": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "picocolors": "^1.1.1",
+                "shell-quote": "^1.8.4"
+            }
+        },
+        "node_modules/lazystream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+            "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "readable-stream": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.6.3"
+            }
+        },
+        "node_modules/lazystream/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/lazystream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lazystream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/light-my-request": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+            "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "dependencies": {
+                "cookie": "^1.0.1",
+                "process-warning": "^4.0.0",
+                "set-cookie-parser": "^2.6.0"
+            }
+        },
+        "node_modules/light-my-request/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/light-my-request/node_modules/process-warning": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+            "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/light-my-request/node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lighthouse-logger": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+            "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "debug": "^2.6.9",
+                "marky": "^1.2.2"
+            }
+        },
+        "node_modules/lighthouse-logger/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/lighthouse-logger/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
+        },
+        "node_modules/listhen": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.1.tgz",
+            "integrity": "sha512-6nt/86SkqUQSLW1ofz8MxC6RhRMqOl3ONISe6qqvJ3xj09aJWQx6DhgSZpugs3PX4PXdOas/WD6A9jx6J2N19A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@parcel/watcher-wasm": "^2.5.6",
+                "citty": "^0.2.2",
+                "consola": "^3.4.2",
+                "crossws": "^0.4.10",
+                "defu": "^6.1.7",
+                "get-port-please": "^3.2.0",
+                "h3": "^1.15.11",
+                "http-shutdown": "^1.2.2",
+                "jiti": "^2.7.0",
+                "node-forge": "^1.4.0",
+                "pathe": "^2.0.3",
+                "std-env": "^4.2.0",
+                "tinyclip": "^0.1.15",
+                "ufo": "^1.6.4",
+                "untun": "^0.2.2",
+                "uqr": "^0.1.3"
+            },
+            "bin": {
+                "listen": "bin/listhen.mjs",
+                "listhen": "bin/listhen.mjs"
+            },
+            "peerDependencies": {
+                "@parcel/watcher": "^2.5.6"
+            },
+            "peerDependenciesMeta": {
+                "@parcel/watcher": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+            "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/local-pkg": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+            "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mlly": "^1.7.4",
+                "pkg-types": "^2.3.0",
+                "quansync": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/locate-character": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+            "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+            "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/magic-regexp": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/magic-regexp/-/magic-regexp-0.11.0.tgz",
+            "integrity": "sha512-LG77Z/gVnwz7oaDpD4heX6ryl+lcr4l1B2gnP4MMvt2pGhGC1Dfj7dl1pXpP4ih+VQFLuAadeKVa+lARAzfW+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.30.21",
+                "regexp-tree": "^0.1.27",
+                "type-level-regexp": "~0.1.17",
+                "unplugin": "^3.0.0"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magic-string-ast": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+            "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "magic-string": "^0.30.19"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+            "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/makeerror": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "dependencies": {
+                "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/marky": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+            "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mdast-util-definitions": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+            "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-hast": {
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+            "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "trim-lines": "^3.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/memoize-one": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/metro": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+            "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/core": "^7.25.2",
+                "@babel/generator": "^7.29.1",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "accepts": "^2.0.0",
+                "ci-info": "^2.0.0",
+                "connect": "^3.6.5",
+                "debug": "^4.4.0",
+                "error-stack-parser": "^2.0.6",
+                "flow-enums-runtime": "^0.0.6",
+                "graceful-fs": "^4.2.4",
+                "hermes-parser": "0.35.0",
+                "image-size": "^1.0.2",
+                "invariant": "^2.2.4",
+                "jest-worker": "^29.7.0",
+                "jsc-safe-url": "^0.2.2",
+                "lodash.throttle": "^4.1.1",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-config": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-file-map": "0.84.4",
+                "metro-resolver": "0.84.4",
+                "metro-runtime": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-symbolicate": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
+                "metro-transform-worker": "0.84.4",
+                "mime-types": "^3.0.1",
+                "nullthrows": "^1.1.1",
+                "serialize-error": "^2.1.0",
+                "source-map": "^0.5.6",
+                "throat": "^5.0.0",
+                "ws": "^7.5.10",
+                "yargs": "^17.6.2"
+            },
+            "bin": {
+                "metro": "src/cli.js"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-babel-transformer": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+            "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.25.2",
+                "flow-enums-runtime": "^0.0.6",
+                "hermes-parser": "0.35.0",
+                "metro-cache-key": "0.84.4",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+            "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+            "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-estree": "0.35.0"
+            }
+        },
+        "node_modules/metro-cache": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+            "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "exponential-backoff": "^3.1.1",
+                "flow-enums-runtime": "^0.0.6",
+                "https-proxy-agent": "^7.0.5",
+                "metro-core": "0.84.4"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-cache-key": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+            "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-config": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+            "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "connect": "^3.6.5",
+                "flow-enums-runtime": "^0.0.6",
+                "jest-validate": "^29.7.0",
+                "metro": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-runtime": "0.84.4",
+                "yaml": "^2.6.1"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-core": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+            "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
+                "lodash.throttle": "^4.1.1",
+                "metro-resolver": "0.84.4"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-file-map": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+            "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.4.0",
+                "fb-watchman": "^2.0.0",
+                "flow-enums-runtime": "^0.0.6",
+                "graceful-fs": "^4.2.4",
+                "invariant": "^2.2.4",
+                "jest-worker": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "nullthrows": "^1.1.1",
+                "walker": "^1.0.7"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-minify-terser": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+            "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
+                "terser": "^5.15.0"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-resolver": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+            "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-runtime": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+            "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.25.0",
+                "flow-enums-runtime": "^0.0.6"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-source-map": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+            "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "flow-enums-runtime": "^0.0.6",
+                "invariant": "^2.2.4",
+                "metro-symbolicate": "0.84.4",
+                "nullthrows": "^1.1.1",
+                "ob1": "0.84.4",
+                "source-map": "^0.5.6",
+                "vlq": "^1.0.0"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-source-map/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/metro-symbolicate": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+            "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6",
+                "invariant": "^2.2.4",
+                "metro-source-map": "0.84.4",
+                "nullthrows": "^1.1.1",
+                "source-map": "^0.5.6",
+                "vlq": "^1.0.0"
+            },
+            "bin": {
+                "metro-symbolicate": "src/index.js"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-symbolicate/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/metro-transform-plugins": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+            "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.25.2",
+                "@babel/generator": "^7.29.1",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "flow-enums-runtime": "^0.0.6",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-transform-worker": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+            "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.25.2",
+                "@babel/generator": "^7.29.1",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "flow-enums-runtime": "^0.0.6",
+                "metro": "0.84.4",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-minify-terser": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/metro/node_modules/ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/metro/node_modules/hermes-estree": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+            "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/metro/node_modules/hermes-parser": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+            "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-estree": "0.35.0"
+            }
+        },
+        "node_modules/metro/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/metro/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+            "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/mime": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+            "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa"
+            ],
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "mime": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^5.0.8"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mkdist": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/mkdist/-/mkdist-2.4.1.tgz",
+            "integrity": "sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "autoprefixer": "^10.4.21",
+                "citty": "^0.1.6",
+                "cssnano": "^7.1.1",
+                "defu": "^6.1.4",
+                "esbuild": "^0.25.9",
+                "jiti": "^1.21.7",
+                "mlly": "^1.8.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0",
+                "postcss": "^8.5.6",
+                "postcss-nested": "^7.0.2",
+                "semver": "^7.7.2",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "mkdist": "dist/cli.cjs"
+            },
+            "peerDependencies": {
+                "sass": "^1.92.1",
+                "typescript": ">=5.9.2",
+                "vue": "^3.5.21",
+                "vue-sfc-transformer": "^0.1.1",
+                "vue-tsc": "^1.8.27 || ^2.0.21 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "sass": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                },
+                "vue-sfc-transformer": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/mkdist/node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
+        "node_modules/mkdist/node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/mkdist/node_modules/jiti": {
+            "version": "1.21.7",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "bin/jiti.js"
+            }
+        },
+        "node_modules/mlly": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^1.3.1",
+                "ufo": "^1.6.3"
+            }
+        },
+        "node_modules/mlly/node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mlly/node_modules/pkg-types": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.1"
+            }
+        },
+        "node_modules/mocked-exports": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/mocked-exports/-/mocked-exports-0.1.1.tgz",
+            "integrity": "sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/muggle-string": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+            "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/nanostores": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+            "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.0.0 || >=22.0.0"
+            }
+        },
+        "node_modules/nanotar": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/nanotar/-/nanotar-0.3.0.tgz",
+            "integrity": "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/neotraverse": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/next": {
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+            "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@next/env": "16.2.12",
+                "@swc/helpers": "0.5.15",
+                "baseline-browser-mapping": "^2.9.19",
+                "caniuse-lite": "^1.0.30001579",
+                "postcss": "8.4.31",
+                "styled-jsx": "5.1.6"
+            },
+            "bin": {
+                "next": "dist/bin/next"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "optionalDependencies": {
+                "@next/swc-darwin-arm64": "16.2.12",
+                "@next/swc-darwin-x64": "16.2.12",
+                "@next/swc-linux-arm64-gnu": "16.2.12",
+                "@next/swc-linux-arm64-musl": "16.2.12",
+                "@next/swc-linux-x64-gnu": "16.2.12",
+                "@next/swc-linux-x64-musl": "16.2.12",
+                "@next/swc-win32-arm64-msvc": "16.2.12",
+                "@next/swc-win32-x64-msvc": "16.2.12",
+                "sharp": "^0.34.5"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.1.0",
+                "@playwright/test": "^1.51.1",
+                "babel-plugin-react-compiler": "*",
+                "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "sass": "^1.3.0"
+            },
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@playwright/test": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/next/node_modules/postcss": {
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "nanoid": "^3.3.6",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/nitropack": {
+            "version": "2.13.4",
+            "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.13.4.tgz",
+            "integrity": "sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@cloudflare/kv-asset-handler": "^0.4.2",
+                "@rollup/plugin-alias": "^6.0.0",
+                "@rollup/plugin-commonjs": "^29.0.2",
+                "@rollup/plugin-inject": "^5.0.5",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^16.0.3",
+                "@rollup/plugin-replace": "^6.0.3",
+                "@rollup/plugin-terser": "^1.0.0",
+                "@vercel/nft": "^1.5.0",
+                "archiver": "^7.0.1",
+                "c12": "^3.3.4",
+                "chokidar": "^5.0.0",
+                "citty": "^0.2.2",
+                "compatx": "^0.2.0",
+                "confbox": "^0.2.4",
+                "consola": "^3.4.2",
+                "cookie-es": "^2.0.1",
+                "croner": "^10.0.1",
+                "crossws": "^0.3.5",
+                "db0": "^0.3.4",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "dot-prop": "^10.1.0",
+                "esbuild": "^0.28.0",
+                "escape-string-regexp": "^5.0.0",
+                "etag": "^1.8.1",
+                "exsolve": "^1.0.8",
+                "globby": "^16.2.0",
+                "gzip-size": "^7.0.0",
+                "h3": "^1.15.11",
+                "hookable": "^5.5.3",
+                "httpxy": "^0.5.1",
+                "ioredis": "^5.10.1",
+                "jiti": "^2.6.1",
+                "klona": "^2.0.6",
+                "knitwork": "^1.3.0",
+                "listhen": "^1.9.1",
+                "magic-string": "^0.30.21",
+                "magicast": "^0.5.2",
+                "mime": "^4.1.0",
+                "mlly": "^1.8.2",
+                "node-fetch-native": "^1.6.7",
+                "node-mock-http": "^1.0.4",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.1",
+                "pretty-bytes": "^7.1.0",
+                "radix3": "^1.1.2",
+                "rollup": "^4.60.2",
+                "rollup-plugin-visualizer": "^7.0.1",
+                "scule": "^1.3.0",
+                "semver": "^7.7.4",
+                "serve-placeholder": "^2.0.2",
+                "serve-static": "^2.2.1",
+                "source-map": "^0.7.6",
+                "std-env": "^4.1.0",
+                "ufo": "^1.6.4",
+                "ultrahtml": "^1.6.0",
+                "uncrypto": "^0.1.3",
+                "unctx": "^2.5.0",
+                "unenv": "2.0.0-rc.24",
+                "unimport": "^6.2.0",
+                "unplugin-utils": "^0.3.1",
+                "unstorage": "^1.17.5",
+                "untyped": "^2.0.0",
+                "unwasm": "^0.5.3",
+                "youch": "^4.1.1",
+                "youch-core": "^0.3.3"
+            },
+            "bin": {
+                "nitro": "dist/cli/index.mjs",
+                "nitropack": "dist/cli/index.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "xml2js": "^0.6.2"
+            },
+            "peerDependenciesMeta": {
+                "xml2js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/nitropack/node_modules/cookie-es": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
+            "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/nitropack/node_modules/crossws": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/nlcst-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+            "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch-native": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/node-forge": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+            "dev": true,
+            "license": "(BSD-3-Clause OR GPL-2.0)",
+            "peer": true,
+            "engines": {
+                "node": ">= 6.13.0"
+            }
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "node_modules/node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/node-mock-http": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+            "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/nopt": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "abbrev": "^3.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/nostics": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+            "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm-run-path/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
+        "node_modules/nullthrows": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+            "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/nuxt": {
+            "version": "3.21.10",
+            "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.21.10.tgz",
+            "integrity": "sha512-lZZT7D/H7ZRsKjAMbIdIBcBT55t18tptdUO7FqoxuKm5MwP/EhPwGFwv0wtKBwIN7dS7/bY4u+8cSCJi98PdGQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@dxup/nuxt": "^0.5.3",
+                "@nuxt/cli": "^3.37.0",
+                "@nuxt/devtools": "^3.3.1",
+                "@nuxt/kit": "3.21.10",
+                "@nuxt/nitro-server": "3.21.10",
+                "@nuxt/schema": "3.21.10",
+                "@nuxt/telemetry": "^2.8.0",
+                "@nuxt/vite-builder": "3.21.10",
+                "@unhead/vue": "^2.1.16",
+                "@vue/shared": "^3.5.40",
+                "c12": "^3.3.4",
+                "chokidar": "^5.0.0",
+                "compatx": "^0.2.0",
+                "consola": "^3.4.2",
+                "cookie-es": "^2.0.1",
+                "defu": "^6.1.7",
+                "destr": "^2.0.5",
+                "devalue": "^5.8.2",
+                "errx": "^0.1.0",
+                "escape-string-regexp": "^5.0.0",
+                "exsolve": "^1.1.0",
+                "h3": "^1.15.11",
+                "hookable": "^5.5.3",
+                "ignore": "^7.0.6",
+                "impound": "^1.1.6",
+                "jiti": "^2.7.0",
+                "klona": "^2.0.6",
+                "knitwork": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.2",
+                "nanotar": "^0.3.0",
+                "nypm": "^0.6.8",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11",
+                "on-change": "^6.0.2",
+                "oxc-minify": "^0.141.0",
+                "oxc-parser": "^0.140.0",
+                "oxc-transform": "^0.141.0",
+                "oxc-walker": "^1.0.0",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.1.0",
+                "pkg-types": "^2.3.1",
+                "rou3": "^0.9.1",
+                "scule": "^1.3.0",
+                "semver": "^7.8.5",
+                "std-env": "^4.2.0",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "ultrahtml": "^1.7.0",
+                "uncrypto": "^0.1.3",
+                "unctx": "^2.5.0",
+                "unimport": "^6.3.1",
+                "unplugin": "^3.3.0",
+                "unplugin-vue-router": "^0.19.2",
+                "untyped": "^2.0.0",
+                "vue": "^3.5.40",
+                "vue-router": "^4.6.4"
+            },
+            "bin": {
+                "nuxi": "bin/nuxt.mjs",
+                "nuxt": "bin/nuxt.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@parcel/watcher": "^2.1.0",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@parcel/watcher": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/nuxt/node_modules/@nuxt/schema": {
+            "version": "3.21.10",
+            "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.21.10.tgz",
+            "integrity": "sha512-i356YiRQ+xmGz1K1GS8IKQsFE/mRE6vuNoHvhdkk3jSXW+ncV9jp5ap/GX7t3xOr3XqxPUiNpMV9PpzoMMbJBA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/shared": "^3.5.40",
+                "defu": "^6.1.7",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.1",
+                "std-env": "^4.2.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
+        "node_modules/nuxt/node_modules/cookie-es": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
+            "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/nuxt/node_modules/rou3": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
+            "integrity": "sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/nypm": {
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.9.tgz",
+            "integrity": "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "citty": "^0.2.2",
+                "pathe": "^2.0.3",
+                "tinyexec": "^1.2.4"
+            },
+            "bin": {
+                "nypm": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/ob1": {
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+            "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flow-enums-runtime": "^0.0.6"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
+        "node_modules/ofetch": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+            "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "destr": "^2.0.5",
+                "node-fetch-native": "^1.6.7",
+                "ufo": "^1.6.1"
+            }
+        },
+        "node_modules/ohash": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/on-change": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/on-change/-/on-change-6.0.2.tgz",
+            "integrity": "sha512-08+12qcOVEA0fS9g/VxKS27HaT94nRutUT77J2dr8zv/unzXopvhBuF8tNLWsoLQ5IgrQ6eptGeGqUYat82U1w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/on-change?sponsor=1"
+            }
+        },
+        "node_modules/on-exit-leak-free": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/oniguruma-parser": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+            "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/oniguruma-to-es": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+            "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "oniguruma-parser": "^0.12.2",
+                "regex": "^6.1.0",
+                "regex-recursion": "^6.0.2"
+            }
+        },
+        "node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/oxc-minify": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.141.0.tgz",
+            "integrity": "sha512-+T/r+nBaKTT7UL5WDZHH8+l0bz+IZ495jHXiY2J6DWYkJXKrBCQRBS+u+hmlnhRfC5b0Uq1poZs0FLVMiDAmbw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-minify/binding-android-arm-eabi": "0.141.0",
+                "@oxc-minify/binding-android-arm64": "0.141.0",
+                "@oxc-minify/binding-darwin-arm64": "0.141.0",
+                "@oxc-minify/binding-darwin-x64": "0.141.0",
+                "@oxc-minify/binding-freebsd-x64": "0.141.0",
+                "@oxc-minify/binding-linux-arm-gnueabihf": "0.141.0",
+                "@oxc-minify/binding-linux-arm-musleabihf": "0.141.0",
+                "@oxc-minify/binding-linux-arm64-gnu": "0.141.0",
+                "@oxc-minify/binding-linux-arm64-musl": "0.141.0",
+                "@oxc-minify/binding-linux-ppc64-gnu": "0.141.0",
+                "@oxc-minify/binding-linux-riscv64-gnu": "0.141.0",
+                "@oxc-minify/binding-linux-riscv64-musl": "0.141.0",
+                "@oxc-minify/binding-linux-s390x-gnu": "0.141.0",
+                "@oxc-minify/binding-linux-x64-gnu": "0.141.0",
+                "@oxc-minify/binding-linux-x64-musl": "0.141.0",
+                "@oxc-minify/binding-openharmony-arm64": "0.141.0",
+                "@oxc-minify/binding-wasm32-wasi": "0.141.0",
+                "@oxc-minify/binding-win32-arm64-msvc": "0.141.0",
+                "@oxc-minify/binding-win32-ia32-msvc": "0.141.0",
+                "@oxc-minify/binding-win32-x64-msvc": "0.141.0"
+            }
+        },
+        "node_modules/oxc-parser": {
+            "version": "0.140.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
+            "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "^0.140.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.140.0",
+                "@oxc-parser/binding-android-arm64": "0.140.0",
+                "@oxc-parser/binding-darwin-arm64": "0.140.0",
+                "@oxc-parser/binding-darwin-x64": "0.140.0",
+                "@oxc-parser/binding-freebsd-x64": "0.140.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.140.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.140.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.140.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
+            }
+        },
+        "node_modules/oxc-transform": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.141.0.tgz",
+            "integrity": "sha512-CrMPblXfPl57WIvGjynrUThcyEGcS3E3YUHkPYAwXYYla23gLlaIYifVFTMQsFr5uxA/2k/XMG5n6c/XsuAvaQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-transform/binding-android-arm-eabi": "0.141.0",
+                "@oxc-transform/binding-android-arm64": "0.141.0",
+                "@oxc-transform/binding-darwin-arm64": "0.141.0",
+                "@oxc-transform/binding-darwin-x64": "0.141.0",
+                "@oxc-transform/binding-freebsd-x64": "0.141.0",
+                "@oxc-transform/binding-linux-arm-gnueabihf": "0.141.0",
+                "@oxc-transform/binding-linux-arm-musleabihf": "0.141.0",
+                "@oxc-transform/binding-linux-arm64-gnu": "0.141.0",
+                "@oxc-transform/binding-linux-arm64-musl": "0.141.0",
+                "@oxc-transform/binding-linux-ppc64-gnu": "0.141.0",
+                "@oxc-transform/binding-linux-riscv64-gnu": "0.141.0",
+                "@oxc-transform/binding-linux-riscv64-musl": "0.141.0",
+                "@oxc-transform/binding-linux-s390x-gnu": "0.141.0",
+                "@oxc-transform/binding-linux-x64-gnu": "0.141.0",
+                "@oxc-transform/binding-linux-x64-musl": "0.141.0",
+                "@oxc-transform/binding-openharmony-arm64": "0.141.0",
+                "@oxc-transform/binding-wasm32-wasi": "0.141.0",
+                "@oxc-transform/binding-win32-arm64-msvc": "0.141.0",
+                "@oxc-transform/binding-win32-ia32-msvc": "0.141.0",
+                "@oxc-transform/binding-win32-x64-msvc": "0.141.0"
+            }
+        },
+        "node_modules/oxc-walker": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/oxc-walker/-/oxc-walker-1.1.1.tgz",
+            "integrity": "sha512-Hwd7dq28zu/Er99+bpWp16CGwFrhyalJh0W3JOB7XpPvgWo3MqMi2ksWGKuzzA9zt50mJ2pIUwR5lpAdZ9ACNQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@oxc-project/types": ">=0.98.0",
+                "oxc-parser": ">=0.98.0",
+                "rolldown": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@oxc-project/types": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+            "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "yocto-queue": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-queue": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
+            "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "eventemitter3": "^5.0.1",
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true
+        },
+        "node_modules/package-manager-detector": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+            "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/parse-latin": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+            "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0",
+                "@types/unist": "^3.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unist-util-modify-children": "^4.0.0",
+                "unist-util-visit-children": "^3.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/perfect-debounce": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+            "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/piccolore": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+            "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pino": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+            "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@pinojs/redact": "^0.4.0",
+                "atomic-sleep": "^1.0.0",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^3.0.0",
+                "pino-std-serializers": "^7.0.0",
+                "process-warning": "^5.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^4.0.1",
+                "thread-stream": "^4.0.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/pino-abstract-transport": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+            "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/pino-std-serializers": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+            "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/pkg-types": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.4",
+                "exsolve": "^1.0.8",
+                "pathe": "^2.0.3"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.16",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-calc": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+            "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12 || ^20.9 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.38"
+            }
+        },
+        "node_modules/postcss-colormin": {
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.10.tgz",
+            "integrity": "sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@colordx/core": "^5.4.3",
+                "browserslist": "^4.28.2",
+                "caniuse-api": "^3.0.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-convert-values": {
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.12.tgz",
+            "integrity": "sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-discard-comments": {
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.8.tgz",
+            "integrity": "sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-discard-duplicates": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.4.tgz",
+            "integrity": "sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-discard-empty": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.3.tgz",
+            "integrity": "sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-discard-overridden": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.3.tgz",
+            "integrity": "sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-merge-longhand": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.7.tgz",
+            "integrity": "sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0",
+                "stylehacks": "^7.0.11"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-merge-rules": {
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.11.tgz",
+            "integrity": "sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "caniuse-api": "^3.0.0",
+                "cssnano-utils": "^5.0.3",
+                "postcss-selector-parser": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-minify-font-values": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.3.tgz",
+            "integrity": "sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-minify-gradients": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.5.tgz",
+            "integrity": "sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@colordx/core": "^5.4.3",
+                "cssnano-utils": "^5.0.3",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-minify-params": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.9.tgz",
+            "integrity": "sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "cssnano-utils": "^5.0.3",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-minify-selectors": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.2.tgz",
+            "integrity": "sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.1",
+                "caniuse-api": "^3.0.0",
+                "cssesc": "^3.0.0",
+                "postcss-selector-parser": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-nested": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-7.0.2.tgz",
+            "integrity": "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.14"
+            }
+        },
+        "node_modules/postcss-normalize-charset": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
+            "integrity": "sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-display-values": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.3.tgz",
+            "integrity": "sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-positions": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.4.tgz",
+            "integrity": "sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-repeat-style": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.4.tgz",
+            "integrity": "sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-string": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.3.tgz",
+            "integrity": "sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-timing-functions": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.3.tgz",
+            "integrity": "sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-unicode": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.9.tgz",
+            "integrity": "sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-url": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.3.tgz",
+            "integrity": "sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-normalize-whitespace": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.3.tgz",
+            "integrity": "sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-ordered-values": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.4.tgz",
+            "integrity": "sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssnano-utils": "^5.0.3",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-reduce-initial": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.9.tgz",
+            "integrity": "sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "caniuse-api": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-reduce-transforms": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.3.tgz",
+            "integrity": "sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postcss-svgo": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.3.tgz",
+            "integrity": "sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0",
+                "svgo": "^4.0.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >= 18"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-unique-selectors": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.7.tgz",
+            "integrity": "sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/pretty-bytes": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.1.tgz",
+            "integrity": "sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pretty-format": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/process-warning": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+            "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/promise": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+            "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "asap": "~2.0.6"
+            }
+        },
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/prompts/node_modules/kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/proper-lockfile": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+            "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "retry": "^0.12.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "node_modules/proper-lockfile/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/quansync": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+            "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/queue": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+            "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "inherits": "~2.0.3"
+            }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/radix3": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+            "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/range-parser": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/rc9": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "defu": "^6.1.6",
+                "destr": "^2.0.5"
+            }
+        },
+        "node_modules/react": {
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-devtools-core": {
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+            "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "shell-quote": "^1.6.1",
+                "ws": "^7"
+            }
+        },
+        "node_modules/react-devtools-core/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.8"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/react-native": {
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.2.tgz",
+            "integrity": "sha512-zbJXGZpwfZGA79Z9ob6Atvfx4nAQL8yJBa35s58E4Oo+khPykfQP2sTeumkKbjwajFYfVayg8pj7Il9nIfTk7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@react-native/assets-registry": "0.86.2",
+                "@react-native/codegen": "0.86.2",
+                "@react-native/community-cli-plugin": "0.86.2",
+                "@react-native/gradle-plugin": "0.86.2",
+                "@react-native/js-polyfills": "0.86.2",
+                "@react-native/normalize-colors": "0.86.2",
+                "@react-native/virtualized-lists": "0.86.2",
+                "abort-controller": "^3.0.0",
+                "anser": "^1.4.9",
+                "ansi-regex": "^5.0.0",
+                "babel-plugin-syntax-hermes-parser": "0.36.0",
+                "base64-js": "^1.5.1",
+                "commander": "^12.0.0",
+                "flow-enums-runtime": "^0.0.6",
+                "hermes-compiler": "250829098.0.16",
+                "invariant": "^2.2.4",
+                "memoize-one": "^5.0.0",
+                "metro-runtime": "^0.84.3",
+                "metro-source-map": "^0.84.3",
+                "nullthrows": "^1.1.1",
+                "pretty-format": "^29.7.0",
+                "promise": "^8.3.0",
+                "react-devtools-core": "^6.1.5",
+                "react-refresh": "^0.14.0",
+                "regenerator-runtime": "^0.13.2",
+                "scheduler": "0.27.0",
+                "semver": "^7.1.3",
+                "stacktrace-parser": "^0.1.10",
+                "tinyglobby": "^0.2.15",
+                "whatwg-fetch": "^3.0.0",
+                "ws": "^7.5.10",
+                "yargs": "^17.6.2"
+            },
+            "bin": {
+                "react-native": "cli.js"
+            },
+            "engines": {
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            },
+            "peerDependencies": {
+                "@react-native/jest-preset": "0.86.2",
+                "@types/react": "^19.1.1",
+                "react": "^19.2.3"
+            },
+            "peerDependenciesMeta": {
+                "@react-native/jest-preset": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-native/node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/react-native/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-refresh": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+            "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/readdir-glob": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+            "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "minimatch": "^5.1.0"
+            }
+        },
+        "node_modules/readdir-glob/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/readdir-glob/node_modules/brace-expansion": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/readdir-glob/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/regex": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+            "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-recursion": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+            "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/regexp-tree": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+            "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "regexp-tree": "bin/regexp-tree"
+            }
+        },
+        "node_modules/rehype": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+            "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "rehype-parse": "^9.0.0",
+                "rehype-stringify": "^10.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-parse": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+            "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-from-html": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-raw": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-raw": "^9.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/rehype-stringify": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+            "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-parse": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-rehype": {
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-smartypants": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+            "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "retext": "^9.0.0",
+                "retext-smartypants": "^6.0.0",
+                "unified": "^11.0.4",
+                "unist-util-visit": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remix": {
+            "version": "2.17.5",
+            "resolved": "https://registry.npmjs.org/remix/-/remix-2.17.5.tgz",
+            "integrity": "sha512-T3V80F8g5/vvKV7iwQOzZVdsp8QJtvGYDPUdgmLs060lfPae7X3lYezZl4ReUTooawHtvNHPC+wTh+yzwBkn0Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ret": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+            "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/retext": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+            "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0",
+                "retext-latin": "^4.0.0",
+                "retext-stringify": "^4.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/retext-latin": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+            "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0",
+                "parse-latin": "^7.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/retext-smartypants": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+            "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/retext-stringify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+            "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/nlcst": "^2.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/rolldown": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+            "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "=0.142.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.2.1",
+                "@rolldown/binding-darwin-arm64": "1.2.1",
+                "@rolldown/binding-darwin-x64": "1.2.1",
+                "@rolldown/binding-freebsd-x64": "1.2.1",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+                "@rolldown/binding-linux-arm64-musl": "1.2.1",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+                "@rolldown/binding-linux-x64-gnu": "1.2.1",
+                "@rolldown/binding-linux-x64-musl": "1.2.1",
+                "@rolldown/binding-openharmony-arm64": "1.2.1",
+                "@rolldown/binding-wasm32-wasi": "1.2.1",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+                "@rolldown/binding-win32-x64-msvc": "1.2.1"
+            }
+        },
+        "node_modules/rolldown/node_modules/@oxc-project/types": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.62.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+            "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+                "@rollup/rollup-android-arm-eabi": "4.62.4",
+                "@rollup/rollup-android-arm64": "4.62.4",
+                "@rollup/rollup-darwin-arm64": "4.62.4",
+                "@rollup/rollup-darwin-x64": "4.62.4",
+                "@rollup/rollup-freebsd-arm64": "4.62.4",
+                "@rollup/rollup-freebsd-x64": "4.62.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+                "@rollup/rollup-linux-arm64-musl": "4.62.4",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+                "@rollup/rollup-linux-loong64-musl": "4.62.4",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+                "@rollup/rollup-linux-x64-gnu": "4.62.4",
+                "@rollup/rollup-linux-x64-musl": "4.62.4",
+                "@rollup/rollup-openbsd-x64": "4.62.4",
+                "@rollup/rollup-openharmony-arm64": "4.62.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+                "@rollup/rollup-win32-x64-gnu": "4.62.4",
+                "@rollup/rollup-win32-x64-msvc": "4.62.4",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-dts": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
+            "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
+            "dev": true,
+            "license": "LGPL-3.0-only",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "@jridgewell/sourcemap-codec": "^1.5.5",
+                "convert-source-map": "^2.0.0",
+                "magic-string": "^0.30.21"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Swatinem"
+            },
+            "optionalDependencies": {
+                "@babel/code-frame": "^7.29.0"
+            },
+            "peerDependencies": {
+                "rollup": "^3.29.4 || ^4",
+                "typescript": "^4.5 || ^5.0 || ^6.0"
+            }
+        },
+        "node_modules/rollup-plugin-dts/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+            "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "open": "^11.0.0",
+                "picomatch": "^4.0.2",
+                "source-map": "^0.7.4",
+                "yargs": "^18.0.0"
+            },
+            "bin": {
+                "rollup-plugin-visualizer": "dist/bin/cli.js"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "peerDependencies": {
+                "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+                "rollup": "2.x || 3.x || 4.x"
+            },
+            "peerDependenciesMeta": {
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/open": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "default-browser": "^5.4.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
+                "is-inside-container": "^1.0.0",
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^8.2.1",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/rollup-plugin-visualizer/node_modules/yargs/node_modules/string-width": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/rou3": {
+            "version": "0.7.12",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+            "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/safe-regex2": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+            "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ret": "~0.5.0"
+            },
+            "bin": {
+                "safe-regex2": "bin/safe-regex2.js"
+            }
+        },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/sax": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/scule": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+            "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/secure-json-parse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serialize-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+            "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/serialize-javascript": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/seroval": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.6.0.tgz",
+            "integrity": "sha512-TBwwKfscTEgnBEWmYKKeCcmCGmrJi0LV6qNUY//WBA3MDesh/zfn+KOMq/ckpxM4gZ0ouAE706A1eenekM2sug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/seroval-plugins": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.6.0.tgz",
+            "integrity": "sha512-CbR5DP5DPicpd9RwRUzka7hi4x1577eGFXJVBW409LXqqJNst99JSUTZ8CXcnskQX7laPOWpmzliq0gBZEGlrQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "seroval": "^1.0"
+            }
+        },
+        "node_modules/serve-placeholder": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/serve-placeholder/-/serve-placeholder-2.0.2.tgz",
+            "integrity": "sha512-/TMG8SboeiQbZJWRlfTCqMs2DD3SZgWp0kDQePz9yUuCnDfDh/92gf7/PxGhzXTKBIPASIHxFcZndoNbp6QOLQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "defu": "^6.1.4"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+            "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/sharp": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/shiki": {
+            "version": "3.23.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+            "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@shikijs/core": "3.23.0",
+                "@shikijs/engine-javascript": "3.23.0",
+                "@shikijs/engine-oniguruma": "3.23.0",
+                "@shikijs/langs": "3.23.0",
+                "@shikijs/themes": "3.23.0",
+                "@shikijs/types": "3.23.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/simple-git": {
+            "version": "3.36.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+            "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.1.1",
+                "@simple-git/args-pathspec": "^1.0.3",
+                "@simple-git/argv-parser": "^1.1.0",
+                "debug": "^4.4.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/steveukx/git-js?sponsor=1"
+            }
+        },
+        "node_modules/sirv": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/slash": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/smob": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+            "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/smol-toml": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+            "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/cyyynthia"
+            }
+        },
+        "node_modules/sonic-boom": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+            "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/srvx": {
+            "version": "0.11.22",
+            "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.22.tgz",
+            "integrity": "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "srvx": "bin/srvx.mjs"
+            },
+            "engines": {
+                "node": ">=20.16.0"
+            }
+        },
+        "node_modules/stackframe": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+            "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/stacktrace-parser": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+            "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "type-fest": "^0.7.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/stacktrace-parser/node_modules/type-fest": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+            "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/standardwebhooks": {
             "version": "1.0.0",
@@ -50,6 +20519,748 @@
                 "@stablelib/base64": "^1.0.0",
                 "fast-sha256": "^1.3.0"
             }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/streamx": {
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+            "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "events-universal": "^1.0.0",
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/stringify-entities": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "character-entities-html4": "^2.0.0",
+                "character-entities-legacy": "^3.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-literal": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "js-tokens": "^10.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/structured-clone-es": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/structured-clone-es/-/structured-clone-es-2.0.1.tgz",
+            "integrity": "sha512-10ZL5r77LhknxlP1FBiCW+VdnuWOEFLdSS2SKtjyEV+L4qP1hUEIMIZW94LC3jKxRmT/Dj7KkD1mqh/IY6lhKQ==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/styled-jsx": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+            "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "client-only": "0.0.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/stylehacks": {
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.11.tgz",
+            "integrity": "sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.2",
+                "postcss-selector-parser": "^7.1.1"
+            },
+            "engines": {
+                "node": "^18.12.0 || ^20.9.0 || >=22.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.5.13"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/svelte": {
+            "version": "5.56.8",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+            "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.4",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@sveltejs/acorn-typescript": "^1.0.10",
+                "@types/estree": "^1.0.5",
+                "@types/trusted-types": "^2.0.7",
+                "acorn": "^8.12.1",
+                "aria-query": "5.3.1",
+                "axobject-query": "^4.1.0",
+                "clsx": "^2.1.1",
+                "devalue": "^5.8.1",
+                "esm-env": "^1.2.1",
+                "esrap": "^2.2.12",
+                "is-reference": "^3.0.3",
+                "locate-character": "^3.0.0",
+                "magic-string": "^0.30.11",
+                "zimmerframe": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/svelte/node_modules/aria-query": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+            "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/svelte/node_modules/is-reference": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+            "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "^1.0.6"
+            }
+        },
+        "node_modules/svgo": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^11.1.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^3.0.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.1.1",
+                "sax": "^1.5.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
+            }
+        },
+        "node_modules/svgo/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tagged-tag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tar": {
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/tar/node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "streamx": "^2.12.5"
+            }
+        },
+        "node_modules/terser": {
+            "version": "5.49.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/text-decoder": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "b4a": "^1.6.4"
+            }
+        },
+        "node_modules/thread-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+            "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "real-require": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/thread-stream/node_modules/real-require": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+            "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/throat": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/tinyclip": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+            "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^16.14.0 || >= 17.3.0"
+            }
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tmpl": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/toad-cache": {
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+            "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/trim-lines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/trough": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/tsconfck": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+            "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+            "deprecated": "unmaintained",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tsconfck": "bin/tsconfck.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            },
+            "peerDependencies": {
+                "typescript": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "peer": true
+        },
+        "node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-level-regexp": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/type-level-regexp/-/type-level-regexp-0.1.17.tgz",
+            "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/typescript": {
             "version": "5.9.3",
@@ -63,6 +21274,2451 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/ufo": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ultrahtml": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+            "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/unbuild": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/unbuild/-/unbuild-3.6.1.tgz",
+            "integrity": "sha512-+U5CdtrdjfWkZhuO4N9l5UhyiccoeMEXIc2Lbs30Haxb+tRwB3VwB8AoZRxlAzORXunenSo+j6lh45jx+xkKgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/plugin-alias": "^5.1.1",
+                "@rollup/plugin-commonjs": "^28.0.6",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^16.0.1",
+                "@rollup/plugin-replace": "^6.0.2",
+                "@rollup/pluginutils": "^5.2.0",
+                "citty": "^0.1.6",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "esbuild": "^0.25.9",
+                "fix-dts-default-cjs-exports": "^1.0.1",
+                "hookable": "^5.5.3",
+                "jiti": "^2.5.1",
+                "magic-string": "^0.30.17",
+                "mkdist": "^2.3.0",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.2.0",
+                "pretty-bytes": "^7.0.1",
+                "rollup": "^4.46.2",
+                "rollup-plugin-dts": "^6.2.1",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.14",
+                "untyped": "^2.0.0"
+            },
+            "bin": {
+                "unbuild": "dist/cli.mjs"
+            },
+            "peerDependencies": {
+                "typescript": "^5.9.2"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/unbuild/node_modules/@rollup/plugin-alias": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
+            "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unbuild/node_modules/@rollup/plugin-commonjs": {
+            "version": "28.0.9",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
+            "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "fdir": "^6.2.0",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unbuild/node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
+        "node_modules/unbuild/node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/unctx": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+            "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21",
+                "unplugin": "^2.3.11"
+            }
+        },
+        "node_modules/unctx/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/unctx/node_modules/unplugin": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/unenv": {
+            "version": "2.0.0-rc.24",
+            "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+            "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "pathe": "^2.0.3"
+            }
+        },
+        "node_modules/unhead": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.16.tgz",
+            "integrity": "sha512-cD2Q4a6SQHhW9/bPp17NT4GJ1yS0DSLe75WEHKQ8bKa/wjB6cIki3KeL86hhllNBcpv8i6bxdwtwQunneXPqKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hookable": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            }
+        },
+        "node_modules/unhead/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unifont": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+            "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "css-tree": "^3.1.0",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11"
+            }
+        },
+        "node_modules/unimport": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.4.0.tgz",
+            "integrity": "sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.18.0",
+                "escape-string-regexp": "^5.0.0",
+                "estree-walker": "^3.0.3",
+                "local-pkg": "^1.2.1",
+                "magic-string": "^1.1.0",
+                "mlly": "^1.8.2",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.5",
+                "pkg-types": "^2.3.1",
+                "scule": "^1.3.0",
+                "strip-literal": "^4.0.0",
+                "tinyglobby": "^0.2.17",
+                "unplugin": "^3.3.0",
+                "unplugin-utils": "^0.3.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "peerDependencies": {
+                "oxc-parser": "*",
+                "rolldown": "^1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unimport/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/unimport/node_modules/magic-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+            "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/unist-util-find-after": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+            "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-is": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+            "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-modify-children": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+            "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "array-iterate": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-position": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-remove-position": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+            "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-children": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+            "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-parents": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/unplugin": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.4",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unplugin-utils": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+            "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/unplugin-vue-router": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/unplugin-vue-router/-/unplugin-vue-router-0.19.2.tgz",
+            "integrity": "sha512-u5dgLBarxE5cyDK/hzJGfpCTLIAyiTXGlo85COuD4Nssj6G7NxS+i9mhCWz/1p/ud1eMwdcUbTXehQe41jYZUA==",
+            "deprecated": "Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/generator": "^7.28.5",
+                "@vue-macros/common": "^3.1.1",
+                "@vue/language-core": "^3.2.1",
+                "ast-walker-scope": "^0.8.3",
+                "chokidar": "^5.0.0",
+                "json5": "^2.2.3",
+                "local-pkg": "^1.1.2",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.0",
+                "muggle-string": "^0.4.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.15",
+                "unplugin": "^2.3.11",
+                "unplugin-utils": "^0.3.1",
+                "yaml": "^2.8.2"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "^3.5.17",
+                "vue-router": "^4.6.0"
+            },
+            "peerDependenciesMeta": {
+                "vue-router": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unplugin-vue-router/node_modules/unplugin": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+            "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "acorn": "^8.15.0",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
+        "node_modules/unstorage": {
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+            "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "anymatch": "^3.1.3",
+                "chokidar": "^5.0.0",
+                "destr": "^2.0.5",
+                "h3": "^1.15.10",
+                "lru-cache": "^11.2.7",
+                "node-fetch-native": "^1.6.7",
+                "ofetch": "^1.5.1",
+                "ufo": "^1.6.3"
+            },
+            "peerDependencies": {
+                "@azure/app-configuration": "^1.8.0",
+                "@azure/cosmos": "^4.2.0",
+                "@azure/data-tables": "^13.3.0",
+                "@azure/identity": "^4.6.0",
+                "@azure/keyvault-secrets": "^4.9.0",
+                "@azure/storage-blob": "^12.26.0",
+                "@capacitor/preferences": "^6 || ^7 || ^8",
+                "@deno/kv": ">=0.9.0",
+                "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+                "@planetscale/database": "^1.19.0",
+                "@upstash/redis": "^1.34.3",
+                "@vercel/blob": ">=0.27.1",
+                "@vercel/functions": "^2.2.12 || ^3.0.0",
+                "@vercel/kv": "^1 || ^2 || ^3",
+                "aws4fetch": "^1.0.20",
+                "db0": ">=0.2.1",
+                "idb-keyval": "^6.2.1",
+                "ioredis": "^5.4.2",
+                "uploadthing": "^7.4.4"
+            },
+            "peerDependenciesMeta": {
+                "@azure/app-configuration": {
+                    "optional": true
+                },
+                "@azure/cosmos": {
+                    "optional": true
+                },
+                "@azure/data-tables": {
+                    "optional": true
+                },
+                "@azure/identity": {
+                    "optional": true
+                },
+                "@azure/keyvault-secrets": {
+                    "optional": true
+                },
+                "@azure/storage-blob": {
+                    "optional": true
+                },
+                "@capacitor/preferences": {
+                    "optional": true
+                },
+                "@deno/kv": {
+                    "optional": true
+                },
+                "@netlify/blobs": {
+                    "optional": true
+                },
+                "@planetscale/database": {
+                    "optional": true
+                },
+                "@upstash/redis": {
+                    "optional": true
+                },
+                "@vercel/blob": {
+                    "optional": true
+                },
+                "@vercel/functions": {
+                    "optional": true
+                },
+                "@vercel/kv": {
+                    "optional": true
+                },
+                "aws4fetch": {
+                    "optional": true
+                },
+                "db0": {
+                    "optional": true
+                },
+                "idb-keyval": {
+                    "optional": true
+                },
+                "ioredis": {
+                    "optional": true
+                },
+                "uploadthing": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unstorage/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "peer": true,
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/untun": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/untun/-/untun-0.2.2.tgz",
+            "integrity": "sha512-+NnOJcSiEtYsVgJmXUzQbJeRAFXJC4yPJYuh6kF9B0Rm6zunXcs/3GZOTllyocSbUDIxD6Bj7e/4ATw7sph1Sw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "untun": "dist/cli.mjs"
+            }
+        },
+        "node_modules/untyped": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/untyped/-/untyped-2.0.0.tgz",
+            "integrity": "sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.1.6",
+                "defu": "^6.1.4",
+                "jiti": "^2.4.2",
+                "knitwork": "^1.2.0",
+                "scule": "^1.3.0"
+            },
+            "bin": {
+                "untyped": "dist/cli.mjs"
+            }
+        },
+        "node_modules/untyped/node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
+        "node_modules/unwasm": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/unwasm/-/unwasm-0.5.3.tgz",
+            "integrity": "sha512-keBgTSfp3r6+s9ZcSma+0chwxQdmLbB5+dAD9vjtB21UTMYuKAxHXCU1K2CbCtnP09EaWeRvACnXk0EJtUx+hw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "exsolve": "^1.0.8",
+                "knitwork": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.3.0"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/uqr": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.3.tgz",
+            "integrity": "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/verkit": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.2.0.tgz",
+            "integrity": "sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/vfile": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-location": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-message": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+            "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vite": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+            "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "lightningcss": "^1.33.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.23",
+                "rolldown": "~1.2.0",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.4.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-dev-rpc": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/vite-dev-rpc/-/vite-dev-rpc-2.0.0.tgz",
+            "integrity": "sha512-yKwbTwdHKSD2k/aGqyWpPHepo45OQc8lH3/6IfT4ZqeKE26ooKvi4WIEKzqWav8v+9Is8u1k8q54hvOmqASazA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "birpc": "^4.0.0",
+                "vite-hot-client": "^2.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0 || ^8.0.0"
+            }
+        },
+        "node_modules/vite-hot-client": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.2.0.tgz",
+            "integrity": "sha512-76Zs9zrHbH7M7wqeyooGQKdX+yg0pQ0xuQ1PbFp4z5a0Lzn2e5IPFoCswnmqZ4GiwqB4Jo3WcDAMO9jARTJl8w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0"
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-5.3.0.tgz",
+            "integrity": "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cac": "^6.7.14",
+                "es-module-lexer": "^2.0.0",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "vite": "^7.3.1"
+            },
+            "bin": {
+                "vite-node": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/antfu"
+            }
+        },
+        "node_modules/vite-node/node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/vite-node/node_modules/vite": {
+            "version": "7.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-checker": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.14.5.tgz",
+            "integrity": "sha512-c9lQ92eisUO+F7Fd93aelojmiOS+NQpPgQ1XR2LTQHox1/laZf4yAoQj+L3RA9Vgh10e2nFd9b8r2LLyYZsbpA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "chokidar": "^5.0.0",
+                "npm-run-path": "^6.0.0",
+                "picocolors": "^1.1.1",
+                "picomatch": "^4.0.4",
+                "proper-lockfile": "^4.1.2",
+                "tiny-invariant": "^1.3.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@biomejs/biome": ">=2.4.12",
+                "eslint": ">=9.39.4",
+                "meow": "^13.2.0 || ^14.0.0",
+                "optionator": "^0.9.4",
+                "oxlint": ">=1",
+                "stylelint": ">=16.26.1",
+                "typescript": "*",
+                "vite": ">=5.4.21",
+                "vue-tsc": "~2.2.10 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@biomejs/biome": {
+                    "optional": true
+                },
+                "eslint": {
+                    "optional": true
+                },
+                "meow": {
+                    "optional": true
+                },
+                "optionator": {
+                    "optional": true
+                },
+                "oxlint": {
+                    "optional": true
+                },
+                "stylelint": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-checker/node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-inspect": {
+            "version": "11.4.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.4.1.tgz",
+            "integrity": "sha512-ShOFe2PURXGvRS5OrgmOLZOCwDTD7dEBVt0tMpFPKb9AsvqXKCRGM8QgKrUbRbJYFXScHvDPpGRd28rYidC0tA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansis": "^4.3.0",
+                "error-stack-parser-es": "^1.0.5",
+                "obug": "^2.1.1",
+                "ohash": "^2.0.11",
+                "open": "^11.0.0",
+                "perfect-debounce": "^2.1.0",
+                "sirv": "^3.0.2",
+                "unplugin-utils": "^0.3.1",
+                "vite-dev-rpc": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0-0 || ^8.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@nuxt/kit": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-inspect/node_modules/open": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "default-browser": "^5.4.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
+                "is-inside-container": "^1.0.0",
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vite-plugin-vue-tracer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.4.0.tgz",
+            "integrity": "sha512-0tQCjCqZWVSK6UeRW9S4ABbf47lKQ68zvrT2FNvZmiL+alDydCVyH/T3Jlfbdc3T3C2Iuyyl5aVsMbF8IQIoxA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "estree-walker": "^3.0.3",
+                "exsolve": "^1.0.8",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3",
+                "source-map-js": "^1.2.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/vite-plugin-vue-tracer/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vitefu": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+            "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "tests/deps/*",
+                "tests/projects/*",
+                "tests/projects/workspace/packages/*"
+            ],
+            "peerDependencies": {
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vlq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
+            "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/vue": {
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+            "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-sfc": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/server-renderer": "3.5.40",
+                "@vue/shared": "3.5.40"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vue-bundle-renderer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-2.3.1.tgz",
+            "integrity": "sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ufo": "^1.6.4"
+            }
+        },
+        "node_modules/vue-devtools-stub": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
+            "integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/vue-router": {
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+            "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vue/devtools-api": "^6.6.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "vue": "^3.5.0"
+            }
+        },
+        "node_modules/vue-sfc-transformer": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/vue-sfc-transformer/-/vue-sfc-transformer-0.2.5.tgz",
+            "integrity": "sha512-e+yWjXmWH/088bFrgpvVZ4x/4TkgRKM3L9yreSVlzphEy03auX7zgycyHFLEyCizMDmUh+Q2aXYRb3tjETtCyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.27.0",
+                "pathe": "^2.0.3",
+                "tinyglobby": "^0.2.16"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "@volar/typescript": "^2.4.0",
+                "@vue/compiler-core": "^3.5.13",
+                "@vue/language-core": "^3.0.0",
+                "esbuild": "*",
+                "rolldown": ">=1.0.0-beta.0",
+                "typescript": ">=5.0.0",
+                "vue": "^3.5.13"
+            },
+            "peerDependenciesMeta": {
+                "@volar/typescript": {
+                    "optional": true
+                },
+                "@vue/language-core": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/walker": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/web-namespaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+            "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true
+        },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+            "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/whatwg-fetch": {
+            "version": "3.6.20",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+            "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/which-pm-runs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/widest-line": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/xmlbuilder2": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz",
+            "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oozcitak/dom": "^2.0.2",
+                "@oozcitak/infra": "^2.0.2",
+                "@oozcitak/util": "^10.0.0",
+                "js-yaml": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/xxhash-wasm": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+            "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yocto-spinner": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-0.2.3.tgz",
+            "integrity": "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=18.19"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yoctocolors": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/youch": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.1.tgz",
+            "integrity": "sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@poppinss/colors": "^4.1.6",
+                "@poppinss/dumper": "^0.7.0",
+                "@speed-highlight/core": "^1.2.14",
+                "cookie-es": "^3.0.1",
+                "youch-core": "^0.3.3"
+            }
+        },
+        "node_modules/youch-core": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+            "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@poppinss/exception": "^1.2.2",
+                "error-stack-parser-es": "^1.0.5"
+            }
+        },
+        "node_modules/zimmerframe": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+            "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/zip-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+            "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "archiver-utils": "^5.0.0",
+                "compress-commons": "^6.0.2",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
+            }
+        },
+        "node_modules/zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "@dodopayments/sveltekit": "^0.2.8",
                 "@dodopayments/tanstack": "^0.2.8",
                 "dodopayments": "^2.44.0",
+                "dodopayments-checkout": "^1.9.5",
                 "standardwebhooks": "^1.0.0",
                 "typescript": "^5.6.0"
             }
@@ -11484,6 +11485,16 @@
             },
             "bin": {
                 "dodopayments": "bin/cli"
+            }
+        },
+        "node_modules/dodopayments-checkout": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/dodopayments-checkout/-/dodopayments-checkout-1.9.5.tgz",
+            "integrity": "sha512-TRWdXdvwjzL5uNp8518v/1E3zvZf8P+Is5/QVRvHRxqSbIiCrxFqetEfromOaVRqNe7XLE23wWwxj0ccPCEBug==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@dodopayments/skills",
+    "private": true,
+    "version": "2.0.0",
+    "description": "Official Dodo Payments agent skills. Tooling only - the skills themselves are the SKILL.md files.",
+    "type": "module",
+    "scripts": {
+        "validate": "node scripts/validate-skills.mjs .",
+        "typecheck": "node scripts/typecheck-examples.mjs",
+        "check": "npm run validate && npm run typecheck"
+    },
+    "devDependencies": {
+        "dodopayments": "^2.44.0",
+        "typescript": "^5.6.0"
+    },
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dodopayments/skills.git"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "scripts": {
         "validate": "node scripts/validate-skills.mjs .",
         "typecheck": "node scripts/typecheck-examples.mjs",
-        "check": "npm run validate && npm run typecheck"
+        "typecheck:go": "node scripts/check-go-examples.mjs",
+        "typecheck:python": "node scripts/check-python-examples.mjs",
+        "check": "npm run validate && npm run typecheck && npm run typecheck:go && npm run typecheck:python"
     },
     "devDependencies": {
         "@dodopayments/astro": "^0.2.9",
@@ -24,6 +26,7 @@
         "@dodopayments/sveltekit": "^0.2.8",
         "@dodopayments/tanstack": "^0.2.8",
         "dodopayments": "^2.44.0",
+        "dodopayments-checkout": "^1.9.5",
         "standardwebhooks": "^1.0.0",
         "typescript": "^5.6.0"
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,21 @@
         "check": "npm run validate && npm run typecheck"
     },
     "devDependencies": {
+        "@dodopayments/astro": "^0.2.9",
+        "@dodopayments/better-auth": "^1.6.4",
+        "@dodopayments/bun": "^0.1.3",
+        "@dodopayments/convex": "^0.2.13",
+        "@dodopayments/express": "^0.2.9",
+        "@dodopayments/fastify": "^0.2.8",
+        "@dodopayments/hono": "^0.2.8",
+        "@dodopayments/nextjs": "^0.3.7",
+        "@dodopayments/nuxt": "^0.2.8",
+        "@dodopayments/react-native-checkout": "^1.1.0",
+        "@dodopayments/remix": "^0.2.8",
+        "@dodopayments/sveltekit": "^0.2.8",
+        "@dodopayments/tanstack": "^0.2.8",
         "dodopayments": "^2.44.0",
+        "standardwebhooks": "^1.0.0",
         "typescript": "^5.6.0"
     },
     "license": "MIT",

--- a/scripts/check-go-examples.mjs
+++ b/scripts/check-go-examples.mjs
@@ -102,6 +102,12 @@ func main() {}
  * analogue of the TS preamble's `any` declarations. `_ = ctx` / `_ = client`
  * likewise silence the case where a block touches neither.
  */
+/** Stdlib qualifiers a skill might use; see the `undefined:` filter below. */
+const GO_STDLIB = new Set([
+	'os', 'io', 'http', 'time', 'context', 'fmt', 'json', 'errors',
+	'strings', 'strconv', 'bytes', 'log', 'sql', 'url',
+]);
+
 const FIXED_IMPORTS = `import (
 	"io"
 	"net/http"
@@ -222,6 +228,38 @@ function hoistImports(code) {
 }
 
 /**
+ * Index of the last line belonging to the block's own import declaration, or -1
+ * when it has none.
+ *
+ * Blocks that ship an import group are compiled with THAT group, not a
+ * substituted superset. Blanking it and prepending a known-good set validated
+ * the statements while silently excusing the snippet's own imports - so a
+ * quick-start could call `os.Getenv` without importing `os`, fail the moment a
+ * reader pasted it, and still be reported clean.
+ */
+function findImportEnd(lines) {
+    let end = -1;
+    let inGroup = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (inGroup) {
+            end = i;
+            if (/^\s*\)\s*$/.test(line)) inGroup = false;
+            continue;
+        }
+        if (/^\s*import\s*\(\s*$/.test(line)) {
+            inGroup = true;
+            end = i;
+            continue;
+        }
+        if (/^\s*import\s+(?:[\w.]+\s+)?["`][^"`]+["`]\s*$/.test(line)) {
+            end = i;
+        }
+    }
+    return end;
+}
+
+/**
  * Does the block open with a top-level declaration (func/type/const/var/package)
  * as its first non-blank, non-import line? Such blocks are near-complete files
  * and go straight into the file body. Everything else is a statement fragment
@@ -263,11 +301,48 @@ function main() {
         const rel = `dodo-payments/${dir}/SKILL.md`;
         const md = readFileSync(join(SKILLS_DIR, dir, 'SKILL.md'), 'utf8');
         for (const b of extractBlocks(md)) {
-            const body = hoistImports(b.code);
             const name = `case_${String(n).padStart(4, '0')}.go`;
+            const srcLines = b.code.split('\n');
+            const impEnd = findImportEnd(srcLines);
+            const ownImports = impEnd >= 0;
 
             let header;
             let footer;
+            let body;
+
+            if (ownImports) {
+                // Compile the snippet's OWN imports. Nothing is substituted, so
+                // a missing or bogus import is a real failure here.
+                header = 'package main\n\n';
+                const after = srcLines.slice(impEnd + 1).join('\n');
+                if (isFileScope(after)) {
+                    body = b.code;
+                    footer = '\n';
+                } else {
+                    // Statements need a function, but the opener must sit after
+                    // the imports. Consume the blank line that conventionally
+                    // follows the group so the body keeps its original line
+                    // count and the mapping stays a single fixed offset.
+                    const opener = `func case${String(n).padStart(4, '0')}() {`;
+                    const blank = srcLines.findIndex((l, i) => i > impEnd && !l.trim());
+                    const copy = [...srcLines];
+                    if (blank !== -1) copy[blank] = opener;
+                    else copy.splice(impEnd + 1, 0, opener);
+                    body = copy.join('\n');
+                    footer = '\n}\n';
+                }
+                writeFileSync(join(WORK, name), `${header}${body}${footer}`);
+                index.set(name, {
+                    file: rel,
+                    startLine: b.startLine,
+                    offset: header.split('\n').length - 1,
+                    ownImports: true,
+                });
+                n++;
+                continue;
+            }
+
+            body = hoistImports(b.code);
             if (isFileScope(body)) {
                 // Near-complete file (own funcs/types). Drop it in verbatim after
                 // the fixed imports; the block's declarations are just more
@@ -291,6 +366,7 @@ function main() {
                 // leave blank lines behind, so the body is line-for-line the
                 // same as the original block and no further correction applies.
                 offset: header.split('\n').length - 1,
+                ownImports: false,
             });
             n++;
         }
@@ -328,8 +404,11 @@ function main() {
     const tidyOut = (tidy.stdout || '') + (tidy.stderr || '');
     if (tidy.status !== 0 || !existsSync(join(WORK, 'go.sum'))) {
         console.error(
-            `FATAL: could not resolve ${SDK_MODULE} ${SDK_VERSION}, so no SDK types were checked.\n` +
-            'Ensure the module is available (in the Go module cache or reachable for download).\n' +
+            'FATAL: `go mod tidy` failed, so nothing was type-checked.\n' +
+            `Usually ${SDK_MODULE} ${SDK_VERSION} is unavailable (not in the module\n` +
+            'cache and not reachable). It can also mean a SKILL.md import group names a\n' +
+            'package that does not exist - check the resolver output below before\n' +
+            'assuming the SDK is at fault.\n' +
             'Refusing to report a passing run.\n\n' +
             tidyOut.trim(),
         );
@@ -390,14 +469,20 @@ function main() {
         if (undef) {
             const sym = undef[1];
             const isSdk = /^(dodopayments|option|param|ctx|client)\b/.test(sym) || /^dodopayments\./.test(sym);
-            if (!isSdk) continue;
+            // When the block ships its own imports, a bare stdlib qualifier means
+            // the published snippet forgot to import it - the exact defect that
+            // substituting a known-good import set used to conceal.
+            const isMissingStdlib = meta.ownImports && GO_STDLIB.has(sym.split('.')[0]);
+            if (!isSdk && !isMissingStdlib) continue;
         }
 
         // Unused locals/imports are artifacts of compiling a fragment in
         // isolation, never an SDK-shape error. Wrong SDK usage never shows up
         // as "declared and not used".
         if (/declared and not used/.test(entry.message)) continue;
-        if (/imported and not used/.test(entry.message)) continue;
+        // Only excusable when WE supplied the imports. When the block ships its
+        // own group, an unused import is a defect in the published snippet.
+        if (!meta.ownImports && /imported and not used/.test(entry.message)) continue;
 
         // Deduplicate: pass 1 and pass 2 overlap.
         if (diags.some((d) => d.file === entry.file && d.line === entry.line && d.message === entry.message)) continue;

--- a/scripts/check-go-examples.mjs
+++ b/scripts/check-go-examples.mjs
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+/**
+ * Compile every Go example in every SKILL.md against the real
+ * `github.com/dodopayments/dodopayments-go` SDK.
+ *
+ * The skills are pasted verbatim into agent context, so a wrong field name
+ * propagates as reliably as a wrong hostname — and fails silently rather than
+ * loudly. Prose review does not reliably catch that class of error; the
+ * compiler does. The TypeScript examples get this via `typecheck-examples.mjs`;
+ * this is the Go counterpart.
+ *
+ * How it works
+ *   1. Extract every ```go fenced block from each SKILL.md.
+ *   2. Skip blocks marked as deliberate counter-examples ("Wrong:", "Broken:",
+ *      "Anti-pattern") — those are supposed to be incorrect.
+ *   3. Wrap each block in `package main`: hoist its own imports out, prepend a
+ *      fixed supplemental import set plus `ctx`/`client` so bare fragments
+ *      compile, and neutralize unused-import noise. A blank line replaces every
+ *      hoisted line so reported lines still line up with the original block.
+ *   4. `go build` the whole set and map diagnostics back to SKILL.md:<line>.
+ *
+ * Usage:
+ *   node scripts/check-go-examples.mjs           # report
+ *   node scripts/check-go-examples.mjs --json    # machine readable
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS_DIR = join(ROOT, 'dodo-payments');
+const WORK = join(ROOT, '.gocheck-tmp');
+const JSON_OUT = process.argv.includes('--json');
+
+/**
+ * Pinned deliberately. The examples are written against exactly these symbols
+ * (option.WithEnvironmentTestMode, param.Field[time.Time] fields, the
+ * two-argument Webhooks.Unwrap), so checking them against a floating latest
+ * would report drift that the docs never claimed to track. Bump this in lockstep
+ * with the version quoted in the skills themselves.
+ */
+const SDK_MODULE = 'github.com/dodopayments/dodopayments-go';
+const SDK_VERSION = 'v1.110.0';
+
+/** Fences we attempt to compile. */
+const GO_LANGS = new Set(['go']);
+
+/**
+ * A block is a deliberate counter-example only when it is EXPLICITLY labelled
+ * as one — a bolded label such as `**Wrong:**`, or an opt-out comment. Same
+ * rule as the TS checker: inferring intent from bare prose silently removes
+ * coverage, so opting out has to be a marker you can grep for.
+ */
+const NEGATIVE_MARKER =
+    /(?:\*\*|__)\s*(?:wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|unsafe|never)\b[^*_\n]{0,60}?(?:\*\*|__)/i;
+
+/** Explicit, greppable opt-out for blocks that cannot compile by design. */
+const SKIP_COMMENT = /<!--\s*gocheck:\s*skip\s*-->/i;
+
+/**
+ * The fixed supplemental preamble prepended to every block.
+ *
+ * Fragment blocks reference `client` and `ctx` without constructing them (they
+ * were set up in an earlier block of the same SKILL.md). Declaring them at
+ * package level keeps such fragments compiling AND keeps the SDK actually
+ * checked — an untyped `client` would resolve nothing, which is exactly how a
+ * "clean" run hides every method-name error.
+ *
+ * Blocks that declare their own `client :=` simply shadow this one, which is
+ * legal Go.
+ *
+ * `main` lives here (once) so the package links; every case body is a uniquely
+ * named function that Go tolerates being unused at package scope. Go errors on
+ * unused IMPORTS and unused LOCAL variables, but never on unused funcs or
+ * unused package-level vars, so this file carries the machinery that would
+ * otherwise trip those rules.
+ */
+const SUPPORT = `package main
+
+import (
+	"context"
+
+	"github.com/dodopayments/dodopayments-go"
+)
+
+var ctx = context.Background()
+var client = dodopayments.NewClient()
+
+func main() {}
+`;
+
+/**
+ * Imports are file-scoped in Go, so each case file must carry the full set it
+ * might touch. This is the fixed supplemental import block prepended to every
+ * case. Fragments lean on it; blocks with their own `import (...)` get theirs
+ * hoisted to blank lines (see hoistImports) and fall back on this set.
+ *
+ * Each import is immediately referenced by a package-scope `var _ = ...` so an
+ * import the block never uses does not trip "imported and not used" — the Go
+ * analogue of the TS preamble's `any` declarations. `_ = ctx` / `_ = client`
+ * likewise silence the case where a block touches neither.
+ */
+const FIXED_IMPORTS = `import (
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/dodopayments/dodopayments-go"
+	"github.com/dodopayments/dodopayments-go/option"
+)
+`;
+
+/**
+ * Reference every fixed import exactly once so unused ones stay quiet — the Go
+ * analogue of the TS preamble's `any` declarations. `_ = ctx` / `_ = client`
+ * likewise silence the case where a block touches neither. Uses package-scope
+ * vars (never an unused-local error). `param` is deliberately absent: it lives
+ * under `internal/` in the SDK and is not importable from outside the module;
+ * blocks reach `param.Field[T]` through `dodopayments.F(...)`, which is exactly
+ * how the docs use it.
+ */
+const FIXED_NEUTRALIZERS = `var (
+	_ = io.ReadAll
+	_ = http.MethodGet
+	_ = os.Getenv
+	_ = time.Now
+	_ = option.WithBearerToken
+	_ = dodopayments.NewClient
+	_ = ctx
+	_ = client
+)
+`;
+
+function listSkillDirs() {
+    return readdirSync(SKILLS_DIR)
+        .filter((d) => statSync(join(SKILLS_DIR, d)).isDirectory())
+        .sort();
+}
+
+/**
+ * Extract compilable Go blocks with their 1-based start line in the source file.
+ */
+function extractBlocks(md) {
+    const lines = md.split('\n');
+    const blocks = [];
+    let i = 0;
+    while (i < lines.length) {
+        const open = lines[i].match(/^```([a-zA-Z]*)\s*$/);
+        if (!open) {
+            i++;
+            continue;
+        }
+        const lang = open[1].toLowerCase();
+        // find close
+        let j = i + 1;
+        while (j < lines.length && !/^```\s*$/.test(lines[j])) j++;
+
+        if (GO_LANGS.has(lang)) {
+            // Explicit markers only, and only in the 2 lines immediately above.
+            let negative = false;
+            for (let k = i - 1, seen = 0; k >= 0 && seen < 2; k--) {
+                if (!lines[k].trim()) continue;
+                seen++;
+                if (SKIP_COMMENT.test(lines[k]) || NEGATIVE_MARKER.test(lines[k])) {
+                    negative = true;
+                    break;
+                }
+                if (/^#{1,6}\s/.test(lines[k])) break;
+            }
+            if (!negative) {
+                blocks.push({
+                    startLine: i + 2, // first line of code, 1-based
+                    code: lines.slice(i + 1, j).join('\n'),
+                });
+            }
+        }
+        i = j + 1;
+    }
+    return blocks;
+}
+
+/**
+ * Hoist any `import "..."` / `import ( ... )` out of the block.
+ *
+ * Each hoisted line is replaced by a BLANK line rather than removed, so the
+ * body keeps the same line count as the original block. That makes the
+ * source-line mapping a single fixed offset instead of a per-block correction —
+ * the same discipline the TS checker uses so reported line numbers never drift.
+ *
+ * Blocks that declare their own imports still fall back on FIXED_IMPORTS, which
+ * is a superset of what the skills touch; anything they import that we already
+ * have resolves identically, and the blanked lines preserve the mapping.
+ */
+function hoistImports(code) {
+    const lines = code.split('\n');
+    const out = [];
+    let inGroup = false;
+    for (const line of lines) {
+        if (inGroup) {
+            // Inside a parenthesized `import ( ... )`. Blank every line until
+            // the closing paren, which we also blank.
+            out.push('');
+            if (/^\s*\)\s*$/.test(line)) inGroup = false;
+            continue;
+        }
+        if (/^\s*import\s*\(\s*$/.test(line)) {
+            inGroup = true;
+            out.push('');
+            continue;
+        }
+        // Single-line import: `import "x"` or `import alias "x"`.
+        if (/^\s*import\s+(?:[\w.]+\s+)?["`][^"`]+["`]\s*$/.test(line)) {
+            out.push('');
+            continue;
+        }
+        out.push(line);
+    }
+    return out.join('\n');
+}
+
+/**
+ * Does the block open with a top-level declaration (func/type/const/var/package)
+ * as its first non-blank, non-import line? Such blocks are near-complete files
+ * and go straight into the file body. Everything else is a statement fragment
+ * that must live inside a function.
+ */
+function isFileScope(bodyAfterHoist) {
+    for (const line of bodyAfterHoist.split('\n')) {
+        const t = line.trim();
+        if (!t || t.startsWith('//')) continue;
+        return /^(func|type|const|var|package)\b/.test(t);
+    }
+    return false;
+}
+
+function main() {
+    // Locate the module in the local cache before doing anything. If it is
+    // absent, every check below is meaningless — refuse to report a passing run,
+    // exactly as the TS checker does when `dodopayments` is not installed.
+    const goVersion = spawnSync('go', ['version'], { encoding: 'utf8' });
+    if (goVersion.status !== 0) {
+        console.error('FATAL: `go` is not on PATH. Install Go 1.25+ and retry.');
+        process.exit(2);
+    }
+
+    rmSync(WORK, { recursive: true, force: true });
+    mkdirSync(WORK, { recursive: true });
+
+    writeFileSync(
+        join(WORK, 'go.mod'),
+        `module dodocheck\n\ngo 1.25\n\nrequire ${SDK_MODULE} ${SDK_VERSION}\n`,
+    );
+    writeFileSync(join(WORK, 'z_support.go'), SUPPORT);
+
+    /** @type {Map<string,{file:string,startLine:number,offset:number}>} */
+    const index = new Map();
+    let n = 0;
+
+    for (const dir of listSkillDirs()) {
+        const rel = `dodo-payments/${dir}/SKILL.md`;
+        const md = readFileSync(join(SKILLS_DIR, dir, 'SKILL.md'), 'utf8');
+        for (const b of extractBlocks(md)) {
+            const body = hoistImports(b.code);
+            const name = `case_${String(n).padStart(4, '0')}.go`;
+
+            let header;
+            let footer;
+            if (isFileScope(body)) {
+                // Near-complete file (own funcs/types). Drop it in verbatim after
+                // the fixed imports; the block's declarations are just more
+                // package members. No wrapping function, so nothing to close.
+                header = `package main\n\n${FIXED_IMPORTS}\n${FIXED_NEUTRALIZERS}\n`;
+                footer = '\n';
+            } else {
+                // Statement fragment. Wrap in a uniquely named function so bare
+                // statements (and any `client :=` that shadows the package var)
+                // are legal. `_ = ...`-style neutralizers for locals are not
+                // needed at the top level, so we only close the function.
+                header = `package main\n\n${FIXED_IMPORTS}\n${FIXED_NEUTRALIZERS}\nfunc case${String(n).padStart(4, '0')}() {\n`;
+                footer = '\n}\n';
+            }
+
+            writeFileSync(join(WORK, name), `${header}${body}${footer}`);
+            index.set(name, {
+                file: rel,
+                startLine: b.startLine,
+                // Lines added before the block body begins. Hoisted imports
+                // leave blank lines behind, so the body is line-for-line the
+                // same as the original block and no further correction applies.
+                offset: header.split('\n').length - 1,
+            });
+            n++;
+        }
+    }
+
+    // `go build` reports diagnostics as `./case_0001.go:LINE:COL: message`, one
+    // per line, and exits non-zero when any file fails.
+    const runBuild = (excludeNames = new Set()) => {
+        // Move excluded files aside by renaming to a non-.go extension so the
+        // package still links (z_support carries `main`) while the excluded
+        // file is invisible to the compiler.
+        for (const nm of excludeNames) {
+            const p = join(WORK, nm);
+            if (existsSync(p)) writeFileSync(p + '.excluded', readFileSync(p)), rmSync(p);
+        }
+        const r = spawnSync('go', ['build', '-o', join(WORK, 'dodocheck.bin'), './...'], {
+            cwd: WORK,
+            encoding: 'utf8',
+            // `go mod tidy` needs the network the first time to write go.sum;
+            // after that the module lives in the cache. Allow the download here
+            // and nowhere else.
+            env: { ...process.env, GOFLAGS: '-mod=mod' },
+        });
+        return (r.stdout || '') + (r.stderr || '');
+    };
+
+    // Resolve the module (writes go.sum from the cache / a single fetch). If the
+    // SDK cannot be found, bail loudly rather than reporting a green run over
+    // zero real checks.
+    const tidy = spawnSync('go', ['mod', 'tidy'], {
+        cwd: WORK,
+        encoding: 'utf8',
+        env: { ...process.env, GOFLAGS: '-mod=mod' },
+    });
+    const tidyOut = (tidy.stdout || '') + (tidy.stderr || '');
+    if (tidy.status !== 0 || !existsSync(join(WORK, 'go.sum'))) {
+        console.error(
+            `FATAL: could not resolve ${SDK_MODULE} ${SDK_VERSION}, so no SDK types were checked.\n` +
+            'Ensure the module is available (in the Go module cache or reachable for download).\n' +
+            'Refusing to report a passing run.\n\n' +
+            tidyOut.trim(),
+        );
+        rmSync(WORK, { recursive: true, force: true });
+        process.exit(2);
+    }
+
+    // Go, like tsc, suppresses semantic errors program-wide the moment ANY file
+    // has a SYNTAX error. So: pass 1 finds unparseable files, pass 2 excludes
+    // them and compiles the rest. Without this a single malformed block would
+    // hide every real SDK error in all the others.
+    const pass1 = runBuild();
+    const broken = new Set();
+    for (const line of pass1.split('\n')) {
+        const m = line.match(/(?:^|[/\\])(case_\d+\.go):\d+:\d+:\s+syntax error:/);
+        if (m) broken.add(m[1]);
+    }
+
+    const out = broken.size ? pass1 + '\n' + runBuild(broken) : pass1;
+
+    const diags = [];
+    const unparseable = [];
+    let sdkResolutionFailed = false;
+
+    for (const line of out.split('\n')) {
+        const m = line.match(/(?:^|[/\\])(case_\d+\.go):(\d+):(?:(\d+):)?\s+(.*)$/);
+        if (!m) continue;
+        const [, name, lineNo, , message] = m;
+        const meta = index.get(name);
+        if (!meta) continue;
+
+        // Body line 1 sits at file line offset+1 and maps to SKILL.md startLine.
+        const srcLine = meta.startLine + (Number(lineNo) - meta.offset) - 1;
+        const entry = { file: meta.file, line: srcLine, message: message.trim() };
+
+        // A file that fails to PARSE gets no semantic checking at all, so every
+        // type error inside it would be silently hidden. Surface these loudly
+        // rather than letting them masquerade as a clean run.
+        if (/^syntax error:/.test(entry.message)) {
+            unparseable.push(entry);
+            continue;
+        }
+
+        // If the SDK module itself does not resolve, every "undefined" below is
+        // meaningless — treat it as a fatal non-check, not a wall of errors.
+        if (/could not import github\.com\/dodopayments\/dodopayments-go/.test(entry.message) ||
+            /cannot find module providing package github\.com\/dodopayments\/dodopayments-go/.test(entry.message)) {
+            sdkResolutionFailed = true;
+            continue;
+        }
+
+        // Fragments legitimately reference app-level helpers and packages the
+        // skill never defines (a `handlePayment`, a `db`, a non-SDK import).
+        // Those are not what we are testing. But NEVER filter an undefined that
+        // names an SDK symbol — `undefined: option.WithEnvironment`,
+        // `dodopayments.Foo` etc. are the entire point of this check.
+        const undef = entry.message.match(/^undefined:\s+([A-Za-z_][\w.]*)/);
+        if (undef) {
+            const sym = undef[1];
+            const isSdk = /^(dodopayments|option|param|ctx|client)\b/.test(sym) || /^dodopayments\./.test(sym);
+            if (!isSdk) continue;
+        }
+
+        // Unused locals/imports are artifacts of compiling a fragment in
+        // isolation, never an SDK-shape error. Wrong SDK usage never shows up
+        // as "declared and not used".
+        if (/declared and not used/.test(entry.message)) continue;
+        if (/imported and not used/.test(entry.message)) continue;
+
+        // Deduplicate: pass 1 and pass 2 overlap.
+        if (diags.some((d) => d.file === entry.file && d.line === entry.line && d.message === entry.message)) continue;
+
+        diags.push(entry);
+    }
+
+    if (sdkResolutionFailed) {
+        console.error(
+            `FATAL: ${SDK_MODULE} did not resolve, so no SDK types were checked.\n` +
+            'Refusing to report a passing run.',
+        );
+        rmSync(WORK, { recursive: true, force: true });
+        process.exit(2);
+    }
+
+    rmSync(WORK, { recursive: true, force: true });
+
+    if (JSON_OUT) {
+        console.log(JSON.stringify(diags, null, 2));
+        process.exit(diags.length ? 1 : 0);
+    }
+
+    console.log(`Checked ${n} Go examples across ${listSkillDirs().length} skills.\n`);
+
+    if (unparseable.length) {
+        const files = new Map();
+        for (const u of unparseable) {
+            if (!files.has(u.file)) files.set(u.file, []);
+            files.get(u.file).push(u);
+        }
+        console.log(`SYNTAX ERRORS — these blocks got NO type checking (${unparseable.length}):`);
+        for (const [file, list] of [...files.entries()].sort()) {
+            for (const u of list.slice(0, 3)) {
+                console.log(`  L${u.line} ${u.message}`);
+            }
+            if (list.length > 3) console.log(`  ${file}: ...and ${list.length - 3} more`);
+        }
+        console.log();
+    }
+
+    if (!diags.length && !unparseable.length) {
+        console.log('No Go compile errors found.');
+        return;
+    }
+
+    const byFile = new Map();
+    for (const d of diags) {
+        if (!byFile.has(d.file)) byFile.set(d.file, []);
+        byFile.get(d.file).push(d);
+    }
+
+    for (const [file, list] of [...byFile.entries()].sort()) {
+        console.log(`${file} (${list.length})`);
+        for (const d of list.sort((a, b) => a.line - b.line)) {
+            console.log(`  L${d.line} ${d.message}`);
+        }
+        console.log();
+    }
+
+    console.log(`${diags.length} compile error(s) across ${byFile.size} file(s).`);
+    if (unparseable.length) console.log(`${unparseable.length} block(s) failed to parse.`);
+    process.exit(1);
+}
+
+main();

--- a/scripts/check-python-examples.mjs
+++ b/scripts/check-python-examples.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Type-check every Python example in every SKILL.md against the real
+ * `dodopayments` Python SDK types.
+ *
+ * The skills are pasted verbatim into agent context, so a wrong parameter type
+ * propagates as reliably as a wrong hostname — and fails silently rather than
+ * loudly. The most dangerous case here is concrete: the client's `environment`
+ * option is typed `Literal["live_mode", "test_mode"] | NotGiven`, and passing an
+ * unnarrowed `os.getenv(...)` (which is `str | None`) both type-errors AND blows
+ * up at runtime with `ValueError: Unknown environment: None`. Prose review does
+ * not reliably catch that class of error; the type checker does.
+ *
+ * How it works
+ *   1. Extract every ```python fenced block from each SKILL.md.
+ *   2. Skip blocks marked as deliberate counter-examples ("**Wrong:**", etc.)
+ *      or with an explicit opt-out comment — those are supposed to be incorrect.
+ *   3. Emit each block at MODULE LEVEL (Python is indentation-sensitive, so
+ *      wrapping in a function would change indentation and break the mapping)
+ *      with a fixed-height preamble that binds commonly-referenced names —
+ *      crucially a REAL `client: DodoPayments`, so field/argument errors on the
+ *      SDK surface even in fragment blocks that never re-construct the client.
+ *   4. Run pyright against a venv that has the REAL `dodopayments` installed and
+ *      map diagnostics back to SKILL.md:<line>.
+ *
+ * Why pyright (not mypy)
+ *   pyright understands `Literal` narrowing and `NotGiven` overloads out of the
+ *   box, reports precise `reportArgumentType` on the exact expression, emits
+ *   machine-readable JSON with 0-based line/character ranges (so the mapping is
+ *   exact, not a regex guess), and runs non-interactively via `npx pyright` on
+ *   GitHub Actions ubuntu-latest with zero extra setup. mypy would need a
+ *   config, stub coordination, and is fussier about our synthetic preamble.
+ *
+ * Usage:
+ *   node scripts/check-python-examples.mjs           # report
+ *   node scripts/check-python-examples.mjs --json    # machine readable
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS_DIR = join(ROOT, 'dodo-payments');
+const WORK = join(ROOT, '.pycheck-tmp');
+// Persisted across runs so the venv (the slow part) is created once and reused.
+// This dir is gitignored; see .gitignore.
+const VENV_ROOT = join(ROOT, '.python-check-venv');
+const VENV = join(VENV_ROOT, 'venv');
+const JSON_OUT = process.argv.includes('--json');
+
+/** Fences we attempt to check. */
+const PY_LANGS = new Set(['python', 'py']);
+
+/**
+ * A block is a deliberate counter-example only when it is EXPLICITLY labelled
+ * as one — a bolded label such as `**Wrong:**`, or an opt-out comment.
+ *
+ * Inferring intent from bare prose ("this fails if...") silently removes
+ * coverage; requiring a marker makes opting out deliberate and greppable. This
+ * mirrors the TypeScript checker so the two behave identically.
+ */
+const NEGATIVE_MARKER =
+    /(?:\*\*|__)\s*(?:wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|unsafe|never)\b[^*_\n]{0,60}?(?:\*\*|__)/i;
+
+/** Explicit, greppable opt-out for blocks that cannot check by design. */
+const SKIP_COMMENT = /<!--\s*(?:typecheck|pycheck):\s*skip\s*-->/i;
+
+/**
+ * Fixed-height preamble emitted before every block. Its line count never
+ * changes, so the source-line mapping is a single fixed offset rather than a
+ * per-block arithmetic correction.
+ *
+ * The `client`/`dodo` bindings are the whole point: most blocks use `client`
+ * without re-constructing it (it is set up in an earlier block of the same
+ * SKILL.md). Binding it to the REAL `DodoPayments` type via `cast` — rather than
+ * leaving it undefined or stubbing it as `Any` — is what lets a field-name or
+ * argument-type error surface. A bare annotation (`client: DodoPayments`) makes
+ * pyright treat the name as *unbound*; `cast(..., None)` gives it a real value
+ * of the real type. We deliberately do NOT stub `DodoPayments` itself, so every
+ * SDK type error stays real.
+ *
+ * `os`, `logging`, `typing` etc. are real stdlib imports (no stubbing needed).
+ * App-level helpers the skills legitimately reference without defining are
+ * bound loosely so they generate no noise; anything SDK-shaped is left real.
+ */
+const PREAMBLE_LINES = [
+    'from typing import cast as _cast, Any as _Any',
+    'from dodopayments import DodoPayments as _DodoPayments',
+    '# Typed to the REAL SDK so field/arg errors surface in fragment blocks that',
+    '# reference `client` from an earlier block without re-constructing it.',
+    'client = _cast(_DodoPayments, None)',
+    'dodo = _cast(_DodoPayments, None)',
+    'dodo_client = _cast(_DodoPayments, None)',
+    '# App-level identifiers skills reference without defining. Bound to Any so',
+    '# they are noise-free; nothing SDK-shaped is hidden by these.',
+    'user: _Any = None',
+    'db: _Any = None',
+    'request: _Any = None',
+    'response: _Any = None',
+    'logger: _Any = None',
+    'app: _Any = None',
+    'config: _Any = None',
+    'get_current_user: _Any = None',
+    'grant_access: _Any = None',
+    'revoke_access: _Any = None',
+    'send_email: _Any = None',
+    'notify: _Any = None',
+];
+const PREAMBLE = PREAMBLE_LINES.join('\n') + '\n';
+// Every block body starts exactly this many lines into the emitted file, so
+// body line 1 maps to SKILL.md startLine with a single fixed offset.
+const PREAMBLE_HEIGHT = PREAMBLE_LINES.length;
+
+/**
+ * Hoist `import`/`from ... import` statements out of the block body.
+ *
+ * Imports are legal at module level (we emit at module level), but if a block
+ * re-imports `DodoPayments` it collides with the preamble's alias only in name,
+ * not identity — Python allows the rebind, and pyright still checks the SDK.
+ * We keep imports where they are EXCEPT we must ensure the block does not shadow
+ * our typed `client`/`dodo` with an untyped one in a way that hides errors; it
+ * does not, because a real `DodoPayments(...)` construction is itself checked.
+ *
+ * Each block is emitted verbatim after the preamble — no line is added or
+ * removed inside the body — so the mapping stays exact. We intentionally do NOT
+ * rewrite the body (unlike the TS checker's elision normalization); the Python
+ * examples here are complete, parseable fragments and rewriting them risks
+ * shifting lines or masking errors.
+ */
+
+function listSkillDirs() {
+    return readdirSync(SKILLS_DIR)
+        .filter((d) => statSync(join(SKILLS_DIR, d)).isDirectory())
+        .sort();
+}
+
+/**
+ * Extract checkable Python blocks with their 1-based start line in the source.
+ */
+function extractBlocks(md) {
+    const lines = md.split('\n');
+    const blocks = [];
+    let i = 0;
+    while (i < lines.length) {
+        const open = lines[i].match(/^```([a-zA-Z0-9]*)\s*$/);
+        if (!open) {
+            i++;
+            continue;
+        }
+        const lang = open[1].toLowerCase();
+        // find close
+        let j = i + 1;
+        while (j < lines.length && !/^```\s*$/.test(lines[j])) j++;
+
+        if (PY_LANGS.has(lang)) {
+            // Explicit markers only, and only in the 2 non-blank lines above.
+            let negative = false;
+            for (let k = i - 1, seen = 0; k >= 0 && seen < 2; k--) {
+                if (!lines[k].trim()) continue;
+                seen++;
+                if (SKIP_COMMENT.test(lines[k]) || NEGATIVE_MARKER.test(lines[k])) {
+                    negative = true;
+                    break;
+                }
+                if (/^#{1,6}\s/.test(lines[k])) break;
+            }
+            if (!negative) {
+                blocks.push({
+                    startLine: i + 2, // first line of code, 1-based
+                    code: lines.slice(i + 1, j).join('\n'),
+                });
+            }
+        }
+        i = j + 1;
+    }
+    return blocks;
+}
+
+function venvPython() {
+    const isWin = process.platform === 'win32';
+    return join(VENV, isWin ? 'Scripts' : 'bin', isWin ? 'python.exe' : 'python');
+}
+
+/**
+ * Create the venv with the real `dodopayments` SDK if it is not already there.
+ * Reused across runs (the install is the slow part). Fully automatic — no
+ * manual setup step — and non-interactive so it works on CI.
+ */
+function ensureVenv() {
+    // Derive the interpreter path from the PLATFORM, not from whether a
+    // directory happens to exist yet. Probing `VENV/bin` before the venv is
+    // created always misses on a cold start and silently selects the Windows
+    // `Scripts/` layout, so the first run on POSIX could never succeed.
+    const py = venvPython();
+
+    // Reuse if the venv exists AND already resolves dodopayments. A half-built
+    // venv (interrupted install) would otherwise masquerade as ready and make
+    // the whole run silently check nothing.
+    if (existsSync(py)) {
+        const probe = spawnSync(py, ['-c', 'import dodopayments'], { encoding: 'utf8' });
+        if (probe.status === 0) return py;
+    }
+
+    console.error('Setting up Python venv with the dodopayments SDK (one-time)...');
+    mkdirSync(VENV_ROOT, { recursive: true });
+    const mk = spawnSync('python3', ['-m', 'venv', VENV], { encoding: 'utf8', stdio: 'inherit' });
+    if (mk.status !== 0) {
+        console.error('FATAL: could not create a Python venv with `python3 -m venv`.');
+        process.exit(2);
+    }
+    const install = spawnSync(
+        py,
+        ['-m', 'pip', 'install', '--quiet', '--disable-pip-version-check', 'dodopayments'],
+        { encoding: 'utf8', stdio: 'inherit' },
+    );
+    if (install.status !== 0) {
+        console.error('FATAL: `pip install dodopayments` failed. Refusing to report a passing run.');
+        process.exit(2);
+    }
+    const probe = spawnSync(py, ['-c', 'import dodopayments'], { encoding: 'utf8' });
+    if (probe.status !== 0) {
+        console.error('FATAL: dodopayments did not import after install. Refusing to report a passing run.');
+        process.exit(2);
+    }
+    return py;
+}
+
+function main() {
+    ensureVenv();
+
+    rmSync(WORK, { recursive: true, force: true });
+    mkdirSync(WORK, { recursive: true });
+
+    /** @type {Map<string,{file:string,startLine:number,offset:number}>} */
+    const index = new Map();
+    let n = 0;
+
+    for (const dir of listSkillDirs()) {
+        const rel = `dodo-payments/${dir}/SKILL.md`;
+        const md = readFileSync(join(SKILLS_DIR, dir, 'SKILL.md'), 'utf8');
+        for (const b of extractBlocks(md)) {
+            const name = `case_${String(n).padStart(4, '0')}.py`;
+            // Preamble is a fixed height; the block body follows verbatim so no
+            // line inside it is shifted. body line 1 == emitted line PREAMBLE_HEIGHT+1.
+            const body = `${PREAMBLE}${b.code}\n`;
+            writeFileSync(join(WORK, name), body);
+            index.set(name, {
+                file: rel,
+                startLine: b.startLine,
+                offset: PREAMBLE_HEIGHT,
+            });
+            n++;
+        }
+    }
+
+    // Point pyright at the venv so `dodopayments` resolves to the REAL package.
+    // basic mode surfaces argument/return/attribute errors (incl. reportArgumentType
+    // for the Literal `environment` mismatch) without the strict-mode noise that
+    // would drown real SDK errors in unrelated `Unknown`/`reportUnknown*` churn.
+    writeFileSync(
+        join(WORK, 'pyrightconfig.json'),
+        JSON.stringify(
+            {
+                venvPath: VENV_ROOT,
+                venv: 'venv',
+                include: ['*.py'],
+                typeCheckingMode: 'basic',
+                reportMissingImports: true,
+                reportMissingModuleSource: false,
+            },
+            null,
+            2,
+        ),
+    );
+
+    const r = spawnSync(
+        'npx',
+        ['--yes', 'pyright', '--project', WORK, '--outputjson'],
+        { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+    const raw = r.stdout || '';
+
+    let report;
+    try {
+        report = JSON.parse(raw);
+    } catch {
+        console.error('FATAL: could not parse pyright output. Refusing to report a passing run.');
+        console.error((r.stderr || '').slice(0, 2000));
+        rmSync(WORK, { recursive: true, force: true });
+        process.exit(2);
+    }
+
+    const diags = [];
+    let sdkResolutionFailed = false;
+
+    for (const d of report.generalDiagnostics || []) {
+        if (d.severity !== 'error') continue;
+        const name = (d.file || '').split(/[/\\]/).pop();
+        const meta = index.get(name);
+        if (!meta) continue;
+
+        const rule = d.rule || '';
+        const message = (d.message || '').split('\n')[0];
+        // pyright ranges are 0-based; file line = start.line + 1.
+        const fileLine = d.range.start.line + 1;
+        // Body line 1 sits at file line PREAMBLE_HEIGHT+1 and maps to startLine.
+        const srcLine = meta.startLine + (fileLine - meta.offset) - 1;
+        const entry = { file: meta.file, line: srcLine, code: rule, message };
+
+        // If the SDK itself does not resolve, every check below is meaningless —
+        // surface it as FATAL rather than let a "clean" run hide it.
+        if (rule === 'reportMissingImports' || rule === 'reportMissingModuleSource') {
+            if (/["']dodopayments["']/.test(message)) sdkResolutionFailed = true;
+            // Non-SDK imports (fastapi, flask, django, pydantic, app.*) are not
+            // installed and are EXPECTED to be unresolvable. Filter them.
+            continue;
+        }
+
+        // Undefined app-level identifiers are not what we are testing. The
+        // preamble binds the common ones; anything else is app code we do not
+        // ship. NEVER filter reportArgumentType / reportCallIssue against the
+        // SDK — that is the entire point of this checker.
+        if (rule === 'reportUndefinedVariable' || rule === 'reportUnboundVariable') continue;
+        // Emitting doc fragments in isolation redeclares names across cases; and
+        // `possibly unbound` is an artifact of fragments that assume prior setup.
+        if (rule === 'reportRedeclaration' || rule === 'reportPossiblyUnbound') continue;
+        // `self`-less / decorator-context artifacts from isolated fragments.
+        if (rule === 'reportSelfClsParameterName') continue;
+
+        // Deduplicate identical findings.
+        if (diags.some((x) => x.file === entry.file && x.line === entry.line && x.code === rule && x.message === message)) {
+            continue;
+        }
+        diags.push(entry);
+    }
+
+    if (sdkResolutionFailed) {
+        console.error(
+            "FATAL: the 'dodopayments' module did not resolve, so no SDK types were checked.\n" +
+            'The venv may be corrupt — delete .python-check-venv and re-run. Refusing to report a passing run.',
+        );
+        rmSync(WORK, { recursive: true, force: true });
+        process.exit(2);
+    }
+
+    rmSync(WORK, { recursive: true, force: true });
+
+    if (JSON_OUT) {
+        console.log(JSON.stringify(diags.map((d) => ({ file: d.file, line: d.line, message: d.message })), null, 2));
+        process.exit(diags.length ? 1 : 0);
+    }
+
+    console.log(`Checked ${n} Python examples across ${listSkillDirs().length} skills.\n`);
+
+    if (!diags.length) {
+        console.log('No Python type errors found.');
+        return;
+    }
+
+    const byFile = new Map();
+    for (const d of diags) {
+        if (!byFile.has(d.file)) byFile.set(d.file, []);
+        byFile.get(d.file).push(d);
+    }
+
+    for (const [file, list] of [...byFile.entries()].sort()) {
+        console.log(`${file} (${list.length})`);
+        for (const d of list.sort((a, b) => a.line - b.line)) {
+            console.log(`  L${d.line} ${d.message}`);
+        }
+        console.log();
+    }
+
+    console.log(`${diags.length} type error(s) across ${byFile.size} file(s).`);
+    process.exit(1);
+}
+
+main();

--- a/scripts/typecheck-examples.mjs
+++ b/scripts/typecheck-examples.mjs
@@ -37,27 +37,48 @@ const JSON_OUT = process.argv.includes('--json');
 const TS_LANGS = new Set(['typescript', 'ts', 'tsx']);
 
 /**
- * A block is a deliberate counter-example if the nearby preceding prose says so.
- * Those blocks are *meant* to be wrong and must not be type-checked.
+ * A block is a deliberate counter-example only when it is EXPLICITLY labelled
+ * as one - a bolded label such as `**Wrong:**`, or an opt-out comment.
+ *
+ * This used to match any of "wrong/never/fails/mistake/..." appearing as bare
+ * prose within four preceding lines, which disabled checking on ~20 correct
+ * blocks - including ones explicitly labelled **Correct:** and several that had
+ * just been fixed. Inferring intent from prose silently removes coverage;
+ * requiring a marker makes opting out deliberate and greppable.
  */
-const NEGATIVE_MARKER = /\b(wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|never|fails|mistake)\b/i;
+const NEGATIVE_MARKER =
+    /(?:\*\*|__)\s*(?:wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|unsafe|never)\b[^*_\n]{0,60}?(?:\*\*|__)/i;
+
+/** Explicit, greppable opt-out for blocks that cannot compile by design. */
+const SKIP_COMMENT = /<!--\s*typecheck:\s*skip\s*-->/i;
 
 /**
  * App-level identifiers that skills legitimately reference without defining.
  * Declaring them `any` keeps the signal on SDK shapes.
  */
+/**
+ * Emitted only when the block does NOT bind its own `DodoPayments`. Some blocks
+ * import the *browser* SDK (`import { DodoPayments } from 'dodopayments-checkout'`),
+ * which is a different type from the server SDK; unconditionally importing the
+ * server one here produced a duplicate identifier and then resolved the browser
+ * SDK's members against the wrong type.
+ */
+const PREAMBLE_SDK_VALUE_IMPORT = `import DodoPayments from 'dodopayments';\n`;
+
 const PREAMBLE = `
 /* eslint-disable */
-import DodoPayments from 'dodopayments';
+// Type-only alias so \`client\` stays typed even when the block binds its own
+// \`DodoPayments\` value from a different package.
+import type DodoPaymentsSDK__ from 'dodopayments';
 
 // Most blocks use \`client\` without re-constructing it (it is set up in an
 // earlier block of the same SKILL.md). Without a TYPED declaration here, the
 // identifier resolves to \`any\` and the SDK is never actually checked - which
 // is precisely how a "clean" run can hide every field-name error.
 // Blocks that do declare their own \`const client\` shadow this legally.
-declare const client: DodoPayments;
-declare const dodo: DodoPayments;
-declare const dodoClient: DodoPayments;
+declare const client: DodoPaymentsSDK__;
+declare const dodo: DodoPaymentsSDK__;
+declare const dodoClient: DodoPaymentsSDK__;
 
 declare var db: any;
 declare var prisma: any;
@@ -105,6 +126,20 @@ declare function getUser(...args: any[]): any;
 declare function requireUser(...args: any[]): any;
 declare function lookupProductId(...args: any[]): any;
 declare function planToProductId(...args: any[]): any;
+
+// Astro and Vite expose env through \`import.meta.env\`, typed as string.
+// DECLARE it rather than suppressing the resulting TS2339: an unknown property
+// makes the whole expression \`any\`, which silently disables checking on
+// everything downstream - the same failure mode as an unresolved import, and
+// how unnarrowed \`environment\` survived in the Astro examples.
+declare global {
+    interface ImportMetaEnv {
+        readonly [key: string]: string;
+    }
+    interface ImportMeta {
+        readonly env: ImportMetaEnv;
+    }
+}
 `;
 
 /**
@@ -154,20 +189,32 @@ function stripExports(code) {
 /**
  * Imports are only legal at module top level, but we wrap each block in a
  * function so top-level await works. Hoist any import statements out.
+ *
+ * Each hoisted line is replaced by a BLANK line rather than removed, so the
+ * body keeps the same line count as the original block. That makes the
+ * source-line mapping a single fixed offset instead of a per-block correction,
+ * which is what previously drifted reported line numbers by `1 - hoisted`.
  */
 function hoistImports(code) {
     const imports = [];
     const rest = [];
     for (const line of code.split('\n')) {
         if (/^\s*import\s.+from\s+['"][^'"]+['"];?\s*$/.test(line) || /^\s*import\s+['"][^'"]+['"];?\s*$/.test(line)) {
-            // The preamble already imports the SDK; re-importing it collides.
-            if (/from\s+['"]dodopayments['"]/.test(line)) continue;
             imports.push(line.trim());
+            rest.push('');
         } else {
             rest.push(line);
         }
     }
     return { imports: imports.join('\n'), body: rest.join('\n') };
+}
+
+/**
+ * Does the block bind the identifier `DodoPayments` itself (default or named,
+ * from any module)? If so the preamble must not also import it.
+ */
+function bindsDodoPayments(code) {
+    return /^\s*import\s+(?:DodoPayments\b|(?:[\w*\s{},]*\{[^}]*\bDodoPayments\b[^}]*\}))/m.test(code);
 }
 
 function listSkillDirs() {
@@ -195,12 +242,12 @@ function extractBlocks(md) {
         while (j < lines.length && !/^```\s*$/.test(lines[j])) j++;
 
         if (TS_LANGS.has(lang)) {
-            // negative-example detection: scan back up to 4 non-empty lines
+            // Explicit markers only, and only in the 2 lines immediately above.
             let negative = false;
-            for (let k = i - 1, seen = 0; k >= 0 && seen < 4; k--) {
+            for (let k = i - 1, seen = 0; k >= 0 && seen < 2; k--) {
                 if (!lines[k].trim()) continue;
                 seen++;
-                if (NEGATIVE_MARKER.test(lines[k])) {
+                if (SKIP_COMMENT.test(lines[k]) || NEGATIVE_MARKER.test(lines[k])) {
                     negative = true;
                     break;
                 }
@@ -242,16 +289,17 @@ function main() {
             const ext = looksLikeJsx(normalized) ? 'tsx' : 'ts';
             const name = `case_${String(n).padStart(4, '0')}.${ext}`;
 
-            const header = `${PREAMBLE}\n${imports}\nexport {};\nasync function __case() {\n`;
+            const sdkImport = bindsDodoPayments(b.code) ? '' : PREAMBLE_SDK_VALUE_IMPORT;
+            const header = `${PREAMBLE}\n${sdkImport}${imports}\nexport {};\nasync function __case() {\n`;
             const body = `${header}${inner}\n}\nvoid __case;\n`;
             writeFileSync(join(WORK, name), body);
             index.set(name, {
                 file: rel,
                 startLine: b.startLine,
-                // lines added before the user's code begins. Imports were
-                // hoisted out of the body, so account for how many were moved.
+                // Lines added before the user's code begins. Hoisted imports
+                // leave blank lines behind, so the body is line-for-line the
+                // same as the original block and no further correction applies.
                 offset: header.split('\n').length - 1,
-                hoisted: imports ? imports.split('\n').length : 0,
             });
             n++;
         }
@@ -319,7 +367,8 @@ function main() {
         const meta = index.get(name);
         if (!meta) continue;
 
-        const srcLine = meta.startLine + (Number(lineNo) - meta.offset);
+        // Body line 1 sits at file line offset+1 and maps to SKILL.md startLine.
+        const srcLine = meta.startLine + (Number(lineNo) - meta.offset) - 1;
         const entry = { file: meta.file, line: srcLine, code, message };
 
         // A file that fails to PARSE gets no semantic checking at all, so every
@@ -346,9 +395,9 @@ function main() {
         if (code === 'TS2686' || code === 'TS6133') continue;
         if (code === 'TS2528' || code === 'TS2323') continue;
         // Runtime/framework globals we deliberately do not ship types for
-        // (Astro/Vite import.meta.env, Bun, Electron preload, DOM extras).
-        // These are not SDK-shape errors.
-        if (/'env' does not exist on type 'ImportMeta'/.test(message)) continue;
+        // (Bun, Electron preload, DOM extras). These are not SDK-shape errors.
+        // NOTE: import.meta.env is deliberately NOT suppressed here - it is
+        // declared in the preamble instead, so Astro examples stay checked.
         if (code === 'TS2868' || /Cannot find name 'Bun'/.test(message)) continue;
         if (/does not exist on type 'Window/.test(message)) continue;
         // Artifacts of our own elision normalization / isolated fragments.

--- a/scripts/typecheck-examples.mjs
+++ b/scripts/typecheck-examples.mjs
@@ -1,0 +1,421 @@
+#!/usr/bin/env node
+/**
+ * Type-check every TypeScript example in every SKILL.md against the real
+ * `dodopayments` SDK types.
+ *
+ * The skills are pasted verbatim into agent context, so a wrong field name
+ * propagates as reliably as a wrong hostname — and fails silently rather than
+ * loudly. Prose review does not reliably catch that class of error; the
+ * compiler does.
+ *
+ * How it works
+ *   1. Extract every ```typescript / ```ts fenced block from each SKILL.md.
+ *   2. Skip blocks marked as deliberate counter-examples ("Wrong:", "Broken:",
+ *      "Anti-pattern") — those are supposed to be incorrect.
+ *   3. Wrap each block in a module with the SDK imported and a permissive
+ *      ambient preamble that declares app-level helpers (db, grantAccess, ...)
+ *      as `any`, so we only surface SDK-shape errors, not missing-app-code noise.
+ *   4. Compile the whole set with tsc and map diagnostics back to
+ *      SKILL.md:<line>.
+ *
+ * Usage:
+ *   node scripts/typecheck-examples.mjs           # report
+ *   node scripts/typecheck-examples.mjs --json    # machine readable
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS_DIR = join(ROOT, 'dodo-payments');
+const WORK = join(ROOT, '.typecheck-tmp');
+const JSON_OUT = process.argv.includes('--json');
+
+/** Fences we attempt to compile. */
+const TS_LANGS = new Set(['typescript', 'ts', 'tsx']);
+
+/**
+ * A block is a deliberate counter-example if the nearby preceding prose says so.
+ * Those blocks are *meant* to be wrong and must not be type-checked.
+ */
+const NEGATIVE_MARKER = /\b(wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|never|fails|mistake)\b/i;
+
+/**
+ * App-level identifiers that skills legitimately reference without defining.
+ * Declaring them `any` keeps the signal on SDK shapes.
+ */
+const PREAMBLE = `
+/* eslint-disable */
+import DodoPayments from 'dodopayments';
+
+// Most blocks use \`client\` without re-constructing it (it is set up in an
+// earlier block of the same SKILL.md). Without a TYPED declaration here, the
+// identifier resolves to \`any\` and the SDK is never actually checked - which
+// is precisely how a "clean" run can hide every field-name error.
+// Blocks that do declare their own \`const client\` shadow this legally.
+declare const client: DodoPayments;
+declare const dodo: DodoPayments;
+declare const dodoClient: DodoPayments;
+
+declare var db: any;
+declare var prisma: any;
+declare var redis: any;
+declare var queue: any;
+declare var eventQueue: any;
+declare var Worker: any;
+declare var Queue: any;
+declare var app: any;
+declare var express: any;
+declare var req: any;
+declare var res: any;
+declare var request: any;
+declare var response: any;
+declare var next: any;
+declare var logger: any;
+declare var console: any;
+// Typed deliberately: env vars are \`string | undefined\`, and the SDK's
+// \`environment\` option is a narrow union. Leaving this \`any\` would hide the
+// very common mistake of passing an unnarrowed env var straight through.
+declare var process: { env: Record<string, string | undefined>; [k: string]: any };
+declare var fetch: any;
+declare var Buffer: any;
+declare var crypto: any;
+declare var NextResponse: any;
+declare var NextRequest: any;
+declare var authClient: any;
+declare var auth: any;
+declare var config: any;
+declare var Conf: any;
+declare var machineIdSync: any;
+declare var Store: any;
+declare function grantAccess(...args: any[]): any;
+declare function revokeAccess(...args: any[]): any;
+declare function grantCustomerAccess(...args: any[]): any;
+declare function revokeCustomerAccess(...args: any[]): any;
+declare function restoreCustomerAccess(...args: any[]): any;
+declare function handlePaymentSucceeded(...args: any[]): any;
+declare function handleSubscriptionActive(...args: any[]): any;
+declare function markDisputeResolved(...args: any[]): any;
+declare function getLicenseKeyIdsForSubscription(...args: any[]): any;
+declare function notify(...args: any[]): any;
+declare function sendEmail(...args: any[]): any;
+declare function getUser(...args: any[]): any;
+declare function requireUser(...args: any[]): any;
+declare function lookupProductId(...args: any[]): any;
+declare function planToProductId(...args: any[]): any;
+`;
+
+/**
+ * Skills legitimately elide irrelevant arguments as `{...}`. That is not valid
+ * TypeScript, and an unparseable file gets NO semantic checking at all - which
+ * would silently hide every type error in it. Normalize the elisions instead.
+ */
+function normalizeElisions(code) {
+    let out = code
+        // `foo({...})` -> `foo({} as any)`
+        .replace(/\{\s*\.\.\.\s*\}/g, '{} as any')
+        // `product_cart: [...]` -> `product_cart: ([] as any)`
+        .replace(/\[\s*\.\.\.\s*\]/g, '([] as any)')
+        // `unwrap(...)` -> spread of any[], which satisfies any arity so we do
+        // not invent false "expected 2 arguments" errors on elided calls.
+        .replace(/\(\s*\.\.\.\s*\)/g, '(...([] as any[]))')
+        // a line consisting only of `...` or `...,`
+        .replace(/^([ \t]*)\.\.\.[ \t]*,?[ \t]*$/gm, '$1// ...');
+
+    // Some blocks are switch-case fragments shown without the enclosing switch.
+    if (/^\s*case\s+['"]/m.test(out) && !/\bswitch\s*\(/.test(out)) {
+        out = `switch ((null as any)) {\n${out}\n}`;
+    }
+    return out;
+}
+
+/** JSX needs a .tsx extension or it will not parse. */
+function looksLikeJsx(code) {
+    return /<\/[A-Za-z][\w.]*>|<[A-Z][\w.]*[\s/>]|<>/.test(code);
+}
+
+/**
+ * `export` is only legal at module top level, but we wrap blocks in a function
+ * so top-level await works. Framework examples (Next.js route handlers etc.)
+ * are full of `export const GET = ...`. Strip the modifier - it does not affect
+ * the type checking we care about, and leaving it makes the file unparseable,
+ * which would silently skip the whole file.
+ */
+function stripExports(code) {
+    return code
+        .replace(/^(\s*)export\s+default\s+(function|class|async\s+function)\b/gm, '$1$2')
+        .replace(/^(\s*)export\s+default\s+/gm, '$1const __default__ = ')
+        .replace(/^(\s*)export\s+(?=(const|let|var|function|async|class|interface|type|enum|abstract)\b)/gm, '$1')
+        .replace(/^\s*export\s*\{[^}]*\}\s*;?\s*$/gm, '');
+}
+
+/**
+ * Imports are only legal at module top level, but we wrap each block in a
+ * function so top-level await works. Hoist any import statements out.
+ */
+function hoistImports(code) {
+    const imports = [];
+    const rest = [];
+    for (const line of code.split('\n')) {
+        if (/^\s*import\s.+from\s+['"][^'"]+['"];?\s*$/.test(line) || /^\s*import\s+['"][^'"]+['"];?\s*$/.test(line)) {
+            // The preamble already imports the SDK; re-importing it collides.
+            if (/from\s+['"]dodopayments['"]/.test(line)) continue;
+            imports.push(line.trim());
+        } else {
+            rest.push(line);
+        }
+    }
+    return { imports: imports.join('\n'), body: rest.join('\n') };
+}
+
+function listSkillDirs() {
+    return readdirSync(SKILLS_DIR)
+        .filter((d) => statSync(join(SKILLS_DIR, d)).isDirectory())
+        .sort();
+}
+
+/**
+ * Extract compilable TS blocks with their 1-based start line in the source file.
+ */
+function extractBlocks(md) {
+    const lines = md.split('\n');
+    const blocks = [];
+    let i = 0;
+    while (i < lines.length) {
+        const open = lines[i].match(/^```([a-zA-Z]*)\s*$/);
+        if (!open) {
+            i++;
+            continue;
+        }
+        const lang = open[1].toLowerCase();
+        // find close
+        let j = i + 1;
+        while (j < lines.length && !/^```\s*$/.test(lines[j])) j++;
+
+        if (TS_LANGS.has(lang)) {
+            // negative-example detection: scan back up to 4 non-empty lines
+            let negative = false;
+            for (let k = i - 1, seen = 0; k >= 0 && seen < 4; k--) {
+                if (!lines[k].trim()) continue;
+                seen++;
+                if (NEGATIVE_MARKER.test(lines[k])) {
+                    negative = true;
+                    break;
+                }
+                if (/^#{1,6}\s/.test(lines[k])) break;
+            }
+            if (!negative) {
+                blocks.push({
+                    startLine: i + 2, // first line of code, 1-based
+                    code: lines.slice(i + 1, j).join('\n'),
+                });
+            }
+        }
+        i = j + 1;
+    }
+    return blocks;
+}
+
+function main() {
+    if (!existsSync(join(ROOT, 'node_modules', 'dodopayments'))) {
+        console.error(
+            'dodopayments is not installed. Run `npm install` in the repo root first.',
+        );
+        process.exit(2);
+    }
+
+    rmSync(WORK, { recursive: true, force: true });
+    mkdirSync(WORK, { recursive: true });
+
+    /** @type {Map<string,{file:string,startLine:number,offset:number}>} */
+    const index = new Map();
+    let n = 0;
+
+    for (const dir of listSkillDirs()) {
+        const rel = `dodo-payments/${dir}/SKILL.md`;
+        const md = readFileSync(join(SKILLS_DIR, dir, 'SKILL.md'), 'utf8');
+        for (const b of extractBlocks(md)) {
+            const normalized = stripExports(normalizeElisions(b.code));
+            const { imports, body: inner } = hoistImports(normalized);
+            const ext = looksLikeJsx(normalized) ? 'tsx' : 'ts';
+            const name = `case_${String(n).padStart(4, '0')}.${ext}`;
+
+            const header = `${PREAMBLE}\n${imports}\nexport {};\nasync function __case() {\n`;
+            const body = `${header}${inner}\n}\nvoid __case;\n`;
+            writeFileSync(join(WORK, name), body);
+            index.set(name, {
+                file: rel,
+                startLine: b.startLine,
+                // lines added before the user's code begins. Imports were
+                // hoisted out of the body, so account for how many were moved.
+                offset: header.split('\n').length - 1,
+                hoisted: imports ? imports.split('\n').length : 0,
+            });
+            n++;
+        }
+    }
+
+    writeFileSync(
+        join(WORK, 'tsconfig.json'),
+        JSON.stringify(
+            {
+                compilerOptions: {
+                    target: 'ES2022',
+                    module: 'ESNext',
+                    moduleResolution: 'bundler',
+                    jsx: 'preserve',
+                    strict: false,
+                    noImplicitAny: false,
+                    skipLibCheck: true,
+                    noEmit: true,
+                    allowJs: false,
+                    esModuleInterop: true,
+                    baseUrl: '.',
+                    paths: { '*': ['../node_modules/*'] },
+                    types: [],
+                },
+                include: ['*.ts', '*.tsx'],
+            },
+            null,
+            2,
+        ),
+    );
+
+    // tsc suppresses ALL semantic diagnostics program-wide when any file has a
+    // syntax error. So: pass 1 finds unparseable files, pass 2 excludes them and
+    // type-checks the rest. Without this, a single bad block hides every real
+    // error in all 17 skills.
+    const runTsc = (exclude = []) => {
+        const cfg = JSON.parse(readFileSync(join(WORK, 'tsconfig.json'), 'utf8'));
+        cfg.exclude = exclude;
+        writeFileSync(join(WORK, 'tsconfig.json'), JSON.stringify(cfg, null, 2));
+        const r = spawnSync(
+            process.execPath,
+            [join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', join(WORK, 'tsconfig.json'), '--pretty', 'false'],
+            { encoding: 'utf8' },
+        );
+        return (r.stdout || '') + (r.stderr || '');
+    };
+
+    const pass1 = runTsc();
+    const broken = new Set();
+    for (const line of pass1.split('\n')) {
+        const m = line.match(/(?:^|[/\\])(case_\d+\.tsx?)\(\d+,\d+\):\s+error\s+TS1\d{3}:/);
+        if (m) broken.add(m[1]);
+    }
+
+    const out = broken.size ? pass1 + '\n' + runTsc([...broken]) : pass1;
+    const diags = [];
+    const unparseable = [];
+    let sdkResolutionFailed = false;
+
+    for (const line of out.split('\n')) {
+        // tsc prints paths relative to cwd, e.g. `.typecheck-tmp/case_0001.ts(42,13): error ...`
+        const m = line.match(/(?:^|[/\\])(case_\d+\.tsx?)\((\d+),(\d+)\):\s+error\s+(TS\d+):\s+(.*)$/);
+        if (!m) continue;
+        const [, name, lineNo, , code, message] = m;
+        const meta = index.get(name);
+        if (!meta) continue;
+
+        const srcLine = meta.startLine + (Number(lineNo) - meta.offset);
+        const entry = { file: meta.file, line: srcLine, code, message };
+
+        // A file that fails to PARSE gets no semantic checking at all, so every
+        // type error inside it would be silently hidden. Surface these loudly
+        // rather than letting them masquerade as a clean run.
+        if (/^TS1\d{3}$/.test(code)) {
+            unparseable.push(entry);
+            continue;
+        }
+
+        if (code === 'TS2307') {
+            // Non-SDK imports (next/server, express, @dodopayments/*) are not
+            // installed and are expected to be unresolvable. But if the SDK
+            // itself cannot resolve, every check below is meaningless.
+            if (/'dodopayments'/.test(message)) sdkResolutionFailed = true;
+            continue;
+        }
+
+        // Undeclared app-level identifiers are not what we are testing.
+        if (code === 'TS2304' || code === 'TS2552') continue;
+        if (/Cannot find namespace/.test(message)) continue;
+        // Artifacts of compiling doc fragments in isolation, not SDK errors.
+        if (code === 'TS2451' || code === 'TS2440' || code === 'TS2393') continue; // redeclare
+        if (code === 'TS2686' || code === 'TS6133') continue;
+        if (code === 'TS2528' || code === 'TS2323') continue;
+        // Runtime/framework globals we deliberately do not ship types for
+        // (Astro/Vite import.meta.env, Bun, Electron preload, DOM extras).
+        // These are not SDK-shape errors.
+        if (/'env' does not exist on type 'ImportMeta'/.test(message)) continue;
+        if (code === 'TS2868' || /Cannot find name 'Bun'/.test(message)) continue;
+        if (/does not exist on type 'Window/.test(message)) continue;
+        // Artifacts of our own elision normalization / isolated fragments.
+        if (code === 'TS2556' || code === 'TS2347' || code === 'TS18004') continue;
+
+        // Deduplicate: pass 1 and pass 2 overlap.
+        if (diags.some((d) => d.file === entry.file && d.line === entry.line && d.code === code)) continue;
+
+        diags.push(entry);
+    }
+
+    if (sdkResolutionFailed) {
+        console.error(
+            "FATAL: the 'dodopayments' module did not resolve, so no SDK types were checked.\n" +
+            'Run `npm install` in the repo root. Refusing to report a passing run.',
+        );
+        rmSync(WORK, { recursive: true, force: true });
+        process.exit(2);
+    }
+
+    rmSync(WORK, { recursive: true, force: true });
+
+    if (JSON_OUT) {
+        console.log(JSON.stringify(diags, null, 2));
+        process.exit(diags.length ? 1 : 0);
+    }
+
+    console.log(`Type-checked ${n} TypeScript examples across ${listSkillDirs().length} skills.\n`);
+
+    if (unparseable.length) {
+        const files = new Map();
+        for (const u of unparseable) {
+            if (!files.has(u.file)) files.set(u.file, []);
+            files.get(u.file).push(u);
+        }
+        console.log(`SYNTAX ERRORS - these blocks got NO type checking (${unparseable.length}):`);
+        for (const [file, list] of [...files.entries()].sort()) {
+            for (const u of list.slice(0, 3)) {
+                console.log(`  ${file}:${u.line} ${u.code}: ${u.message}`);
+            }
+            if (list.length > 3) console.log(`  ${file}: ...and ${list.length - 3} more`);
+        }
+        console.log();
+    }
+
+    if (!diags.length && !unparseable.length) {
+        console.log('No SDK type errors found.');
+        return;
+    }
+
+    const byFile = new Map();
+    for (const d of diags) {
+        if (!byFile.has(d.file)) byFile.set(d.file, []);
+        byFile.get(d.file).push(d);
+    }
+
+    for (const [file, list] of [...byFile.entries()].sort()) {
+        console.log(`${file} (${list.length})`);
+        for (const d of list.sort((a, b) => a.line - b.line)) {
+            console.log(`  L${d.line} ${d.code}: ${d.message}`);
+        }
+        console.log();
+    }
+
+    console.log(`${diags.length} type error(s) across ${byFile.size} file(s).`);
+    if (unparseable.length) console.log(`${unparseable.length} block(s) failed to parse.`);
+    process.exit(1);
+}
+
+main();

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// Validates the dodopayments/skills repo before opening a PR.
+// Usage: node validate-skills.mjs /path/to/skills-pr
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.argv[2];
+if (!root) {
+    console.error('usage: node validate-skills.mjs <repo-root>');
+    process.exit(2);
+}
+
+const errors = [];
+const warnings = [];
+const err = (f, m) => errors.push(`${f}: ${m}`);
+const warn = (f, m) => warnings.push(`${f}: ${m}`);
+
+const skillsDir = join(root, 'dodo-payments');
+const dirs = readdirSync(skillsDir).filter((d) => statSync(join(skillsDir, d)).isDirectory()).sort();
+
+// name field is allowed to differ from dir only for this one legacy case
+const NAME_EXCEPTIONS = { 'best-practices': 'dodo-best-practices' };
+
+// Banned content. Each: [regex, human explanation]
+const BANNED = [
+    [/api\.dodopayments\.com/, 'dead hostname (no DNS record) — use live./test.dodopayments.com'],
+    [/\bsk_(test|live)_/, 'Stripe key format — Dodo uses dodo_test_ / dodo_live_'],
+    [/\bpk_(test|live)_/, 'Stripe-style publishable API key - Dodo issues no such credential'],
+    // NOTE: `publishable_key` IS a real field on CheckoutSessionResponse (returned
+    // with `client_secret` when confirm=true), so the bare word must not be banned.
+    // What must never appear is treating it as a client-side API *credential*.
+    [
+        /(?:apiKey|api_key)\s*[:=]\s*['"`]?(?:your[_-]?)?publishable|NEXT_PUBLIC_[A-Z_]*PUBLISHABLE|PUBLISHABLE_(?:API_)?KEY\s*=/,
+        'publishable_key is a per-session checkout field, not an API credential',
+    ],
+    [/createPortalSession/, 'not a real method — use customers.customerPortal.create(id, {...})'],
+    [/payments\.create\s*\(/, 'deprecated — use checkoutSessions.create()'],
+    [/createHmac\(\s*['"]sha256['"]\s*\)?/, 'hand-rolled webhook HMAC is forbidden — use webhooks.unwrap() or standardwebhooks'],
+    [/@ts-(ignore|expect-error)/, 'type suppression'],
+    [/\bas any\b/, 'type suppression'],
+    [/dodopayments-webhooks/, 'deprecated third-party package'],
+    [/proration_behavior/, 'wrong param name — plan changes use proration_billing_mode'],
+];
+
+// Signing-string check: if a skill shows the algorithm it must include all three parts.
+const SIGNING_HINT = /webhook-id\s*\.\s*webhook-timestamp|webhook-id`?\s*\+|\$\{?webhookId\}?\./;
+
+const seenNames = new Map();
+
+for (const dir of dirs) {
+    const file = join(skillsDir, dir, 'SKILL.md');
+    const rel = `dodo-payments/${dir}/SKILL.md`;
+    if (!existsSync(file)) {
+        err(rel, 'missing SKILL.md');
+        continue;
+    }
+    const raw = readFileSync(file, 'utf8');
+
+    // --- frontmatter ---
+    const fm = raw.match(/^---\n([\s\S]*?)\n---\n/);
+    if (!fm) {
+        err(rel, 'missing or malformed YAML frontmatter');
+        continue;
+    }
+    const body = raw.slice(fm[0].length);
+    const nameM = fm[1].match(/^name:\s*(.+)$/m);
+    const descM = fm[1].match(/^description:\s*(.+)$/m);
+    if (!nameM) err(rel, 'frontmatter missing `name`');
+    if (!descM) err(rel, 'frontmatter missing `description`');
+
+    if (nameM) {
+        const name = nameM[1].trim();
+        const expected = NAME_EXCEPTIONS[dir] ?? dir;
+        if (name !== expected) err(rel, `frontmatter name "${name}" != expected "${expected}"`);
+        if (seenNames.has(name)) err(rel, `duplicate skill name "${name}" (also in ${seenNames.get(name)})`);
+        seenNames.set(name, rel);
+    }
+    if (descM) {
+        const d = descM[1].trim();
+        if (d.length < 40) warn(rel, `description is very short (${d.length} chars) — weakens skill matching`);
+        if (d.length > 400) warn(rel, `description is very long (${d.length} chars)`);
+    }
+
+    // extra frontmatter keys
+    for (const line of fm[1].split('\n')) {
+        const k = line.match(/^([a-zA-Z_-]+):/);
+        if (k && !['name', 'description'].includes(k[1])) warn(rel, `unexpected frontmatter key "${k[1]}"`);
+    }
+
+    // --- banned content ---
+    // Only CODE is held to the API-shape rules. Prose is where "never do X" warnings live,
+    // so prose is only flagged when it asserts the bad pattern without negating it.
+    // Code fences introduced as negative examples ("Wrong:", "Don't:", "Incorrect") are skipped.
+    const lines = body.split('\n');
+    const NEGATION = /\b(never|not|no|none|don't|do not|avoid|wrong|incorrect|dead|deprecated|does not exist|doesn't exist|instead of|rather than|is secret)\b/i;
+    const NEG_EXAMPLE = /\b(wrong|incorrect|don't|do not|avoid|bad|anti-pattern|broken|never)\b/i;
+
+    let inFence = false;
+    let fenceIsNegative = false;
+    lines.forEach((line, idx) => {
+        const lineNo = idx + 2; // +1 for 0-index, +1 for frontmatter offset approximation
+        if (/^```/.test(line)) {
+            if (!inFence) {
+                // look back up to 4 non-empty lines for a negative-example marker
+                let marker = false;
+                for (let j = idx - 1, seen = 0; j >= 0 && seen < 4; j--) {
+                    if (!lines[j].trim()) continue;
+                    seen++;
+                    if (NEG_EXAMPLE.test(lines[j])) { marker = true; break; }
+                    if (/^#{1,6}\s/.test(lines[j])) break; // stop at a heading
+                }
+                fenceIsNegative = marker;
+                inFence = true;
+            } else {
+                inFence = false;
+                fenceIsNegative = false;
+            }
+            return;
+        }
+
+        for (const [re, why] of BANNED) {
+            if (!re.test(line)) continue;
+            if (inFence) {
+                if (fenceIsNegative) continue; // deliberate counter-example
+                err(rel, `line ${lineNo} (code): ${why} -> ${line.trim().slice(0, 100)}`);
+            } else {
+                // prose: only an error if stated affirmatively
+                if (!NEGATION.test(line)) {
+                    err(rel, `line ${lineNo} (prose): ${why} -> ${line.trim().slice(0, 100)}`);
+                }
+            }
+        }
+    });
+
+    // --- webhook signing string sanity ---
+    if (/timestamp\s*\}?\s*\.\s*\$?\{?payload/i.test(body) && !SIGNING_HINT.test(body)) {
+        err(rel, 'shows a signed message of timestamp.payload without webhook-id — signatures will never validate');
+    }
+
+    // --- code fences must be tagged and balanced ---
+    const fences = body.match(/^```.*$/gm) ?? [];
+    if (fences.length % 2 !== 0) err(rel, `unbalanced code fences (${fences.length})`);
+    fences.forEach((f, i) => {
+        if (i % 2 === 0 && f.trim() === '```') err(rel, 'untagged code fence — every block needs a language');
+    });
+
+    // --- empty catch blocks ---
+    if (/catch\s*\([^)]*\)\s*\{\s*\}/.test(body)) err(rel, 'empty catch block');
+
+    // --- emoji ---
+    if (/[\u{1F300}-\u{1FAFF}\u{2700}-\u{27BF}\u{2600}-\u{26FF}]/u.test(body)) {
+        warn(rel, 'contains emoji (house style says none)');
+    }
+
+    if (body.split('\n').length < 40) warn(rel, 'suspiciously short skill');
+}
+
+// --- marketplace.json ---
+const mpPath = join(root, '.claude-plugin', 'marketplace.json');
+if (!existsSync(mpPath)) {
+    err('.claude-plugin/marketplace.json', 'missing');
+} else {
+    let mp;
+    try {
+        mp = JSON.parse(readFileSync(mpPath, 'utf8'));
+    } catch (e) {
+        err('.claude-plugin/marketplace.json', `invalid JSON: ${e.message}`);
+    }
+    if (mp) {
+        const listed = new Set();
+        for (const p of mp.plugins ?? []) {
+            if (!p.name) err('marketplace.json', 'plugin entry missing name');
+            if (!p.description) err('marketplace.json', `plugin "${p.name}" missing description`);
+            for (const s of p.skills ?? []) {
+                const abs = join(root, s);
+                if (!existsSync(join(abs, 'SKILL.md'))) {
+                    err('marketplace.json', `plugin "${p.name}" -> "${s}" has no SKILL.md`);
+                }
+                listed.add(s.replace(/^\.\//, '').replace(/\/$/, ''));
+            }
+        }
+        for (const dir of dirs) {
+            const key = `dodo-payments/${dir}`;
+            if (!listed.has(key)) err('marketplace.json', `skill directory "${key}" is not registered`);
+        }
+    }
+}
+
+// --- README coverage ---
+const readmePath = join(root, 'README.md');
+if (existsSync(readmePath)) {
+    const readme = readFileSync(readmePath, 'utf8');
+    for (const dir of dirs) {
+        if (!readme.includes(`dodo-payments/${dir}`)) {
+            err('README.md', `skill "${dir}" is not listed in the README table`);
+        }
+    }
+} else {
+    err('README.md', 'missing');
+}
+
+// --- report ---
+console.log(`Scanned ${dirs.length} skills in ${root}\n`);
+if (warnings.length) {
+    console.log(`WARNINGS (${warnings.length}):`);
+    for (const w of warnings) console.log('  ! ' + w);
+    console.log();
+}
+if (errors.length) {
+    console.log(`ERRORS (${errors.length}):`);
+    for (const e of errors) console.log('  x ' + e);
+    console.log('\nFAILED');
+    process.exit(1);
+}
+console.log('All checks passed.');

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -48,6 +48,14 @@ const SIGNING_HINT = /webhook-id\s*\.\s*webhook-timestamp|webhook-id`?\s*\+|\$\{
 
 const seenNames = new Map();
 
+/**
+ * skill dir -> frontmatter description, so marketplace.json can be checked for
+ * DRIFT rather than mere presence. The two are published separately; an agent
+ * matches on the marketplace description but then loads the skill body, so a
+ * silent divergence makes the wrong skill get selected.
+ */
+const frontmatterDesc = new Map();
+
 for (const dir of dirs) {
     const file = join(skillsDir, dir, 'SKILL.md');
     const rel = `dodo-payments/${dir}/SKILL.md`;
@@ -78,6 +86,7 @@ for (const dir of dirs) {
     }
     if (descM) {
         const d = descM[1].trim();
+        frontmatterDesc.set(dir, d);
         if (d.length < 40) warn(rel, `description is very short (${d.length} chars) — weakens skill matching`);
         if (d.length > 400) warn(rel, `description is very long (${d.length} chars)`);
     }
@@ -177,7 +186,22 @@ if (!existsSync(mpPath)) {
                 if (!existsSync(join(abs, 'SKILL.md'))) {
                     err('marketplace.json', `plugin "${p.name}" -> "${s}" has no SKILL.md`);
                 }
-                listed.add(s.replace(/^\.\//, '').replace(/\/$/, ''));
+                const key = s.replace(/^\.\//, '').replace(/\/$/, '');
+                listed.add(key);
+
+                // Presence was already checked; what actually matters is that the
+                // two copies have not DRIFTED. Byte-for-byte, because an agent
+                // selects on the marketplace text and then loads the skill body.
+                const dir = key.replace(/^dodo-payments\//, '');
+                const fmDesc = frontmatterDesc.get(dir);
+                if (p.description && fmDesc && p.description.trim() !== fmDesc) {
+                    err(
+                        'marketplace.json',
+                        `plugin "${p.name}" description does not match ${key}/SKILL.md frontmatter\n` +
+                        `    marketplace: ${p.description.trim()}\n` +
+                        `    frontmatter: ${fmDesc}`,
+                    );
+                }
             }
         }
         for (const dir of dirs) {


### PR DESCRIPTION
The skills had drifted from the current API. Beyond being stale, several shipped instructions that produce **broken or insecure payment code** — and because these are loaded by coding agents, every error propagates into downstream products.

This rewrites all 8 existing skills, adds 9 new ones, and fixes the defects below.

## Critical defects fixed

Each verified empirically, not assumed.

| Defect | Evidence | Impact |
|---|---|---|
| Base URL `api.dodopayments.com` | **No DNS A record**; `curl` → connection failure. `live.`/`test.` return 401 as expected | Any raw-HTTP integration fails outright |
| Webhook signing omitted `webhook-id` | Standard Webhooks signs `webhook-id.webhook-timestamp.body` | **No signature could ever validate** — in all 4 languages |
| `timingSafeEqual` on unequal lengths | Node throws rather than returning false | Handler crashes on malformed input |
| Signature header parsed via `split(',')[1]` | Header is a space-separated versioned list | Breaks on key rotation |
| Key prefix `sk_test_`/`sk_live_` | That's Stripe's format | Copy-paste confusion |
| `customers.createPortalSession()` | Method does not exist | Runtime TypeError |
| `payments.create()` | `@deprecated` in SDK source | Teaches a sunset path |
| "publishable key" | No such concept in Dodo | Invites leaking a secret key client-side |

## Additional errors caught in review

Two independent expert reviews, then re-verified against `dodopayments-typescript@d022bee` — the SDK types, not the docs.

**Wrong API shapes:** invented `trial`/`renewed` subscription statuses (real enum is `pending|active|on_hold|cancelled|failed|expired`); `updatePaymentMethod` needs a `payment_method` wrapper; list endpoints use `page_size`/`page_number` and return `items`, not `limit`/`offset`/`data`; `retrieveCreditUsage` and `previewChangePlan` response shapes; no top-level `customer_id` on checkout; preview totals live on `current_breakup`; and the SDK already retries twice (`maxRetries ?? 2`), so the advice to add a retry loop was wrong.

**Unsafe behavior:**
- `dispute.accepted` was treated as a **win that restored customer access**. It means the merchant *conceded* — the cardholder keeps the funds.
- Subscription cancellation disabled **every license key the customer owned**, including keys for unrelated products, and ignored end-of-period cancellation.
- Webhook handlers returned `2xx` **before** durably persisting, so a crash silently dropped paid events.
- Queue example called BullMQ's removed `Queue.process()`; idempotency was read-then-write, which races under retries.
- A subscription webhook parsed `req.json()` with **no signature verification**; `express.json()` ran before the webhook route, destroying the signed bytes.
- Checkout and mobile handlers accepted attacker-controlled `productId`/`customerId`.

Invented events removed: `subscription.created`, `subscription.renewal_failed`.

## New skills

| Skill | Covers |
|---|---|
| `framework-adapters` | The 13 official `@dodopayments/*` packages |
| `product-catalog-management` | Products, add-ons, collections, digital delivery |
| `customer-management` | Customers, portal, payment methods, wallets |
| `refunds-and-disputes` | Refunds and the dispute lifecycle |
| `discounts-and-promotions` | Codes, eligibility, stacking, cycle limits |
| `localized-pricing` | Localized pricing vs adaptive currency vs PPP |
| `mobile-checkout` | React Native, Flutter, iOS, Android |
| `testing-and-go-live` | Test mode, test methods, launch checklist |
| `better-auth-integration` | The `@dodopayments/better-auth` plugin |

`credit-based-billing` also got a full pass with an end-to-end AI-product example: token consumption → usage event → credit deduction → low-balance webhook → top-up.

## Upstream doc bugs not propagated

The official docs contain defects that a naive rewrite would have copied. These are corrected here and are **worth fixing upstream**:

- Next.js and Astro adapter pages show **two `export const POST`** in one file
- The Hono portal snippet imports `Checkout` but calls `CustomerPortal`
- `DODO_PAYMENTS_ENVIRONMENT="test_mode"or"live_mode"` — malformed
- Fastify/Hono examples carry stray trailing quotes
- Better Auth setup imports `betterAuth` but invokes `BetterAuth`
- Nuxt README uses the stale `NUXT_PRIVATE_BEARER_TOKEN`
- Discounts feature page says percentage-only; the API defines `flat` too

## Consistency

Ownership boundaries are now explicit — `webhook-integration` owns verification, `product-catalog-management` owns the product schema, `framework-adapters` owns route plumbing — so the skills stop contradicting each other. Nine descriptions were rewritten so agents route correctly between overlapping skills ("give users 500 free credits" → credits, not usage).

`marketplace.json` is now **generated from skill frontmatter**, so plugin descriptions can't drift. README is regrouped by task.

## Verification

A validator gates every rule: dead hostnames, wrong key formats, hand-rolled HMAC, deprecated calls, type suppression, unregistered skills, README coverage, frontmatter/directory agreement, and manifest integrity. It distinguishes real code from deliberate `Wrong:` counter-examples.

- Against the **current** `main`: **32 errors**
- Against this branch: **all checks passed**

17 skills, 17 manifest entries, 17 README rows, all descriptions in sync.

> Note: `dodopayments/dodo-agent-plugin` vendors this repo as the `skills-src` submodule and its README still says "eight skills". That pointer and copy need a follow-up bump after this merges.